### PR TITLE
Fix stale state references in draft views

### DIFF
--- a/draft_app/epl.py
+++ b/draft_app/epl.py
@@ -1,8 +1,5 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session
-from .state import (
-    epl_state, epl_players, save_epl_state,
-    user_is_full, draft_is_completed
-)
+from . import state
 from .config import EPL_USERS, EPL_POSITION_LIMITS
 from .services import epl_deadlines_window
 
@@ -10,7 +7,7 @@ bp = Blueprint("epl", __name__)
 
 def can_pick_epl(user, plyr):
     # В EPL нет ограничения "не более одного игрока из клуба"
-    cnt = sum(1 for x in epl_state['rosters'][user] if x['position'] == plyr['position'])
+    cnt = sum(1 for x in state.epl_state['rosters'][user] if x['position'] == plyr['position'])
     if cnt >= EPL_POSITION_LIMITS[plyr['position']]:
         return False, f"Максимум {EPL_POSITION_LIMITS[plyr['position']]} игроков на позиции {plyr['position']}."
     return True, ''
@@ -21,63 +18,63 @@ def index():
     club_filter = request.args.get('club', '')
     pos_filter  = request.args.get('position', '')
 
-    completed = draft_is_completed(epl_state, EPL_POSITION_LIMITS, len(EPL_USERS))
+    completed = state.draft_is_completed(state.epl_state, EPL_POSITION_LIMITS, len(EPL_USERS))
 
     if request.method == "POST":
         if completed:
             flash('Драфт завершён. Пики больше недоступны.', 'warning')
             return redirect(url_for('epl.index', club=club_filter, position=pos_filter))
 
-        idx = epl_state['current_pick_index']
-        next_user = epl_state['draft_order'][idx] if idx < len(epl_state['draft_order']) else None
+        idx = state.epl_state['current_pick_index']
+        next_user = state.epl_state['draft_order'][idx] if idx < len(state.epl_state['draft_order']) else None
 
         if current_user != next_user and not session.get('godmode'):
             flash('Сейчас не ваш ход.', 'error')
             return redirect(url_for('epl.index', club=club_filter, position=pos_filter))
 
         acting_user = next_user if session.get('godmode') else current_user
-        if user_is_full(epl_state['rosters'][acting_user], EPL_POSITION_LIMITS):
+        if state.user_is_full(state.epl_state['rosters'][acting_user], EPL_POSITION_LIMITS):
             flash('Ваш состав уже заполнен по всем позициям.', 'warning')
             return redirect(url_for('epl.index', club=club_filter, position=pos_filter))
 
         pid = int(request.form.get('player_id') or 0)
-        plyr = next(x for x in epl_players if x['playerId'] == pid)
+        plyr = next(x for x in state.epl_players if x['playerId'] == pid)
 
         ok, msg = can_pick_epl(acting_user, plyr)
         if not ok:
             flash(msg, 'error')
         else:
-            epl_state['rosters'][acting_user].append(plyr)
-            epl_state['picks'].append({'user': acting_user, 'player': plyr})
-            epl_state['current_pick_index'] += 1
-            save_epl_state()
+            state.epl_state['rosters'][acting_user].append(plyr)
+            state.epl_state['picks'].append({'user': acting_user, 'player': plyr})
+            state.epl_state['current_pick_index'] += 1
+            state.save_epl_state()
         return redirect(url_for('epl.index', club=club_filter, position=pos_filter))
 
     # GET
-    drafted_ids = [rec['player']['playerId'] for rec in epl_state['picks']]
+    drafted_ids = [rec['player']['playerId'] for rec in state.epl_state['picks']]
     filtered = [
-        p for p in epl_players
+        p for p in state.epl_players
         if p['playerId'] not in drafted_ids
         and (not club_filter or p['clubName'] == club_filter)
         and (not pos_filter or p['position'] == pos_filter)
     ]
     filtered.sort(key=lambda x: x.get('price', 0.0), reverse=True)
 
-    idx = epl_state['current_pick_index']
-    next_user = epl_state['draft_order'][idx] if (idx < len(epl_state['draft_order'])) else None
+    idx = state.epl_state['current_pick_index']
+    next_user = state.epl_state['draft_order'][idx] if (idx < len(state.epl_state['draft_order'])) else None
     next_round = idx // len(EPL_USERS) + 1 if next_user else None
 
     return render_template(
         'index.html',
         draft_title='EPL Fantasy Draft',
         players=([] if completed else filtered),
-        clubs=sorted({p['clubName'] for p in epl_players}),
-        positions=sorted({p['position'] for p in epl_players}),
+        clubs=sorted({p['clubName'] for p in state.epl_players}),
+        positions=sorted({p['position'] for p in state.epl_players}),
         club_filter=club_filter,
         pos_filter=pos_filter,
         next_user=None if completed else next_user,
         next_round=None if completed else next_round,
-        rosters=epl_state['rosters'],
+        rosters=state.epl_state['rosters'],
         position_limits=EPL_POSITION_LIMITS,
         current_user=current_user,
         status_url=url_for('epl.status'),
@@ -87,14 +84,14 @@ def index():
 @bp.route("/epl/status")
 def status():
     view = request.args.get('view', 'picks')
-    idx = epl_state['current_pick_index']
-    next_user = epl_state['draft_order'][idx] if idx < len(epl_state['draft_order']) else None
+    idx = state.epl_state['current_pick_index']
+    next_user = state.epl_state['draft_order'][idx] if idx < len(state.epl_state['draft_order']) else None
     next_round = idx // len(EPL_USERS) + 1 if next_user else None
-    completed = draft_is_completed(epl_state, EPL_POSITION_LIMITS, len(EPL_USERS))
+    completed = state.draft_is_completed(state.epl_state, EPL_POSITION_LIMITS, len(EPL_USERS))
 
     if view == 'picks':
         pick_list = []
-        for i, rec in enumerate(epl_state['picks']):
+        for i, rec in enumerate(state.epl_state['picks']):
             pick_list.append({'round': i // len(EPL_USERS) + 1,
                               'user': rec['user'], 'player': rec['player']})
         return render_template(
@@ -116,17 +113,17 @@ def status():
             position_slots.append({'position': pos, 'slot_index': i})
 
     rosters_points, rosters_sum, pick_numbers, rosters_grouped = {}, {}, {}, {}
-    for num, rec in enumerate(epl_state['picks'], start=1):
+    for num, rec in enumerate(state.epl_state['picks'], start=1):
         pick_numbers.setdefault(rec['user'], {})[rec['player']['playerId']] = num
 
     for user in EPL_USERS:
         grouped = {'Goalkeeper': [], 'Defender': [], 'Midfielder': [], 'Forward': []}
-        for p in epl_state['rosters'][user]:
+        for p in state.epl_state['rosters'][user]:
             grouped[p['position']].append(p)
         rosters_grouped[user] = grouped
         rosters_points[user] = {}
         rosters_sum[user] = {}
-        for plyr in epl_state['rosters'][user]:
+        for plyr in state.epl_state['rosters'][user]:
             pid = plyr['playerId']
             rosters_points[user][pid] = ['-'] * len(rounds_range)
             rosters_sum[user][pid] = 0
@@ -137,7 +134,7 @@ def status():
         status_endpoint='epl.status',
         view='rosters',
         users=EPL_USERS,
-        rosters=epl_state['rosters'],
+        rosters=state.epl_state['rosters'],
         rosters_grouped=rosters_grouped,
         position_slots=position_slots,
         rounds_range=rounds_range,

--- a/draft_app/stats.py
+++ b/draft_app/stats.py
@@ -1,6 +1,6 @@
 import os
 from flask import Blueprint, render_template, flash, redirect, url_for
-from .state import ucl_players
+from . import state
 from .config import UCL_CACHE_DIR
 from .services import session_req, HEADERS_GENERIC, load_json, save_json
 
@@ -8,7 +8,7 @@ bp = Blueprint("stats", __name__)
 
 @bp.route("/stats/<int:pid>")
 def index(pid):
-    plyr = next((p for p in ucl_players if p['playerId'] == pid), None)
+    plyr = next((p for p in state.ucl_players if p['playerId'] == pid), None)
     if not plyr:
         flash('Игрок не найден', 'error')
         return redirect(url_for('ucl.index'))

--- a/draft_app/ucl.py
+++ b/draft_app/ucl.py
@@ -1,9 +1,6 @@
 import os
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session
-from .state import (
-    ucl_state, ucl_players, save_ucl_state,
-    user_is_full, draft_is_completed
-)
+from . import state
 from .config import (
     UCL_USERS, UCL_POSITION_LIMITS, UCL_POSITION_MAP,
     POSITION_ORDER
@@ -13,11 +10,11 @@ bp = Blueprint("ucl", __name__)
 
 def can_pick_ucl(user, plyr):
     # уникальность клуба
-    clubs = {x['clubName'] for x in ucl_state['rosters'][user]}
+    clubs = {x['clubName'] for x in state.ucl_state['rosters'][user]}
     if plyr['clubName'] in clubs:
         return False, 'У вас уже есть игрок этого клуба.'
     # лимит по позиции
-    cnt = sum(1 for x in ucl_state['rosters'][user] if x['position'] == plyr['position'])
+    cnt = sum(1 for x in state.ucl_state['rosters'][user] if x['position'] == plyr['position'])
     if cnt >= UCL_POSITION_LIMITS[plyr['position']]:
         return False, f"Максимум {UCL_POSITION_LIMITS[plyr['position']]} игроков на позиции {plyr['position']}."
     return True, ''
@@ -28,62 +25,62 @@ def index():
     club_filter = request.args.get('club', '')
     pos_filter  = request.args.get('position', '')
 
-    completed = draft_is_completed(ucl_state, UCL_POSITION_LIMITS, len(UCL_USERS))
+    completed = state.draft_is_completed(state.ucl_state, UCL_POSITION_LIMITS, len(UCL_USERS))
 
     if request.method == "POST":
         if completed:
             flash('Драфт завершён. Пики больше недоступны.', 'warning')
             return redirect(url_for('ucl.index', club=club_filter, position=pos_filter))
 
-        idx = ucl_state['current_pick_index']
-        next_user = ucl_state['draft_order'][idx] if idx < len(ucl_state['draft_order']) else None
+        idx = state.ucl_state['current_pick_index']
+        next_user = state.ucl_state['draft_order'][idx] if idx < len(state.ucl_state['draft_order']) else None
 
         if current_user != next_user and not session.get('godmode'):
             flash('Сейчас не ваш ход.', 'error')
             return redirect(url_for('ucl.index', club=club_filter, position=pos_filter))
 
         acting_user = next_user if session.get('godmode') else current_user
-        if user_is_full(ucl_state['rosters'][acting_user], UCL_POSITION_LIMITS):
+        if state.user_is_full(state.ucl_state['rosters'][acting_user], UCL_POSITION_LIMITS):
             flash('Ваш состав уже заполнен по всем позициям.', 'warning')
             return redirect(url_for('ucl.index', club=club_filter, position=pos_filter))
 
         pid = int(request.form.get('player_id') or 0)
-        plyr = next(x for x in ucl_players if x['playerId'] == pid)
+        plyr = next(x for x in state.ucl_players if x['playerId'] == pid)
 
         ok, msg = can_pick_ucl(acting_user, plyr)
         if not ok:
             flash(msg, 'error')
         else:
-            ucl_state['rosters'][acting_user].append(plyr)
-            ucl_state['picks'].append({'user': acting_user, 'player': plyr})
-            ucl_state['current_pick_index'] += 1
-            save_ucl_state()
+            state.ucl_state['rosters'][acting_user].append(plyr)
+            state.ucl_state['picks'].append({'user': acting_user, 'player': plyr})
+            state.ucl_state['current_pick_index'] += 1
+            state.save_ucl_state()
         return redirect(url_for('ucl.index', club=club_filter, position=pos_filter))
 
     # GET
-    drafted_ids = [rec['player']['playerId'] for rec in ucl_state['picks']]
+    drafted_ids = [rec['player']['playerId'] for rec in state.ucl_state['picks']]
     filtered = [
-        p for p in ucl_players
+        p for p in state.ucl_players
         if p['playerId'] not in drafted_ids
         and (not club_filter or p['clubName'] == club_filter)
         and (not pos_filter or p['position'] == pos_filter)
     ]
 
-    idx = ucl_state['current_pick_index']
-    next_user = ucl_state['draft_order'][idx] if (idx < len(ucl_state['draft_order'])) else None
+    idx = state.ucl_state['current_pick_index']
+    next_user = state.ucl_state['draft_order'][idx] if (idx < len(state.ucl_state['draft_order'])) else None
     next_round = idx // len(UCL_USERS) + 1 if next_user else None
 
     return render_template(
         'index.html',
         draft_title='UCL Fantasy Draft',
         players=([] if completed else filtered),
-        clubs=sorted({p['clubName'] for p in ucl_players}),
-        positions=sorted({p['position'] for p in ucl_players}),
+        clubs=sorted({p['clubName'] for p in state.ucl_players}),
+        positions=sorted({p['position'] for p in state.ucl_players}),
         club_filter=club_filter,
         pos_filter=pos_filter,
         next_user=None if completed else next_user,
         next_round=None if completed else next_round,
-        rosters=ucl_state['rosters'],
+        rosters=state.ucl_state['rosters'],
         position_limits=UCL_POSITION_LIMITS,
         current_user=current_user,
         status_url=url_for('ucl.status'),
@@ -96,14 +93,14 @@ def status():
     from .services import load_json
 
     view = request.args.get('view', 'picks')
-    idx = ucl_state['current_pick_index']
-    next_user = ucl_state['draft_order'][idx] if idx < len(ucl_state['draft_order']) else None
+    idx = state.ucl_state['current_pick_index']
+    next_user = state.ucl_state['draft_order'][idx] if idx < len(state.ucl_state['draft_order']) else None
     next_round = idx // len(UCL_USERS) + 1 if next_user else None
-    completed = draft_is_completed(ucl_state, UCL_POSITION_LIMITS, len(UCL_USERS))
+    completed = state.draft_is_completed(state.ucl_state, UCL_POSITION_LIMITS, len(UCL_USERS))
 
     if view == 'picks':
         pick_list = []
-        for i, rec in enumerate(ucl_state['picks']):
+        for i, rec in enumerate(state.ucl_state['picks']):
             pick_list.append({'round': i // len(UCL_USERS) + 1,
                               'user': rec['user'], 'player': rec['player']})
         return render_template(
@@ -133,13 +130,13 @@ def status():
     for user in UCL_USERS:
         # сгруппируем по позиции
         grouped = {'Goalkeeper': [], 'Defender': [], 'Midfielder': [], 'Forward': []}
-        for p in ucl_state['rosters'][user]:
+        for p in state.ucl_state['rosters'][user]:
             grouped[p['position']].append(p)
         rosters_grouped[user] = grouped
 
         rosters_points[user] = {}
         rosters_sum[user] = {}
-        for plyr in ucl_state['rosters'][user]:
+        for plyr in state.ucl_state['rosters'][user]:
             pid = plyr['playerId']
             cache = os.path.join(UCL_CACHE_DIR, f'popupstats_70_{pid}.json')
             pts_map, total = {}, 0


### PR DESCRIPTION
## Summary
- Import the state module directly so UCL and EPL views always see initialized draft data
- Use state-backed player lists and rosters in stats and draft pages

## Testing
- `python -m py_compile draft_app/ucl.py draft_app/epl.py draft_app/stats.py`


------
https://chatgpt.com/codex/tasks/task_e_6897c21c98a4832394fcbc463a98c34d