### PR TITLE
Expose HTTP session and headers for stats blueprint

### DIFF
--- a/draft_app/services.py
+++ b/draft_app/services.py
@@ -1,10 +1,32 @@
 import json
 from datetime import datetime
+
+import requests
+
 from .config import (
     UCL_POSITION_MAP, FPL_POSITION_MAP, WARSZAWA_TZ
 )
 from .epl_services import ensure_fpl_bootstrap_fresh
 
+
+HTTP_SESSION = requests.Session()
+
+HEADERS_GENERIC = {
+    "User-Agent": "Mozilla/5.0"
+}
+
+__all__ = [
+    "HTTP_SESSION",
+    "HEADERS_GENERIC",
+    "load_json",
+    "save_json",
+    "parse_ucl_players",
+    "fetch_and_cache_fpl_bootstrap",
+    "get_bootstrap_data",
+    "load_epl_players",
+    "format_deadline",
+    "epl_deadlines_window",
+]
 
 
 def load_json(path, default=None):

--- a/draft_app/stats.py
+++ b/draft_app/stats.py
@@ -2,7 +2,7 @@ import os
 from flask import Blueprint, render_template, flash, redirect, url_for
 from . import state
 from .config import UCL_CACHE_DIR
-from .services import session_req, HEADERS_GENERIC, load_json, save_json
+from .services import HTTP_SESSION, HEADERS_GENERIC, load_json, save_json
 
 bp = Blueprint("stats", __name__)
 
@@ -19,7 +19,7 @@ def index(pid):
     data = load_json(cache_path, default=None)
     if data is None:
         try:
-            r = session_req.get(popup_url, headers=HEADERS_GENERIC, timeout=10)
+            r = HTTP_SESSION.get(popup_url, headers=HEADERS_GENERIC, timeout=10)
             r.raise_for_status()
             data = r.json()
             save_json(cache_path, data)


### PR DESCRIPTION
## Summary
- share a `requests.Session` and generic headers from the services module
- use the shared session in the stats blueprint for fetching popup stats

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import draft
from draft_app.services import HTTP_SESSION
from draft_app.stats import bp
print('import ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a49ebe7da48323a0020c37eb1b2d0f