### PR TITLE
Fix understat dependency for Heroku deployment

### DIFF
--- a/draft_app/top4_routes.py
+++ b/draft_app/top4_routes.py
@@ -45,6 +45,7 @@ def index():
                 "clubName": meta.get("clubName"),
                 "position": meta.get("position"),
                 "league": meta.get("league"),
+                "price": meta.get("price"),
             },
             "ts": datetime.now().isoformat(timespec="seconds"),
         }
@@ -76,6 +77,12 @@ def index():
     positions = sorted({p.get("position") for p in players if p.get("position")})
     if pos_filter:
         players = [p for p in players if p.get("position") == pos_filter]
+
+    sort_field = request.args.get("sort") or "price"
+    sort_dir = request.args.get("dir") or "desc"
+    reverse = sort_dir == "desc"
+    if sort_field == "price":
+        players.sort(key=lambda p: (p.get("price") is None, p.get("price")), reverse=reverse)
 
     annotate_can_pick(players, state, current_user)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ gunicorn==21.2.0
 requests==2.32.3
 urllib3==2.2.2
 boto3>=1.34
-aiohttp>=3.9.0
-understat>=0.3.1
-beautifulsoup4>=4.12.0
+aiohttp==3.8.3
+understat==0.1.12
+beautifulsoup4==4.11.1

--- a/templates/index.html
+++ b/templates/index.html
@@ -95,14 +95,25 @@
             <th>Игрок</th>
             <th>Клуб</th>
             <th>Позиция</th>
+            {% if table_league != 'top4' %}
             <th>Статистика</th>
             <th class="num">
               <button type="button" id="fp-sort-btn" class="link" data-dir="desc" title="Сортировать по FP 2024/25">
                 FP 2024/25 <span id="fp-sort-arrow">↓</span>
               </button>
             </th>
+            {% endif %}
             {% if show_price %}
               <th class="num">
+                {% if table_league == 'top4' %}
+                <a href="{{ url_for('top4.index', league=league_filter, club=club_filter, position=pos_filter, sort='price', dir=next_dir_price) }}"
+                   style="text-decoration:none;color:inherit">
+                  Стоимость
+                  {% if current_sort == 'price' %}
+                    {{ '↑' if current_dir == 'asc' else '↓' }}
+                  {% endif %}
+                </a>
+                {% else %}
                 <a href="{{ url_for('epl.index', club=club_filter, position=pos_filter, sort='price', dir=next_dir_price) }}"
                    style="text-decoration:none;color:inherit">
                   Цена
@@ -110,6 +121,7 @@
                     {{ '↑' if current_dir == 'asc' else '↓' }}
                   {% endif %}
                 </a>
+                {% endif %}
               </th>
             {% endif %}
             <th class="num">Действия</th>
@@ -126,12 +138,14 @@
               <td>{{ p.shortName or p.fullName }}</td>
               <td>{{ p.clubName }}</td>
               <td>{{ p.position }}</td>
+              {% if table_league != 'top4' %}
               <td>
                 <button type="button" class="link link-stat" data-pid="{{ p.playerId }}" data-name="{{ p.shortName or p.fullName }}">stat</button>
               </td>
               <td class="num">
                 <span class="fp-cell" data-pid="{{ p.playerId }}" data-fp="0">0</span>
               </td>
+              {% endif %}
               {% if show_price %}<td class="num">{{ '%.1f'|format(p.price) }}</td>{% endif %}
               <td class="num">
                 <form method="post" style="display:inline;">


### PR DESCRIPTION
## Summary
- use versions of understat, aiohttp, and beautifulsoup4 compatible with PyPI
- hide FP 2024/25 and stats columns on Top-4 draft page
- add sortable Transfermarkt market value column to Top-4 draft

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5a49345a88323b2777dc11d56e7ab