### PR TITLE
Cache gameweek totals and sync lineups to S3

### DIFF
--- a/draft_app/epl_routes.py
+++ b/draft_app/epl_routes.py
@@ -16,6 +16,7 @@ from .epl_services import (
     fixtures_for_gw, points_for_gw, gw_info,
 )
 from .lineup_store import load_lineup, save_lineup
+from .gw_score_store import load_gw_score, save_gw_score
 
 bp = Blueprint("epl", __name__)
 
@@ -544,67 +545,72 @@ def results():
     raw_total: Dict[str, int] = {m: 0 for m in managers}
 
     for gw in gws:
-        _auto_fill_lineups(gw, state, rosters, deadline_map.get(gw))
-        stats = points_for_gw(gw, pidx)
-        gw_scores: Dict[str, int] = {}
-        for m in managers:
-            lineup = load_lineup(m, gw)
-            players_ids = [int(x) for x in (lineup.get("players") or [])]
-            bench_ids = [int(x) for x in (lineup.get("bench") or [])]
-            if not players_ids:
-                roster_ids = [int(p.get("playerId")) for p in rosters.get(m, [])]
-                players_ids = roster_ids[:11]
-                bench_ids = roster_ids[11:]
-            else:
-                selected = {pid for pid in players_ids + bench_ids}
-                extra: list[int] = []
-                for pl in rosters.get(m, []) or []:
-                    pid = pl.get("playerId") or pl.get("id")
-                    if pid and int(pid) not in selected:
-                        extra.append(int(pid))
-                pos_order = {"GK": 0, "DEF": 1, "MID": 2, "FWD": 3}
-                extra.sort(key=lambda pid: pos_order.get(pidx.get(str(pid), {}).get("position"), 99))
-                bench_ids.extend(extra)
-
-            bench_pool: list[dict] = []
-            for pid in bench_ids:
-                meta = pidx.get(str(pid), {})
-                s = stats.get(pid, {})
-                bench_pool.append(
-                    {
-                        "pos": meta.get("position"),
-                        "points": int(s.get("points", 0)),
-                        "minutes": int(s.get("minutes", 0)),
-                        "used": False,
-                    }
-                )
-
-            total = 0
-            for pid in players_ids:
-                meta = pidx.get(str(pid), {})
-                s = stats.get(pid, {})
-                pos = meta.get("position")
-                status = s.get("status")
-                minutes = int(s.get("minutes", 0))
-                pts = int(s.get("points", 0))
-                if status == "finished" and minutes == 0:
-                    sub = None
-                    for b in bench_pool:
-                        if b["pos"] == pos and b["minutes"] > 0 and not b["used"]:
-                            sub = b
-                            break
-                    if sub:
-                        total += sub["points"]
-                        sub["used"] = True
-                    else:
-                        total += -2
+        gw_scores = load_gw_score(gw)
+        if any(m not in gw_scores for m in managers):
+            _auto_fill_lineups(gw, state, rosters, deadline_map.get(gw))
+            stats = points_for_gw(gw, pidx)
+            gw_scores = {}
+            for m in managers:
+                lineup = load_lineup(m, gw)
+                players_ids = [int(x) for x in (lineup.get("players") or [])]
+                bench_ids = [int(x) for x in (lineup.get("bench") or [])]
+                if not players_ids:
+                    roster_ids = [int(p.get("playerId")) for p in rosters.get(m, [])]
+                    players_ids = roster_ids[:11]
+                    bench_ids = roster_ids[11:]
                 else:
-                    total += pts
+                    selected = {pid for pid in players_ids + bench_ids}
+                    extra: list[int] = []
+                    for pl in rosters.get(m, []) or []:
+                        pid = pl.get("playerId") or pl.get("id")
+                        if pid and int(pid) not in selected:
+                            extra.append(int(pid))
+                    pos_order = {"GK": 0, "DEF": 1, "MID": 2, "FWD": 3}
+                    extra.sort(key=lambda pid: pos_order.get(pidx.get(str(pid), {}).get("position"), 99))
+                    bench_ids.extend(extra)
 
-            points_by_manager[m][gw] = total
-            gw_scores[m] = total
+                bench_pool: list[dict] = []
+                for pid in bench_ids:
+                    meta = pidx.get(str(pid), {})
+                    s = stats.get(pid, {})
+                    bench_pool.append(
+                        {
+                            "pos": meta.get("position"),
+                            "points": int(s.get("points", 0)),
+                            "minutes": int(s.get("minutes", 0)),
+                            "used": False,
+                        }
+                    )
 
-        # assign classification points
+                total = 0
+                for pid in players_ids:
+                    meta = pidx.get(str(pid), {})
+                    s = stats.get(pid, {})
+                    pos = meta.get("position")
+                    status = s.get("status")
+                    minutes = int(s.get("minutes", 0))
+                    pts = int(s.get("points", 0))
+                    if status == "finished" and minutes == 0:
+                        sub = None
+                        for b in bench_pool:
+                            if b["pos"] == pos and b["minutes"] > 0 and not b["used"]:
+                                sub = b
+                                break
+                        if sub:
+                            total += sub["points"]
+                            sub["used"] = True
+                        else:
+                            total += -2
+                    else:
+                        total += pts
+
+                gw_scores[m] = total
+            save_gw_score(gw, gw_scores)
+
+        for m in managers:
+            pts = int(gw_scores.get(m, 0))
+            points_by_manager[m][gw] = pts
+
         ordered = sorted(gw_scores.items(), key=lambda x: x[1], reverse=True)
         prev_pts = None
         rank = 0

--- a/draft_app/gw_score_store.py
+++ b/draft_app/gw_score_store.py
@@ -1,0 +1,55 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Dict
+
+from .epl_services import _s3_enabled, _s3_bucket, _s3_get_json, _s3_put_json
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+GW_SCORE_DIR = BASE_DIR / "data" / "cache" / "gw_scores"
+GW_SCORE_DIR.mkdir(parents=True, exist_ok=True)
+
+def _s3_results_prefix() -> str:
+    return os.getenv("DRAFT_S3_RESULTS_PREFIX", "gw_scores")
+
+def _s3_key(gw: int) -> str:
+    prefix = _s3_results_prefix().strip().strip("/")
+    return f"{prefix}/gw{int(gw)}.json"
+
+def load_gw_score(gw: int) -> Dict[str, int]:
+    """Load cached total scores for a gameweek."""
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _s3_key(gw)
+        if bucket:
+            data = _s3_get_json(bucket, key)
+            if isinstance(data, dict):
+                try:
+                    return {str(k): int(v) for k, v in data.items()}
+                except Exception:
+                    return {}
+    p = GW_SCORE_DIR / f"gw{int(gw)}.json"
+    if p.exists():
+        try:
+            with p.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                return {str(k): int(v) for k, v in data.items()}
+        except Exception:
+            pass
+    return {}
+
+def save_gw_score(gw: int, scores: Dict[str, int]) -> None:
+    """Persist total scores for a gameweek (S3 + local)."""
+    payload = {str(k): int(v) for k, v in scores.items()}
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _s3_key(gw)
+        if bucket and not _s3_put_json(bucket, key, payload):
+            print(f"[EPL:S3] save_gw_score fallback gw={gw}")
+    tmp_fd, tmp_name = tempfile.mkstemp(prefix="gw_score_", suffix=".json", dir=str(GW_SCORE_DIR))
+    os.close(tmp_fd)
+    with open(tmp_name, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    os.replace(tmp_name, GW_SCORE_DIR / f"gw{int(gw)}.json")

--- a/draft_app/lineup_store.py
+++ b/draft_app/lineup_store.py
@@ -12,8 +12,8 @@ LINEUP_ROOT = BASE_DIR / 'lineups'
 LINEUP_ROOT.mkdir(parents=True, exist_ok=True)
 _safe_re = re.compile(r"[^a-z0-9_\-]", re.I)
 
-S3_BUCKET = os.getenv("LINEUP_S3_BUCKET")
-S3_PREFIX = os.getenv("LINEUP_S3_PREFIX", "lineups")
+S3_BUCKET = os.getenv("LINEUP_S3_BUCKET") or os.getenv("DRAFT_S3_BUCKET")
+S3_PREFIX = os.getenv("LINEUP_S3_PREFIX") or os.getenv("DRAFT_S3_LINEUPS_PREFIX", "lineups")
 _s3_client = None
 if S3_BUCKET:
     try:


### PR DESCRIPTION
## Summary
- cache EPL gameweek total scores as JSON on S3
- read cached scores on results page and save missing ones
- store lineups on S3 using global bucket fallback

## Testing
- `pytest`
- `python -m py_compile draft_app/gw_score_store.py draft_app/lineup_store.py draft_app/epl_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4a3e70fe08323baa0765d02f1fd15