### PR TITLE
feat: click-based lineup placement

### DIFF
--- a/draft_app/epl_routes.py
+++ b/draft_app/epl_routes.py
@@ -161,6 +161,7 @@ def squad():
         roster_ext.append({
             "playerId": pid,
             "fullName": pl.get("fullName") or meta.get("fullName"),
+            "shortName": meta.get("shortName"),
             "position": pl.get("position") or meta.get("position"),
             "clubName": pl.get("clubName") or meta.get("clubName"),
             "photo": photo_url_for(pid),
@@ -177,6 +178,7 @@ def squad():
             lineup_ext.append({
                 "playerId": int(pid),
                 "fullName": meta.get("fullName"),
+                "shortName": meta.get("shortName"),
                 "position": meta.get("position"),
                 "clubName": meta.get("clubName"),
                 "photo": photo_url_for(pid),
@@ -189,6 +191,7 @@ def squad():
             bench_ext.append({
                 "playerId": int(pid),
                 "fullName": meta.get("fullName"),
+                "shortName": meta.get("shortName"),
                 "position": meta.get("position"),
                 "clubName": meta.get("clubName"),
                 "photo": photo_url_for(pid),
@@ -233,7 +236,6 @@ def squad():
                 pos_counts.get("DEF") == counts["DEF"] and
                 pos_counts.get("MID") == counts["MID"] and
                 pos_counts.get("FWD") == counts["FWD"] and
-                len(bench) <= 4 and
                 not set(ids) & set(bench)
             )
             if valid:

--- a/draft_app/epl_services.py
+++ b/draft_app/epl_services.py
@@ -186,13 +186,20 @@ def nameclub_index(plist: List[Dict[str, Any]]) -> Dict[Tuple[str,str], Set[str]
     return idx
 
 def photo_url_for(pid: int) -> Optional[str]:
+    """Return player photo URL or placeholder if missing."""
     data = json_load(EPL_FPL) or {}
     for e in (data.get("elements") or []):
         if int(e.get("id", -1)) == int(pid):
             code = e.get("code")
             if code:
-                return f"https://resources.premierleague.com/premierleague/photos/players/110x140/p{code}.png"
-    return None
+                return (
+                    "https://resources.premierleague.com/"
+                    f"premierleague/photos/players/110x140/p{code}.png"
+                )
+    return (
+        "https://resources.premierleague.com/"
+        "premierleague25/photos/players/110x140/placeholder.png"
+    )
 
 # ======================
 #      STATE (S3)

--- a/draft_app/static/css/squad.css
+++ b/draft_app/static/css/squad.css
@@ -9,20 +9,21 @@
 .player {
   width: 80px;
   text-align: center;
-  cursor: move;
+  cursor: pointer;
 }
 .player img {
   width: 60px;
-  height: 60px;
+  height: 80px;
   object-fit: cover;
-  border-radius: 50%;
+  border-radius: 0;
+}
+.player.selected {
+  outline: 2px solid #3273dc;
 }
 .lineup-pos {
   margin-bottom: 1rem;
 }
-.lineup-pos .slots .player {
-  cursor: move;
-}
+
 
 .lineup-pos[data-pos="BENCH"] .slots {
   flex-wrap: nowrap;

--- a/templates/squad.html
+++ b/templates/squad.html
@@ -26,8 +26,8 @@
       <div id="roster" class="player-list">
         {% for p in roster %}
           <div class="player" data-id="{{ p.playerId }}" data-pos="{{ p.position }}">
-            {% if p.photo %}<img src="{{ p.photo }}" alt="" />{% endif %}
-            <span>{{ p.fullName }}</span>
+            <img src="{{ p.photo }}" alt="" />
+            <span>{{ p.shortName or p.fullName }}</span>
             <small>{{ p.position }}</small>
           </div>
         {% endfor %}
@@ -54,7 +54,7 @@
         </div>
         <div class="lineup-pos" data-pos="BENCH">
           <h3>Запасные</h3>
-          <div class="slots" id="slot-BENCH" data-max="4"></div>
+          <div class="slots" id="slot-BENCH"></div>
         </div>
       </div>
     </div>
@@ -67,6 +67,5 @@
 </form>
 <script id="lineup-data" type="application/json">{{ lineup|map(attribute='playerId')|list|tojson }}</script>
 <script id="bench-data" type="application/json">{{ bench|map(attribute='playerId')|list|tojson }}</script>
-<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
 <script src="{{ url_for('static', filename='js/squad.js') }}"></script>
 {% endblock %}

--- a/templates/status.html
+++ b/templates/status.html
@@ -79,7 +79,7 @@
                 <div class="block-title">GK</div>
                 <ul class="bullets">
                   {% for p in g.GK %}
-                    <li>{{ p.fullName if p else "—" }}</li>
+                    <li>{{ (p.shortName or p.fullName) if p else "—" }}</li>
                   {% endfor %}
                 </ul>
               </div>
@@ -87,7 +87,7 @@
                 <div class="block-title">DEF</div>
                 <ul class="bullets">
                   {% for p in g.DEF %}
-                    <li>{{ p.fullName if p else "—" }}</li>
+                    <li>{{ (p.shortName or p.fullName) if p else "—" }}</li>
                   {% endfor %}
                 </ul>
               </div>
@@ -95,7 +95,7 @@
                 <div class="block-title">MID</div>
                 <ul class="bullets">
                   {% for p in g.MID %}
-                    <li>{{ p.fullName if p else "—" }}</li>
+                    <li>{{ (p.shortName or p.fullName) if p else "—" }}</li>
                   {% endfor %}
                 </ul>
               </div>
@@ -103,7 +103,7 @@
                 <div class="block-title">FWD</div>
                 <ul class="bullets">
                   {% for p in g.FWD %}
-                    <li>{{ p.fullName if p else "—" }}</li>
+                    <li>{{ (p.shortName or p.fullName) if p else "—" }}</li>
                   {% endfor %}
                 </ul>
               </div>


### PR DESCRIPTION
## Summary
- replace drag-and-drop with click-to-place lineup selection
- show short player names and rectangular photos with placeholder fallback
- remove bench size limit and allow unlimited substitutes

## Testing
- `python -m py_compile draft_app/epl_routes.py draft_app/epl_services.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c7e0ba7bc8323862b9f48b13e95de