### PR TITLE
Enhance EPL lineups page with bench and deadline info

### DIFF
--- a/templates/lineups.html
+++ b/templates/lineups.html
@@ -2,6 +2,9 @@
 {% block title %}Составы на Gameweek {{ gw }}{% endblock %}
 {% block content %}
 <h1 class="title">Составы на Gameweek {{ gw }}</h1>
+{% if deadline_warsaw %}
+<p>Дедлайн: {{ deadline_warsaw.strftime("%d.%m %H:%M") }} (Варшава) / {{ deadline_minsk.strftime("%d.%m %H:%M") }} (Минск)</p>
+{% endif %}
 <form method="get" class="mb-4">
   <label class="label">Gameweek</label>
   <div class="field has-addons">
@@ -17,7 +20,7 @@
   <thead>
     <tr>
       {% for m in managers %}
-      <th>{{ m }}</th>
+      <th>{{ '🟢' if status[m] else '🔴' }} {{ m }}</th>
       {% endfor %}
     </tr>
   </thead>
@@ -25,9 +28,21 @@
     <tr>
       {% for m in managers %}
       <td>
-        {% for p in lineups[m] %}
-          <div>{{ p.name }} - {{ p.points }}</div>
-        {% endfor %}
+        {% if lineups[m].has_lineup %}
+          {% for p in lineups[m].starters %}
+            <div>{{ p.name }} ({{ p.pos }}) - {{ p.points }}</div>
+          {% endfor %}
+          {% if lineups[m].bench %}
+            <div class="mt-2 has-text-weight-semibold">Запас</div>
+            {% for p in lineups[m].bench %}
+              <div class="has-text-grey">{{ p.name }} ({{ p.pos }}) - {{ p.points }}</div>
+            {% endfor %}
+          {% endif %}
+        {% else %}
+          {% for p in lineups[m].starters %}
+            <div>{{ p.name }} ({{ p.pos }}) - {{ p.points }}</div>
+          {% endfor %}
+        {% endif %}
       </td>
       {% endfor %}
     </tr>


### PR DESCRIPTION
## Summary
- show bench players and team rosters on EPL lineups page even if no lineup submitted
- indicate managers with green/red circles based on lineup submission
- display deadline times for Warsaw and Minsk and show player positions in table

## Testing
- `python -m py_compile draft_app/epl_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_689c9f2a6b888323a6e4b1c96f4c4d33