### PR TITLE
Add bench and position-aware drag-and-drop

### DIFF
--- a/draft_app/static/css/squad.css
+++ b/draft_app/static/css/squad.css
@@ -23,3 +23,7 @@
 .lineup-pos .slots .player {
   cursor: move;
 }
+
+.lineup-pos[data-pos="BENCH"] .slots {
+  flex-wrap: nowrap;
+}

--- a/templates/squad.html
+++ b/templates/squad.html
@@ -52,15 +52,21 @@
           <h3>FWD</h3>
           <div class="slots" id="slot-FWD"></div>
         </div>
+        <div class="lineup-pos" data-pos="BENCH">
+          <h3>Запасные</h3>
+          <div class="slots" id="slot-BENCH" data-max="4"></div>
+        </div>
       </div>
     </div>
   </div>
   <input type="hidden" name="player_ids" id="player_ids" />
+  <input type="hidden" name="bench_ids" id="bench_ids" />
   <div class="field">
     <button type="submit" class="button is-primary" {% if not editable %}disabled{% endif %}>Сохранить</button>
   </div>
 </form>
 <script id="lineup-data" type="application/json">{{ lineup|map(attribute='playerId')|list|tojson }}</script>
+<script id="bench-data" type="application/json">{{ bench|map(attribute='playerId')|list|tojson }}</script>
 <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 <script src="{{ url_for('static', filename='js/squad.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Sort roster by position order and add bench handling in squad view
- Restrict drag-and-drop to matching player positions and enable substitutes bench
- Capture bench order and render it with dedicated styling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c7b625d248323b20961a08f19cb7f