### PR TITLE
Align points and add position separators in EPL lineups

### DIFF
--- a/templates/lineups.html
+++ b/templates/lineups.html
@@ -33,14 +33,18 @@
     <tr>
       {% for m in managers %}
       <td>
+        {% set hue = loop.index0 * 60 %}
+        {% set c1 = 'hsl(' ~ hue ~ ', 70%, 90%)' %}
+        {% set c2 = 'hsl(' ~ hue ~ ', 70%, 80%)' %}
         {% if lineups[m].has_lineup %}
           {% set last_pos = None %}
           {% for p in lineups[m].starters %}
             {% if last_pos and p.pos != last_pos %}
-              <div></div>
+              <hr class="my-1"/>
             {% endif %}
             {% set last_pos = p.pos %}
-            <div class="is-flex is-justify-content-space-between">
+            {% set row_color = c1 if loop.index0 % 2 == 0 else c2 %}
+            <div class="is-flex is-justify-content-space-between" style="background-color: {{ row_color }};">
               <span>{{ p.name }} <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/></span>
               <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
             </div>
@@ -50,10 +54,11 @@
             {% set last_pos = None %}
             {% for p in lineups[m].bench %}
               {% if last_pos and p.pos != last_pos %}
-                <div></div>
+                <hr class="my-1"/>
               {% endif %}
               {% set last_pos = p.pos %}
-              <div class="is-flex is-justify-content-space-between has-text-grey">
+              {% set row_color = c1 if loop.index0 % 2 == 0 else c2 %}
+              <div class="is-flex is-justify-content-space-between has-text-grey" style="background-color: {{ row_color }};">
                 <span>{{ p.name }} ({{ p.pos }})</span>
                 <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
               </div>
@@ -63,10 +68,11 @@
           {% set last_pos = None %}
           {% for p in lineups[m].starters %}
             {% if last_pos and p.pos != last_pos %}
-              <div></div>
+              <hr class="my-1"/>
             {% endif %}
             {% set last_pos = p.pos %}
-            <div class="is-flex is-justify-content-space-between">
+            {% set row_color = c1 if loop.index0 % 2 == 0 else c2 %}
+            <div class="is-flex is-justify-content-space-between" style="background-color: {{ row_color }};">
               <span>{{ p.name }} <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/></span>
               <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
             </div>

--- a/templates/lineups.html
+++ b/templates/lineups.html
@@ -37,12 +37,12 @@
         {% set c1 = 'hsl(' ~ hue ~ ', 70%, 90%)' %}
         {% set c2 = 'hsl(' ~ hue ~ ', 70%, 80%)' %}
         {% if lineups[m].has_lineup %}
-          {% set last_pos = None %}
+          {% set ns = namespace(last_pos=None) %}
           {% for p in lineups[m].starters %}
-            {% if last_pos and p.pos != last_pos %}
+            {% if ns.last_pos and p.pos != ns.last_pos %}
               <hr class="my-1"/>
             {% endif %}
-            {% set last_pos = p.pos %}
+            {% set ns.last_pos = p.pos %}
             {% set row_color = c1 if loop.index0 % 2 == 0 else c2 %}
             <div class="is-flex is-justify-content-space-between" style="background-color: {{ row_color }};">
               <span>{{ p.name }} <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/></span>
@@ -51,12 +51,12 @@
           {% endfor %}
           {% if lineups[m].bench %}
             <div class="mt-2 has-text-weight-semibold">Запас</div>
-            {% set last_pos = None %}
+            {% set ns_bench = namespace(last_pos=None) %}
             {% for p in lineups[m].bench %}
-              {% if last_pos and p.pos != last_pos %}
+              {% if ns_bench.last_pos and p.pos != ns_bench.last_pos %}
                 <hr class="my-1"/>
               {% endif %}
-              {% set last_pos = p.pos %}
+              {% set ns_bench.last_pos = p.pos %}
               {% set row_color = c1 if loop.index0 % 2 == 0 else c2 %}
               <div class="is-flex is-justify-content-space-between has-text-grey" style="background-color: {{ row_color }};">
                 <span>{{ p.name }} ({{ p.pos }})</span>
@@ -65,12 +65,12 @@
             {% endfor %}
           {% endif %}
         {% else %}
-          {% set last_pos = None %}
+          {% set ns = namespace(last_pos=None) %}
           {% for p in lineups[m].starters %}
-            {% if last_pos and p.pos != last_pos %}
+            {% if ns.last_pos and p.pos != ns.last_pos %}
               <hr class="my-1"/>
             {% endif %}
-            {% set last_pos = p.pos %}
+            {% set ns.last_pos = p.pos %}
             {% set row_color = c1 if loop.index0 % 2 == 0 else c2 %}
             <div class="is-flex is-justify-content-space-between" style="background-color: {{ row_color }};">
               <span>{{ p.name }} <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/></span>

--- a/templates/lineups.html
+++ b/templates/lineups.html
@@ -40,12 +40,23 @@
               <div></div>
             {% endif %}
             {% set last_pos = p.pos %}
-              <div>{{ p.points }} {{ p.name }} <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/></div>
+            <div class="is-flex is-justify-content-space-between">
+              <span>{{ p.name }} <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/></span>
+              <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
+            </div>
           {% endfor %}
           {% if lineups[m].bench %}
             <div class="mt-2 has-text-weight-semibold">Запас</div>
+            {% set last_pos = None %}
             {% for p in lineups[m].bench %}
-              <div class="has-text-grey">{{ p.points }} {{ p.name }} ({{ p.pos }})</div>
+              {% if last_pos and p.pos != last_pos %}
+                <div></div>
+              {% endif %}
+              {% set last_pos = p.pos %}
+              <div class="is-flex is-justify-content-space-between has-text-grey">
+                <span>{{ p.name }} ({{ p.pos }})</span>
+                <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
+              </div>
             {% endfor %}
           {% endif %}
         {% else %}
@@ -55,7 +66,10 @@
               <div></div>
             {% endif %}
             {% set last_pos = p.pos %}
-            <div>{{ p.name }} <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/></div>
+            <div class="is-flex is-justify-content-space-between">
+              <span>{{ p.name }} <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/></span>
+              <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
+            </div>
           {% endfor %}
         {% endif %}
       </td>


### PR DESCRIPTION
## Summary
- Show player points to the right of name and club with flex layout for consistent mobile alignment
- Insert blank lines between different positions in starters and bench

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4773fcfec83239841de6cd008612e