### PR TITLE
Sort and format unsubmitted lineups

### DIFF
--- a/draft_app/epl_routes.py
+++ b/draft_app/epl_routes.py
@@ -289,6 +289,7 @@ def lineups():
     managers = sorted(rosters.keys())
     table: Dict[str, dict] = {}
     status: Dict[str, bool] = {}
+    pos_order = {"GK": 0, "DEF": 1, "MID": 2, "FWD": 3}
     for m in managers:
         lineup = (lineups_state.get(m) or {}).get(str(gw))
         starters = []
@@ -315,12 +316,13 @@ def lineups():
             for pl in rosters.get(m, []) or []:
                 pid = pl.get("playerId") or pl.get("id")
                 meta = pidx.get(str(pid), {})
-                name = pl.get("fullName") or meta.get("shortName") or meta.get("fullName") or str(pid)
+                name = meta.get("shortName") or meta.get("fullName") or pl.get("fullName") or str(pid)
                 starters.append({
                     "name": name,
                     "pos": pl.get("position") or meta.get("position"),
                     "points": pts.get(int(pid), 0),
                 })
+            starters.sort(key=lambda p: pos_order.get(p.get("pos"), 99))
             status[m] = False
         table[m] = {
             "starters": starters,

--- a/templates/lineups.html
+++ b/templates/lineups.html
@@ -40,7 +40,7 @@
           {% endif %}
         {% else %}
           {% for p in lineups[m].starters %}
-            <div>{{ p.name }} ({{ p.pos }}) - {{ p.points }}</div>
+            <div>{{ p.points }} {{ p.name }} ({{ p.pos }})</div>
           {% endfor %}
         {% endif %}
       </td>


### PR DESCRIPTION
## Summary
- Sort auto-generated lineups by position so unsubmitted squads list GK→DEF→MID→FWD
- Show points first with short name and position for unsubmitted lineups

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ca1277bac8323b4e069125231b64e