### PR TITLE
Add EPL squad availability indicators and stats popup

### DIFF
--- a/draft_app/epl_routes.py
+++ b/draft_app/epl_routes.py
@@ -163,6 +163,7 @@ def squad():
         pid = pl.get("playerId") or pl.get("id")
         meta = pidx.get(str(pid), {})
         team_id = meta.get("teamId")
+        stats = meta.get("stats") or {}
         roster_ext.append({
             "playerId": pid,
             "fullName": pl.get("fullName") or meta.get("fullName"),
@@ -171,6 +172,16 @@ def squad():
             "clubName": pl.get("clubName") or meta.get("clubName"),
             "photo": photo_url_for(pid),
             "fixture": fixtures_map.get(team_id, ""),
+            "status": meta.get("status"),
+            "chance": meta.get("chance"),
+            "news": meta.get("news"),
+            "stats": {
+                "minutes": stats.get("minutes"),
+                "goals": stats.get("goals"),
+                "assists": stats.get("assists"),
+                "cs": stats.get("cs"),
+                "points": stats.get("points"),
+            },
         })
 
     pos_order = {"GK": 0, "DEF": 1, "MID": 2, "FWD": 3}
@@ -182,6 +193,7 @@ def squad():
         meta = pidx.get(str(pid))
         if meta:
             team_id = meta.get("teamId")
+            stats = meta.get("stats") or {}
             lineup_ext.append({
                 "playerId": int(pid),
                 "fullName": meta.get("fullName"),
@@ -190,6 +202,16 @@ def squad():
                 "clubName": meta.get("clubName"),
                 "photo": photo_url_for(pid),
                 "fixture": fixtures_map.get(team_id, ""),
+                "status": meta.get("status"),
+                "chance": meta.get("chance"),
+                "news": meta.get("news"),
+                "stats": {
+                    "minutes": stats.get("minutes"),
+                    "goals": stats.get("goals"),
+                    "assists": stats.get("assists"),
+                    "cs": stats.get("cs"),
+                    "points": stats.get("points"),
+                },
             })
 
     bench_ext = []
@@ -197,6 +219,7 @@ def squad():
         meta = pidx.get(str(pid))
         if meta:
             team_id = meta.get("teamId")
+            stats = meta.get("stats") or {}
             bench_ext.append({
                 "playerId": int(pid),
                 "fullName": meta.get("fullName"),
@@ -205,6 +228,16 @@ def squad():
                 "clubName": meta.get("clubName"),
                 "photo": photo_url_for(pid),
                 "fixture": fixtures_map.get(team_id, ""),
+                "status": meta.get("status"),
+                "chance": meta.get("chance"),
+                "news": meta.get("news"),
+                "stats": {
+                    "minutes": stats.get("minutes"),
+                    "goals": stats.get("goals"),
+                    "assists": stats.get("assists"),
+                    "cs": stats.get("cs"),
+                    "points": stats.get("points"),
+                },
             })
 
     # Check deadline

--- a/draft_app/epl_services.py
+++ b/draft_app/epl_services.py
@@ -167,6 +167,16 @@ def players_from_fpl(bootstrap: Any) -> List[Dict[str, Any]]:
             "position": pos_map.get(e.get("element_type")),
             "price": (e.get("now_cost") / 10.0) if isinstance(e.get("now_cost"), (int, float)) else None,
             "teamId": int(team_id) if team_id is not None else None,
+            "status": e.get("status"),
+            "news": e.get("news"),
+            "chance": e.get("chance_of_playing_next_round"),
+            "stats": {
+                "minutes": e.get("minutes"),
+                "goals": e.get("goals_scored"),
+                "assists": e.get("assists"),
+                "cs": e.get("clean_sheets"),
+                "points": e.get("total_points"),
+            },
         })
     return out
 

--- a/draft_app/static/css/squad.css
+++ b/draft_app/static/css/squad.css
@@ -22,6 +22,7 @@
   text-align: center;
   cursor: pointer;
   font-size: 0.75rem;
+  position: relative;
 }
 .player img {
   width: 40px;
@@ -36,3 +37,50 @@
 .lineup-pos[data-pos="BENCH"] .slots {
   flex-wrap: nowrap;
 }
+
+/* Availability flags */
+.flag, .info-icon {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+.flag {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 0 14px 14px;
+  cursor: pointer;
+}
+.flag-yellow { border-color: transparent transparent #ffba00 transparent; }
+.flag-orange { border-color: transparent transparent #ff9100 transparent; }
+.flag-red { border-color: transparent transparent #d00000 transparent; }
+.info-icon {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #3c8dbc;
+  color: #fff;
+  font-size: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+/* Modal styles */
+.modal { position: fixed; inset: 0; display: none; }
+.modal[aria-hidden="false"] { display: block; }
+.modal-backdrop { position: absolute; inset:0; background: rgba(0,0,0,.35); }
+.modal-dialog { position: relative; max-width: 360px; margin: 10vh auto; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 10px 30px rgba(0,0,0,.25); }
+.modal-header { display:flex; justify-content:space-between; align-items:center; padding:10px; border-bottom:1px solid #eee; background:#f6f7fb; }
+.modal-title { font-weight:600; }
+.modal-close { background:none; border:none; font-size:20px; line-height:1; cursor:pointer; }
+.modal-body { padding:10px; }
+.player-head { display:flex; align-items:center; gap:8px; margin-bottom:8px; }
+.player-photo { width:55px; height:auto; border-radius:6px; box-shadow:0 1px 3px rgba(0,0,0,.12); }
+.player-name { font-weight:600; font-size:16px; }
+table.tbl { width:100%; border-collapse:separate; border-spacing:0; font-size:14px; }
+table.tbl td { padding:6px 8px; border-bottom:1px solid #f0f0f0; }
+table.tbl td.num { text-align:right; }
+table.tbl tr:nth-child(odd){ background:#fafafa; }
+table.tbl tr:nth-child(even){ background:#f5f7fb; }

--- a/templates/squad.html
+++ b/templates/squad.html
@@ -30,8 +30,24 @@
         {% for pos in ['GK','DEF','MID','FWD'] %}
           <div class="roster-line" id="roster-{{ pos }}">
             {% for p in roster if p.position == pos %}
-              <div class="player" data-id="{{ p.playerId }}" data-pos="{{ p.position }}">
+              <div class="player" data-id="{{ p.playerId }}" data-pos="{{ p.position }}"
+                   data-name="{{ p.shortName or p.fullName }}"
+                   data-news="{{ p.news or '' }}"
+                   data-stats='{{ p.stats|tojson|safe }}'>
                 <img src="{{ p.photo }}" alt="" />
+                {% set st = p.status or 'a' %}
+                {% if st != 'a' %}
+                  {% set ch = p.chance or 0 %}
+                  {% if ch >= 75 %}
+                    <span class="flag flag-yellow"></span>
+                  {% elif ch >= 50 %}
+                    <span class="flag flag-orange"></span>
+                  {% else %}
+                    <span class="flag flag-red"></span>
+                  {% endif %}
+                {% else %}
+                  <span class="info-icon">i</span>
+                {% endif %}
                 <span>{{ p.shortName or p.fullName }}</span>
                 <small>{{ p.position }}{% if p.fixture %} {{ p.fixture }}{% endif %}</small>
               </div>
@@ -74,5 +90,24 @@
 </form>
 <script id="lineup-data" type="application/json">{{ lineup|map(attribute='playerId')|list|tojson }}</script>
 <script id="bench-data" type="application/json">{{ bench|map(attribute='playerId')|list|tojson }}</script>
+
+<div id="player-modal" class="modal" aria-hidden="true">
+  <div class="modal-backdrop" data-close="1"></div>
+  <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="pm-title">
+    <div class="modal-header">
+      <div id="pm-title" class="modal-title">Информация</div>
+      <button type="button" class="modal-close" data-close="1" aria-label="Закрыть">×</button>
+    </div>
+    <div class="modal-body">
+      <div class="player-head">
+        <img id="pm-photo" src="" alt="" class="player-photo" style="display:none;">
+        <div id="pm-name" class="player-name"></div>
+      </div>
+      <div id="pm-news" class="muted" style="margin-bottom:8px;"></div>
+      <div id="pm-stats"></div>
+    </div>
+  </div>
+</div>
+
 <script src="{{ url_for('static', filename='js/squad.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show FPL-style availability flags or info icon in EPL squad selection
- add popup with availability news and season stats for each player

## Testing
- `python -m py_compile draft_app/epl_services.py draft_app/epl_routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689caad96bf8832384060355a9dee0f6