### PR TITLE
Add drag-and-drop EPL squad lineup selection

### DIFF
--- a/draft_app/epl_services.py
+++ b/draft_app/epl_services.py
@@ -218,6 +218,7 @@ def load_state() -> Dict[str, Any]:
     state.setdefault("draft_order", [])
     state.setdefault("current_pick_index", 0)
     state.setdefault("draft_started_at", None)
+    state.setdefault("lineups", {})
     limits = state.setdefault("limits", {})
     limits.setdefault("Max from club", 3)
     return state

--- a/draft_app/static/css/squad.css
+++ b/draft_app/static/css/squad.css
@@ -1,0 +1,25 @@
+.player-list, .slots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 50px;
+  padding: 8px;
+  border: 1px dashed #ccc;
+}
+.player {
+  width: 80px;
+  text-align: center;
+  cursor: move;
+}
+.player img {
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+  border-radius: 50%;
+}
+.lineup-pos {
+  margin-bottom: 1rem;
+}
+.lineup-pos .slots .player {
+  cursor: move;
+}

--- a/draft_app/static/js/squad.js
+++ b/draft_app/static/js/squad.js
@@ -1,0 +1,76 @@
+function formationCounts(fmt){
+  const parts = fmt.split('-').map(x=>parseInt(x,10));
+  if(parts.length!==3||parts.some(isNaN)) return {GK:1,DEF:4,MID:4,FWD:2};
+  return {GK:1,DEF:parts[0],MID:parts[1],FWD:parts[2]};
+}
+
+function buildSlots(){
+  const fmt=document.getElementById('formation').value;
+  const counts=formationCounts(fmt);
+  ['GK','DEF','MID','FWD'].forEach(pos=>{
+    const wrap=document.getElementById('slot-'+pos);
+    wrap.innerHTML='';
+    wrap.dataset.max=counts[pos];
+  });
+}
+
+function initDrag(){
+  Sortable.create(document.getElementById('roster'), {group:'players', animation:150, sort:false});
+  ['GK','DEF','MID','FWD'].forEach(pos=>{
+    Sortable.create(document.getElementById('slot-'+pos), {
+      group:'players', animation:150,
+      onAdd: evt => {
+        const max=parseInt(evt.to.dataset.max||'0',10);
+        if(evt.to.children.length>max){
+          evt.from.insertBefore(evt.item, evt.from.children[evt.oldIndex]);
+        }
+      }
+    });
+  });
+}
+
+function placePreset(){
+  const data=document.getElementById('lineup-data');
+  if(!data) return;
+  try{
+    const ids=JSON.parse(data.textContent||'[]');
+    ids.forEach(pid=>{
+      const el=document.querySelector(`#roster .player[data-id='${pid}']`);
+      if(el){
+        const pos=el.dataset.pos;
+        const target=document.getElementById('slot-'+pos);
+        if(target) target.appendChild(el);
+      }
+    });
+  }catch(e){}
+}
+
+function serialize(){
+  const ids=[];
+  ['GK','DEF','MID','FWD'].forEach(pos=>{
+    const wrap=document.getElementById('slot-'+pos);
+    wrap.querySelectorAll('.player').forEach(p=>ids.push(p.dataset.id));
+  });
+  document.getElementById('player_ids').value=ids.join(',');
+}
+
+document.addEventListener('DOMContentLoaded', ()=>{
+  const editable=document.getElementById('lineup').dataset.editable==='1';
+  buildSlots();
+  if(editable){
+    initDrag();
+  }
+  placePreset();
+  if(editable){
+    const roster=document.getElementById('roster');
+    document.getElementById('formation').addEventListener('change', ()=>{
+      ['GK','DEF','MID','FWD'].forEach(pos=>{
+        const wrap=document.getElementById('slot-'+pos);
+        wrap.querySelectorAll('.player').forEach(p=>roster.appendChild(p));
+      });
+      buildSlots();
+      initDrag();
+    });
+    document.getElementById('lineup-form').addEventListener('submit', serialize);
+  }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,7 +33,8 @@
       <div class="navbar-start">
         <a class="navbar-item" href="{{ url_for('home.index') }}">Главная</a>
         <a class="navbar-item" href="{{ url_for('ucl.index') }}">UCL Драфт</a>
-        <a class="navbar-item" href="{{ url_for('epl.index') }}">EPL Драфт</a>
+        <a class="navbar-item" href="{{ url_for('epl.index') }}">EPL Пики</a>
+        <a class="navbar-item" href="{{ url_for('epl.squad') }}">EPL Состав</a>
         <a class="navbar-item" href="{{ url_for('home.top4') }}">Топ-4</a>
       </div>
       <div class="navbar-end">

--- a/templates/squad.html
+++ b/templates/squad.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% block title %}Мой состав — EPL Драфт{% endblock %}
+{% block content %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/squad.css') }}"/>
+<h1 class="title">Мой состав на Gameweek {{ gw }}</h1>
+<form method="post" id="lineup-form">
+  <div class="field is-grouped">
+    <div class="control">
+      <label class="label">Gameweek</label>
+      <input class="input" type="number" name="gw" value="{{ gw }}" min="1" />
+    </div>
+    <div class="control">
+      <label class="label">Схема</label>
+      <div class="select">
+        <select id="formation" name="formation">
+          {% for f in formations %}
+            <option value="{{ f }}" {% if f==formation %}selected{% endif %}>{{ f }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+  </div>
+  <div class="columns">
+    <div class="column is-half">
+      <h2 class="subtitle">Состав</h2>
+      <div id="roster" class="player-list">
+        {% for p in roster %}
+          <div class="player" data-id="{{ p.playerId }}" data-pos="{{ p.position }}">
+            {% if p.photo %}<img src="{{ p.photo }}" alt="" />{% endif %}
+            <span>{{ p.fullName }}</span>
+            <small>{{ p.position }}</small>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+    <div class="column is-half">
+      <h2 class="subtitle">Стартовые 11</h2>
+      <div id="lineup" class="lineup" data-editable="{{ '1' if editable else '0' }}">
+        <div class="lineup-pos" data-pos="GK">
+          <h3>GK</h3>
+          <div class="slots" id="slot-GK"></div>
+        </div>
+        <div class="lineup-pos" data-pos="DEF">
+          <h3>DEF</h3>
+          <div class="slots" id="slot-DEF"></div>
+        </div>
+        <div class="lineup-pos" data-pos="MID">
+          <h3>MID</h3>
+          <div class="slots" id="slot-MID"></div>
+        </div>
+        <div class="lineup-pos" data-pos="FWD">
+          <h3>FWD</h3>
+          <div class="slots" id="slot-FWD"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <input type="hidden" name="player_ids" id="player_ids" />
+  <div class="field">
+    <button type="submit" class="button is-primary" {% if not editable %}disabled{% endif %}>Сохранить</button>
+  </div>
+</form>
+<script id="lineup-data" type="application/json">{{ lineup|map(attribute='playerId')|list|tojson }}</script>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script src="{{ url_for('static', filename='js/squad.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Allow managers to configure 11-player EPL lineups with selectable formations
- Store per-gameweek lineups and enforce deadlines
- Add navigation tab and UI with drag-and-drop player photos

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c76eb9b508323832ceb2dc47fddd7