### PR TITLE
feat: store lineups in s3

### DIFF
--- a/draft_app/lineup_store.py
+++ b/draft_app/lineup_store.py
@@ -4,10 +4,22 @@ import re
 import tempfile
 from pathlib import Path
 
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
 BASE_DIR = Path(__file__).resolve().parent.parent
 LINEUP_ROOT = BASE_DIR / 'lineups'
 LINEUP_ROOT.mkdir(parents=True, exist_ok=True)
 _safe_re = re.compile(r"[^a-z0-9_\-]", re.I)
+
+S3_BUCKET = os.getenv("LINEUP_S3_BUCKET")
+S3_PREFIX = os.getenv("LINEUP_S3_PREFIX", "lineups")
+_s3_client = None
+if S3_BUCKET:
+    try:
+        _s3_client = boto3.client("s3")
+    except Exception:
+        _s3_client = None
 
 
 def _slug(x: str) -> str:
@@ -20,7 +32,21 @@ def _file_path(manager: str, gw: int) -> Path:
     return p
 
 
+def _s3_key(manager: str, gw: int) -> str:
+    prefix = S3_PREFIX.strip("/")
+    return f"{prefix}/{_slug(manager)}/gw{int(gw)}.json"
+
+
 def load_lineup(manager: str, gw: int) -> dict:
+    if _s3_client:
+        key = _s3_key(manager, gw)
+        try:
+            obj = _s3_client.get_object(Bucket=S3_BUCKET, Key=key)
+            body = obj.get("Body").read().decode("utf-8")
+            data = json.loads(body)
+            return data if isinstance(data, dict) else {}
+        except (ClientError, BotoCoreError, Exception):
+            pass
     p = _file_path(manager, gw)
     if not p.exists():
         return {}
@@ -33,10 +59,22 @@ def load_lineup(manager: str, gw: int) -> dict:
 
 
 def save_lineup(manager: str, gw: int, payload: dict) -> None:
+    data_str = json.dumps(payload, ensure_ascii=False, indent=2)
+    if _s3_client:
+        key = _s3_key(manager, gw)
+        try:
+            _s3_client.put_object(
+                Bucket=S3_BUCKET,
+                Key=key,
+                Body=data_str.encode("utf-8"),
+                ContentType="application/json",
+            )
+        except (ClientError, BotoCoreError, Exception):
+            pass
     p = _file_path(manager, gw)
     tmp_fd, tmp_name = tempfile.mkstemp(prefix='lineup_', suffix='.json', dir=str(p.parent))
     os.close(tmp_fd)
     with open(tmp_name, 'w', encoding='utf-8') as f:
-        json.dump(payload, f, ensure_ascii=False, indent=2)
+        f.write(data_str)
     os.replace(tmp_name, p)
 


### PR DESCRIPTION
## Summary
- save each user's gameweek lineup JSON to optional AWS S3 bucket
- load lineups from S3 when available, with local file fallback

## Testing
- `python -m py_compile draft_app/lineup_store.py`


------
https://chatgpt.com/codex/tasks/task_e_689c8c16fd90832394d24ef5edf315e3