### PR TITLE
Show club logos for EPL lineups

### DIFF
--- a/draft_app/epl_routes.py
+++ b/draft_app/epl_routes.py
@@ -336,6 +336,7 @@ def lineups():
                     "name": name,
                     "pos": meta.get("position"),
                     "points": pts.get(int(pid), 0),
+                    "club": meta.get("clubName"),
                 })
             for pid in lineup.get("bench") or []:
                 meta = pidx.get(str(pid), {})
@@ -344,6 +345,7 @@ def lineups():
                     "name": name,
                     "pos": meta.get("position"),
                     "points": pts.get(int(pid), 0),
+                    "club": meta.get("clubName"),
                 })
             # Add remaining players to bench automatically
             selected = {str(pid) for pid in (lineup.get("players") or []) + (lineup.get("bench") or [])}
@@ -358,6 +360,7 @@ def lineups():
                     "name": name,
                     "pos": pl.get("position") or meta.get("position"),
                     "points": pts.get(int(pid), 0),
+                    "club": meta.get("clubName") or pl.get("clubName"),
                 })
             extra.sort(key=lambda p: pos_order.get(p.get("pos"), 99))
             bench.extend(extra)
@@ -378,6 +381,7 @@ def lineups():
                     "name": name,
                     "pos": pl.get("position") or meta.get("position"),
                     "points": pts.get(int(pid), 0),
+                    "club": meta.get("clubName") or pl.get("clubName"),
                 })
             starters.sort(key=lambda p: pos_order.get(p.get("pos"), 99))
             status[m] = False

--- a/templates/lineups.html
+++ b/templates/lineups.html
@@ -34,8 +34,13 @@
       {% for m in managers %}
       <td>
         {% if lineups[m].has_lineup %}
+          {% set last_pos = None %}
           {% for p in lineups[m].starters %}
-            <div>{{ p.points }} {{ p.name }} ({{ p.pos }}) </div>
+            {% if last_pos and p.pos != last_pos %}
+              <div></div>
+            {% endif %}
+            {% set last_pos = p.pos %}
+            <div>{{ p.points }} {{ p.name }} <img src="https://resources.premierleague.com/premierleague/badges/70/{{ p.club|lower }}.png" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/></div>
           {% endfor %}
           {% if lineups[m].bench %}
             <div class="mt-2 has-text-weight-semibold">Запас</div>
@@ -44,8 +49,13 @@
             {% endfor %}
           {% endif %}
         {% else %}
+          {% set last_pos = None %}
           {% for p in lineups[m].starters %}
-            <div>{{ p.name }} ({{ p.pos }})</div>
+            {% if last_pos and p.pos != last_pos %}
+              <div></div>
+            {% endif %}
+            {% set last_pos = p.pos %}
+            <div>{{ p.name }} <img src="https://resources.premierleague.com/premierleague/badges/70/{{ p.club|lower }}.png" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/></div>
           {% endfor %}
         {% endif %}
       </td>


### PR DESCRIPTION
## Summary
- replace position text with club logos on the EPL lineups page
- insert blank line between starter position groups
- keep bench display unchanged

## Testing
- `python -m py_compile draft_app/epl_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a469ffc6a0832396a581331df6d350