### PR TITLE
Fix Jinja enumerate usage in status template

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -40,9 +40,9 @@
       </thead>
       <tbody>
         {% if pick_list %}
-          {% for i, row in enumerate(pick_list, start=1) %}
+          {% for row in pick_list %}
             <tr>
-              <td class="nowrap">{{ i }}</td>
+              <td class="nowrap">{{ loop.index }}</td>
               <td class="nowrap">{{ row.round }}</td>
               <td>{{ row.user }}</td>
               <td>


### PR DESCRIPTION
## Summary
- Replace Python `enumerate` with Jinja `loop.index` in status table

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897c7ec974c83239acfe1470e826c18