### PR TITLE
Add weekly lineup overview and fixture context

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -35,6 +35,7 @@
         <a class="navbar-item" href="{{ url_for('ucl.index') }}">UCL Драфт</a>
         <a class="navbar-item" href="{{ url_for('epl.index') }}">EPL Пики</a>
         <a class="navbar-item" href="{{ url_for('epl.squad') }}">EPL Состав</a>
+        <a class="navbar-item" href="{{ url_for('epl.lineups') }}">EPL Лайнапы</a>
         <a class="navbar-item" href="{{ url_for('home.top4') }}">Топ-4</a>
       </div>
       <div class="navbar-end">

--- a/templates/lineups.html
+++ b/templates/lineups.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% block title %}Составы на Gameweek {{ gw }}{% endblock %}
+{% block content %}
+<h1 class="title">Составы на Gameweek {{ gw }}</h1>
+<form method="get" class="mb-4">
+  <label class="label">Gameweek</label>
+  <div class="field has-addons">
+    <div class="control">
+      <input class="input" type="number" name="gw" value="{{ gw }}" min="1" style="width:90px"/>
+    </div>
+    <div class="control">
+      <button class="button is-link" type="submit">Показать</button>
+    </div>
+  </div>
+</form>
+<table class="table is-striped is-compact">
+  <thead>
+    <tr>
+      {% for m in managers %}
+      <th>{{ m }}</th>
+      {% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      {% for m in managers %}
+      <td>
+        {% for p in lineups[m] %}
+          <div>{{ p.name }} - {{ p.points }}</div>
+        {% endfor %}
+      </td>
+      {% endfor %}
+    </tr>
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/squad.html
+++ b/templates/squad.html
@@ -3,6 +3,9 @@
 {% block content %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/squad.css') }}"/>
 <h1 class="title">Мой состав на Gameweek {{ gw }}</h1>
+{% if deadline %}
+<h2 style="color:red; font-size:2em;">Дедлайн: {{ deadline.strftime('%Y-%m-%d %H:%M') }} UTC</h2>
+{% endif %}
 <form method="post" id="lineup-form">
   <div class="field is-grouped">
     <div class="control">
@@ -30,7 +33,7 @@
               <div class="player" data-id="{{ p.playerId }}" data-pos="{{ p.position }}">
                 <img src="{{ p.photo }}" alt="" />
                 <span>{{ p.shortName or p.fullName }}</span>
-                <small>{{ p.position }}</small>
+                <small>{{ p.position }}{% if p.fixture %} {{ p.fixture }}{% endif %}</small>
               </div>
             {% endfor %}
           </div>


### PR DESCRIPTION
## Summary
- Display lineup submission deadline prominently on the squad page
- Show upcoming opponent for each roster player
- Add page listing managers' lineups and their players' points for a chosen gameweek

## Testing
- `python -m py_compile draft_app/epl_services.py draft_app/epl_routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c8f2a05e083239d6a18c1aeefcdfe