### PR TITLE
Show lineup timestamps and auto-fill missing bench players

### DIFF
--- a/templates/lineups.html
+++ b/templates/lineups.html
@@ -20,7 +20,12 @@
   <thead>
     <tr>
       {% for m in managers %}
-      <th>{{ '🟢' if status[m] else '🔴' }} {{ m }}</th>
+      <th>
+        {% if lineups[m].ts %}
+        <div class="has-text-grey is-size-7">{{ lineups[m].ts.strftime('%d.%m %H:%M') }}</div>
+        {% endif %}
+        {{ '🟢' if status[m] else '🔴' }} {{ m }}
+      </th>
       {% endfor %}
     </tr>
   </thead>


### PR DESCRIPTION
## Summary
- Display lineup submission time above each manager on EPL lineups page
- Auto-complete bench with remaining roster players sorted by position

## Testing
- `pytest`
- `python -m py_compile draft_app/epl_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_689ca7ab69d0832386bc6230e25aca80