### PR TITLE
Group EPL pages into dropdown and add results page

### DIFF
--- a/draft_app/epl_routes.py
+++ b/draft_app/epl_routes.py
@@ -473,6 +473,11 @@ def lineups():
         deadline_minsk=deadline_minsk,
     )
 
+
+@bp.get("/epl/results")
+def results():
+    return render_template("epl_results.html")
+
 @bp.post("/epl/undo")
 def undo_last_pick():
     if not session.get("godmode"):

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,9 +33,15 @@
       <div class="navbar-start">
         <a class="navbar-item" href="{{ url_for('home.index') }}">Главная</a>
         <a class="navbar-item" href="{{ url_for('ucl.index') }}">UCL Драфт</a>
-        <a class="navbar-item" href="{{ url_for('epl.index') }}">EPL Пики</a>
-        <a class="navbar-item" href="{{ url_for('epl.squad') }}">EPL Состав</a>
-        <a class="navbar-item" href="{{ url_for('epl.lineups') }}">EPL Лайнапы</a>
+        <div class="navbar-item has-dropdown is-hoverable">
+          <a class="navbar-link" href="{{ url_for('epl.index') }}">EPL Драфт</a>
+          <div class="navbar-dropdown">
+            <a class="navbar-item" href="{{ url_for('epl.index') }}">Пики</a>
+            <a class="navbar-item" href="{{ url_for('epl.squad') }}">Состав</a>
+            <a class="navbar-item" href="{{ url_for('epl.lineups') }}">Лайнапы</a>
+            <a class="navbar-item" href="{{ url_for('epl.results') }}">Результаты</a>
+          </div>
+        </div>
         <a class="navbar-item" href="{{ url_for('home.top4') }}">Топ-4</a>
       </div>
       <div class="navbar-end">

--- a/templates/epl_results.html
+++ b/templates/epl_results.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}EPL Результаты — Fantasy Draft{% endblock %}
+{% block content %}
+<h1 class="title">EPL Результаты</h1>
+<p>Страница с результатами EPL появится здесь.</p>
+{% endblock %}

--- a/templates/epl_results.html
+++ b/templates/epl_results.html
@@ -2,5 +2,34 @@
 {% block title %}EPL Результаты — Fantasy Draft{% endblock %}
 {% block content %}
 <h1 class="title">EPL Результаты</h1>
-<p>Страница с результатами EPL появится здесь.</p>
+{% if gws %}
+<table class="table is-striped is-fullwidth">
+  <thead>
+    <tr>
+      <th>Менеджер</th>
+      {% for gw in gws %}
+      <th>GW{{ gw }}</th>
+      {% endfor %}
+      <th>Баллы</th>
+      <th>Победы</th>
+      <th>Очки</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in standings %}
+    <tr>
+      <td>{{ row.manager }}</td>
+      {% for gw in gws %}
+      <td>{{ row.gw_points.get(gw, 0) }}</td>
+      {% endfor %}
+      <td>{{ row.class_points }}</td>
+      <td>{{ row.wins }}</td>
+      <td>{{ row.raw_points }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>Нет завершённых туров.</p>
+{% endif %}
 {% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,11 +1,37 @@
 {% extends "base.html" %}
 {% block title %}Главная — Fantasy Draft{% endblock %}
 {% block content %}
-<h1 class="title">Выберите драфт</h1>
-<div class="buttons">
-  <a class="button is-info is-medium" href="{{ url_for('ucl.index') }}">UCL Fantasy Draft</a>
-  <a class="button is-primary is-medium" href="{{ url_for('epl.index') }}">EPL Fantasy Draft</a>
-  <a class="button is-link is-medium" href="{{ url_for('home.top4') }}">Топ-4 Драфт</a>
+<h1 class="title">Выберите страницу</h1>
+
+<div class="tile is-ancestor">
+  <div class="tile is-parent">
+    <article class="tile is-child box">
+      <p class="title is-5">UCL Fantasy Draft</p>
+      <div class="buttons">
+        <a class="button is-info is-light" href="{{ url_for('ucl.index') }}">Пики</a>
+      </div>
+    </article>
+  </div>
+  <div class="tile is-parent">
+    <article class="tile is-child box">
+      <p class="title is-5">EPL Fantasy Draft</p>
+      <div class="buttons">
+        <a class="button is-primary is-light" href="{{ url_for('epl.index') }}">Пики</a>
+        <a class="button is-primary is-light" href="{{ url_for('epl.squad') }}">Состав</a>
+        <a class="button is-primary is-light" href="{{ url_for('epl.lineups') }}">Лайнапы</a>
+        <a class="button is-primary is-light" href="{{ url_for('epl.results') }}">Результаты</a>
+      </div>
+    </article>
+  </div>
+  <div class="tile is-parent">
+    <article class="tile is-child box">
+      <p class="title is-5">Топ-4 Драфт</p>
+      <div class="buttons">
+        <a class="button is-link is-light" href="{{ url_for('home.top4') }}">Перейти</a>
+      </div>
+    </article>
+  </div>
 </div>
+
 <p class="mt-3 muted small">Подсказка: авторизация — через ID и 4-значный PIN (auth.json). Godmode виден в правом верхнем углу.</p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add dropdown menu for EPL pages in navbar
- reorganize home page with tiles for each draft and links to EPL pages
- add placeholder EPL Results page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a489a8883483238c89e3e384d41ab6