### PR TITLE
Add match status indicators on EPL lineups

### DIFF
--- a/draft_app/epl_routes.py
+++ b/draft_app/epl_routes.py
@@ -318,7 +318,7 @@ def lineups():
     bootstrap = ensure_fpl_bootstrap_fresh()
     players = players_from_fpl(bootstrap)
     pidx = players_index(players)
-    pts = points_for_gw(gw)
+    stats_map = points_for_gw(gw, pidx)
     team_codes = {int(t.get("id")): t.get("code") for t in (bootstrap.get("teams") or []) if t.get("id") is not None}
     managers = sorted(rosters.keys())
     table: Dict[str, dict] = {}
@@ -333,20 +333,26 @@ def lineups():
             for pid in lineup.get("players") or []:
                 meta = pidx.get(str(pid), {})
                 name = meta.get("shortName") or meta.get("fullName") or str(pid)
+                s = stats_map.get(int(pid), {})
                 starters.append({
                     "name": name,
                     "pos": meta.get("position"),
-                    "points": pts.get(int(pid), 0),
+                    "points": s.get("points", 0),
                     "club": team_codes.get(meta.get("teamId")),
+                    "minutes": s.get("minutes", 0),
+                    "status": s.get("status", "not_started"),
                 })
             for pid in lineup.get("bench") or []:
                 meta = pidx.get(str(pid), {})
                 name = meta.get("shortName") or meta.get("fullName") or str(pid)
+                s = stats_map.get(int(pid), {})
                 bench.append({
                     "name": name,
                     "pos": meta.get("position"),
-                    "points": pts.get(int(pid), 0),
+                    "points": s.get("points", 0),
                     "club": team_codes.get(meta.get("teamId")),
+                    "minutes": s.get("minutes", 0),
+                    "status": s.get("status", "not_started"),
                 })
             # Add remaining players to bench automatically
             selected = {str(pid) for pid in (lineup.get("players") or []) + (lineup.get("bench") or [])}
@@ -357,11 +363,14 @@ def lineups():
                     continue
                 meta = pidx.get(str(pid), {})
                 name = meta.get("shortName") or meta.get("fullName") or pl.get("fullName") or str(pid)
+                s = stats_map.get(int(pid), {})
                 extra.append({
                     "name": name,
                     "pos": pl.get("position") or meta.get("position"),
-                    "points": pts.get(int(pid), 0),
+                    "points": s.get("points", 0),
                     "club": team_codes.get(meta.get("teamId")),
+                    "minutes": s.get("minutes", 0),
+                    "status": s.get("status", "not_started"),
                 })
             extra.sort(key=lambda p: pos_order.get(p.get("pos"), 99))
             bench.extend(extra)
@@ -378,11 +387,14 @@ def lineups():
                 pid = pl.get("playerId") or pl.get("id")
                 meta = pidx.get(str(pid), {})
                 name = meta.get("shortName") or meta.get("fullName") or pl.get("fullName") or str(pid)
+                s = stats_map.get(int(pid), {})
                 starters.append({
                     "name": name,
                     "pos": pl.get("position") or meta.get("position"),
-                    "points": pts.get(int(pid), 0),
+                    "points": s.get("points", 0),
                     "club": team_codes.get(meta.get("teamId")),
+                    "minutes": s.get("minutes", 0),
+                    "status": s.get("status", "not_started"),
                 })
             starters.sort(key=lambda p: pos_order.get(p.get("pos"), 99))
             status[m] = False

--- a/draft_app/epl_routes.py
+++ b/draft_app/epl_routes.py
@@ -320,7 +320,7 @@ def lineups():
     pidx = players_index(players)
     stats_map = points_for_gw(gw, pidx)
     team_codes = {int(t.get("id")): t.get("code") for t in (bootstrap.get("teams") or []) if t.get("id") is not None}
-    managers = sorted(rosters.keys())
+    managers = list(rosters.keys())
     table: Dict[str, dict] = {}
     status: Dict[str, bool] = {}
     pos_order = {"GK": 0, "DEF": 1, "MID": 2, "FWD": 3}
@@ -437,6 +437,14 @@ def lineups():
             "ts": ts,
             "total": total_pts,
         }
+
+    managers.sort(
+        key=lambda m: (
+            table[m]["total"] is None,
+            -(table[m]["total"] or 0),
+            table[m]["ts"] or datetime.max,
+        )
+    )
 
     deadline = None
     for ev in (bootstrap.get("events") or []):

--- a/templates/lineups.html
+++ b/templates/lineups.html
@@ -1,6 +1,14 @@
 {% extends "base.html" %}
 {% block title %}Составы на Gameweek {{ gw }}{% endblock %}
 {% block content %}
+<style>
+  .live-dot {
+    height:6px; width:6px; background-color:red; border-radius:50%;
+    display:inline-block; margin-right:2px;
+    animation: blink 1s linear infinite;
+  }
+  @keyframes blink { 50% { opacity:0; } }
+</style>
 <h1 class="title">Составы на Gameweek {{ gw }}</h1>
 {% if deadline_warsaw %}
 <p>Дедлайн: {{ deadline_warsaw.strftime("%d.%m %H:%M") }} (Варшава) / {{ deadline_minsk.strftime("%d.%m %H:%M") }} (Минск)</p>
@@ -45,7 +53,11 @@
             {% set ns.last_pos = p.pos %}
             {% set row_color = c1 if loop.index0 % 2 == 0 else c2 %}
             <div class="is-flex is-justify-content-space-between" style="background-color: {{ row_color }};">
-              <span>{{ p.name }} <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/></span>
+              <span>
+                {% if p.status == 'in_progress' %}<span class="live-dot"></span>{% endif %}
+                <span class="{{ 'has-text-weight-bold' if p.status == 'finished' and p.minutes > 0 else '' }}">{{ p.name }}</span>
+                <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/>
+              </span>
               <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
             </div>
           {% endfor %}
@@ -58,10 +70,13 @@
               {% endif %}
               {% set ns_bench.last_pos = p.pos %}
               {% set row_color = c1 if loop.index0 % 2 == 0 else c2 %}
-              <div class="is-flex is-justify-content-space-between has-text-grey" style="background-color: {{ row_color }};">
-                <span>{{ p.name }} ({{ p.pos }})</span>
-                <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
-              </div>
+                <div class="is-flex is-justify-content-space-between has-text-grey" style="background-color: {{ row_color }};">
+                  <span>
+                    {% if p.status == 'in_progress' %}<span class="live-dot"></span>{% endif %}
+                    <span class="{{ 'has-text-weight-bold' if p.status == 'finished' and p.minutes > 0 else '' }}">{{ p.name }} ({{ p.pos }})</span>
+                  </span>
+                  <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
+                </div>
             {% endfor %}
           {% endif %}
         {% else %}
@@ -73,7 +88,11 @@
             {% set ns.last_pos = p.pos %}
             {% set row_color = c1 if loop.index0 % 2 == 0 else c2 %}
             <div class="is-flex is-justify-content-space-between" style="background-color: {{ row_color }};">
-              <span>{{ p.name }} <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/></span>
+              <span>
+                {% if p.status == 'in_progress' %}<span class="live-dot"></span>{% endif %}
+                <span class="{{ 'has-text-weight-bold' if p.status == 'finished' and p.minutes > 0 else '' }}">{{ p.name }}</span>
+                <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/>
+              </span>
               <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
             </div>
           {% endfor %}

--- a/templates/lineups.html
+++ b/templates/lineups.html
@@ -52,14 +52,15 @@
             {% endif %}
             {% set ns.last_pos = p.pos %}
             {% set row_color = c1 if loop.index0 % 2 == 0 else c2 %}
-            <div class="is-flex is-justify-content-space-between" style="background-color: {{ row_color }};">
-              <span>
-                {% if p.status == 'in_progress' %}<span class="live-dot"></span>{% endif %}
-                <span class="{{ 'has-text-weight-bold' if p.status == 'finished' and p.minutes > 0 else '' }}">{{ p.name }}</span>
-                <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/>
-              </span>
-              <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
-            </div>
+              <div class="is-flex is-justify-content-space-between" style="background-color: {{ row_color }};">
+                <span>
+                  {% if p.status == 'in_progress' %}<span class="live-dot"></span>{% endif %}
+                  <span class="{% if p.subbed_out %}has-text-danger{% elif p.status == 'finished' and p.minutes > 0 %}has-text-weight-bold{% endif %}">{{ p.name }}</span>
+                  {% if p.subbed_out %}<span class="has-text-danger">⬇️</span>{% endif %}
+                  <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/>
+                </span>
+                <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
+              </div>
           {% endfor %}
           {% if lineups[m].bench %}
             <div class="mt-2 has-text-weight-semibold">Запас</div>
@@ -69,11 +70,15 @@
                 <hr class="my-1"/>
               {% endif %}
               {% set ns_bench.last_pos = p.pos %}
-              {% set row_color = c1 if loop.index0 % 2 == 0 else c2 %}
-                <div class="is-flex is-justify-content-space-between has-text-grey" style="background-color: {{ row_color }};">
+                {% set row_color = c1 if loop.index0 % 2 == 0 else c2 %}
+                <div class="is-flex is-justify-content-space-between {% if p.subbed_in %}{% else %}has-text-grey{% endif %}" style="background-color: {{ row_color }};">
                   <span>
                     {% if p.status == 'in_progress' %}<span class="live-dot"></span>{% endif %}
-                    <span class="{{ 'has-text-weight-bold' if p.status == 'finished' and p.minutes > 0 else '' }}">{{ p.name }} ({{ p.pos }})</span>
+                    {% if p.subbed_in %}
+                      <span class="has-text-weight-bold has-text-success">{{ p.name }}<span class="has-text-success">⬆️</span> ({{ p.pos }})</span>
+                    {% else %}
+                      <span class="{{ 'has-text-weight-bold' if p.status == 'finished' and p.minutes > 0 else '' }}">{{ p.name }} ({{ p.pos }})</span>
+                    {% endif %}
                   </span>
                   <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
                 </div>

--- a/templates/lineups.html
+++ b/templates/lineups.html
@@ -32,7 +32,10 @@
         {% if lineups[m].ts %}
         <div class="has-text-grey is-size-7">{{ lineups[m].ts.strftime('%d.%m %H:%M') }}</div>
         {% endif %}
-        {{ '🟢' if status[m] else '🔴' }} {{ m }} <span style="background-color:#006400;color:white;padding:0 4px;border-radius:3px;">{{ lineups[m].total }}</span>
+        {{ '🟢' if status[m] else '🔴' }} {{ m }}
+        {% if lineups[m].total is not none %}
+        <span style="background-color:#006400;color:white;padding:0 4px;border-radius:3px;">{{ lineups[m].total }}</span>
+        {% endif %}
       </th>
       {% endfor %}
     </tr>
@@ -59,7 +62,7 @@
                   {% if p.subbed_out %}<span class="has-text-danger">⬇️</span>{% endif %}
                   <img src="https://resources.premierleague.com/premierleague25/badges/{{ p.club }}.svg" alt="{{ p.club }}" style="height:14px; vertical-align:middle"/>
                 </span>
-                <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
+                <span class="has-text-right" style="min-width:2em"><span class="{% if p.penalized %}has-text-danger has-text-weight-bold{% endif %}">{{ p.points }}</span></span>
               </div>
           {% endfor %}
           {% if lineups[m].bench %}


### PR DESCRIPTION
## Summary
- show red blinking dot next to players whose matches are in progress
- bold players once their match is finished and they have logged minutes
- pull live fixture status and minutes from FPL API

## Testing
- `pytest`
- `python -m py_compile draft_app/epl_services.py draft_app/epl_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a47e3acffc8323adb8ee503d4ed427