### PR TITLE
Fix EPL results calculation with bench substitutions

### DIFF
--- a/draft_app/epl_routes.py
+++ b/draft_app/epl_routes.py
@@ -549,11 +549,58 @@ def results():
         gw_scores: Dict[str, int] = {}
         for m in managers:
             lineup = load_lineup(m, gw)
-            if lineup.get("players"):
-                ids = [int(x) for x in lineup.get("players")]
+            players_ids = [int(x) for x in (lineup.get("players") or [])]
+            bench_ids = [int(x) for x in (lineup.get("bench") or [])]
+            if not players_ids:
+                roster_ids = [int(p.get("playerId")) for p in rosters.get(m, [])]
+                players_ids = roster_ids[:11]
+                bench_ids = roster_ids[11:]
             else:
-                ids = [p.get("playerId") for p in rosters.get(m, [])][:11]
-            total = sum(int(stats.get(pid, {}).get("points", 0)) for pid in ids)
+                selected = {pid for pid in players_ids + bench_ids}
+                extra: list[int] = []
+                for pl in rosters.get(m, []) or []:
+                    pid = pl.get("playerId") or pl.get("id")
+                    if pid and int(pid) not in selected:
+                        extra.append(int(pid))
+                pos_order = {"GK": 0, "DEF": 1, "MID": 2, "FWD": 3}
+                extra.sort(key=lambda pid: pos_order.get(pidx.get(str(pid), {}).get("position"), 99))
+                bench_ids.extend(extra)
+
+            bench_pool: list[dict] = []
+            for pid in bench_ids:
+                meta = pidx.get(str(pid), {})
+                s = stats.get(pid, {})
+                bench_pool.append(
+                    {
+                        "pos": meta.get("position"),
+                        "points": int(s.get("points", 0)),
+                        "minutes": int(s.get("minutes", 0)),
+                        "used": False,
+                    }
+                )
+
+            total = 0
+            for pid in players_ids:
+                meta = pidx.get(str(pid), {})
+                s = stats.get(pid, {})
+                pos = meta.get("position")
+                status = s.get("status")
+                minutes = int(s.get("minutes", 0))
+                pts = int(s.get("points", 0))
+                if status == "finished" and minutes == 0:
+                    sub = None
+                    for b in bench_pool:
+                        if b["pos"] == pos and b["minutes"] > 0 and not b["used"]:
+                            sub = b
+                            break
+                    if sub:
+                        total += sub["points"]
+                        sub["used"] = True
+                    else:
+                        total += -2
+                else:
+                    total += pts
+
             points_by_manager[m][gw] = total
             gw_scores[m] = total
 


### PR DESCRIPTION
## Summary
- handle bench substitutions and penalties when computing EPL results
- align results totals with lineup view

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4a23997a08323b5be594b2cd7ea58