### PR TITLE
Cache FPL bootstrap in tmp or S3

### DIFF
--- a/draft_app/config.py
+++ b/draft_app/config.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from zoneinfo import ZoneInfo
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -22,7 +23,8 @@ EPL_POSITION_LIMITS = {'Goalkeeper': 3, 'Defender': 7, 'Midfielder': 8, 'Forward
 UCL_STATE_FILE   = os.path.join(BASE_DIR, 'draft_state_ucl.json')
 EPL_STATE_FILE   = os.path.join(BASE_DIR, 'draft_state_epl.json')
 UCL_PLAYERS_FILE = os.path.join(BASE_DIR, 'players_70_en_3.json')
-EPL_PLAYERS_FILE = os.path.join(BASE_DIR, 'players_fpl_bootstrap.json')
+# players_fpl_bootstrap.json кешируется вне репозитория
+EPL_PLAYERS_FILE = os.path.join(tempfile.gettempdir(), 'players_fpl_bootstrap.json')
 
 # Кэш-дериктории
 UCL_CACHE_DIR = os.path.join(BASE_DIR, 'popupstats')

--- a/draft_app/status.py
+++ b/draft_app/status.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import json
 from pathlib import Path
+import tempfile
 from typing import Dict, List, Any
 from flask import Blueprint, render_template, url_for, abort
 
@@ -14,7 +15,7 @@ DATA_DIR = BASE_DIR / "data"                       # поменяйте если
 LEAGUE_FILES = {
     "epl": {
         "state": BASE_DIR / "draft_state_epl.json",
-        "players": BASE_DIR / "players_fpl_bootstrap.json",  # если есть; иначе закомментируйте
+        "players": Path(tempfile.gettempdir()) / "players_fpl_bootstrap.json",  # кешируется в /tmp
     },
     "ucl": {
         "state": BASE_DIR / "draft_state_ucl.json",


### PR DESCRIPTION
## Summary
- cache `players_fpl_bootstrap.json` in `/tmp` instead of repository root and optionally mirror to S3
- update bootstrap helpers and consumers to use the new temporary path

## Testing
- `python -m py_compile draft_app/config.py draft_app/epl_services.py draft_app/services.py draft_app/status.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a49a687c5c8323bd85ae3b31762cab