### PR TITLE
Rebuild top-4 draft database with fantasy-h2h data

### DIFF
--- a/data/cache/top4_players.json
+++ b/data/cache/top4_players.json
@@ -6,7 +6,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 10.5,
-    "popularity": 70.0
+    "popularity": 70.1,
+    "fp_last": 185.0
   },
   {
     "playerId": 213748,
@@ -15,7 +16,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 6.2
+    "popularity": 6.8,
+    "fp_last": 57.0
   },
   {
     "playerId": 213928,
@@ -24,7 +26,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 5.8
+    "popularity": 6.1,
+    "fp_last": 112.0
   },
   {
     "playerId": 213670,
@@ -33,7 +36,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 8.5,
-    "popularity": 25.3
+    "popularity": 25.6,
+    "fp_last": 108.0
   },
   {
     "playerId": 214086,
@@ -42,7 +46,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 3.7
+    "popularity": 3.8,
+    "fp_last": 107.0
   },
   {
     "playerId": 214076,
@@ -51,7 +56,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 2.4
+    "popularity": 2.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213792,
@@ -60,7 +66,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 14.9
+    "popularity": 15.1,
+    "fp_last": 57.0
   },
   {
     "playerId": 213929,
@@ -69,7 +76,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 103.0
   },
   {
     "playerId": 213800,
@@ -78,7 +86,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 3.2
+    "popularity": 3.4,
+    "fp_last": 87.0
   },
   {
     "playerId": 214062,
@@ -87,7 +96,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 10.2
+    "popularity": 10.5,
+    "fp_last": 3.0
   },
   {
     "playerId": 213826,
@@ -96,7 +106,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213938,
@@ -105,7 +116,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 4.3
+    "popularity": 4.4,
+    "fp_last": 43.0
   },
   {
     "playerId": 214027,
@@ -114,7 +126,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 1.3
+    "popularity": 1.4,
+    "fp_last": 84.0
   },
   {
     "playerId": 213780,
@@ -123,7 +136,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 2.4
+    "popularity": 2.5,
+    "fp_last": 142.0
   },
   {
     "playerId": 213851,
@@ -132,7 +146,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 2.4
+    "popularity": 2.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214038,
@@ -141,7 +156,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.5,
-    "popularity": 5.4
+    "popularity": 5.4,
+    "fp_last": 159.0
   },
   {
     "playerId": 214106,
@@ -150,7 +166,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213788,
@@ -159,7 +176,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 10.6
+    "popularity": 10.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213636,
@@ -168,7 +186,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 3.1
+    "popularity": 3.1,
+    "fp_last": 101.0
   },
   {
     "playerId": 213729,
@@ -177,7 +196,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 11.5,
-    "popularity": 38.2
+    "popularity": 38.3,
+    "fp_last": 219.0
   },
   {
     "playerId": 213638,
@@ -186,7 +206,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 87.0
   },
   {
     "playerId": 213700,
@@ -195,7 +216,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 9.5,
-    "popularity": 34.6
+    "popularity": 34.8,
+    "fp_last": 152.0
   },
   {
     "playerId": 213798,
@@ -204,7 +226,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 13.2
+    "popularity": 13.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213796,
@@ -213,7 +236,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 12.4
+    "popularity": 12.8,
+    "fp_last": 9.0
   },
   {
     "playerId": 214009,
@@ -222,7 +246,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.5,
-    "popularity": 6.7
+    "popularity": 6.6,
+    "fp_last": 106.0
   },
   {
     "playerId": 213795,
@@ -231,7 +256,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 8.6
+    "popularity": 8.6,
+    "fp_last": 59.0
   },
   {
     "playerId": 213794,
@@ -240,7 +266,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 3.6
+    "popularity": 3.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213709,
@@ -249,7 +276,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 13.8
+    "popularity": 13.8,
+    "fp_last": 99.0
   },
   {
     "playerId": 213708,
@@ -258,7 +286,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 4.9
+    "popularity": 4.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214136,
@@ -267,7 +296,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 42.0
   },
   {
     "playerId": 214032,
@@ -276,7 +306,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 83.0
   },
   {
     "playerId": 213930,
@@ -285,7 +316,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 117.0
   },
   {
     "playerId": 214125,
@@ -294,7 +326,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213753,
@@ -303,7 +336,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 3.3
+    "popularity": 3.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213807,
@@ -312,7 +346,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.5,
-    "popularity": 7.3
+    "popularity": 7.3,
+    "fp_last": 97.0
   },
   {
     "playerId": 213806,
@@ -321,7 +356,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 11.1
+    "popularity": 11.1,
+    "fp_last": 84.0
   },
   {
     "playerId": 213637,
@@ -330,7 +366,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 56.0
   },
   {
     "playerId": 213640,
@@ -339,7 +376,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 2.1
+    "popularity": 2.2,
+    "fp_last": 43.0
   },
   {
     "playerId": 213939,
@@ -348,7 +386,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213956,
@@ -357,7 +396,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 11.5,
-    "popularity": 69.6
+    "popularity": 69.7,
+    "fp_last": 218.0
   },
   {
     "playerId": 213945,
@@ -366,7 +406,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 30.5
+    "popularity": 30.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213714,
@@ -375,7 +416,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 8.5
+    "popularity": 8.5,
+    "fp_last": 98.0
   },
   {
     "playerId": 214132,
@@ -384,7 +426,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 32.0
   },
   {
     "playerId": 213716,
@@ -393,7 +436,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 5.9
+    "popularity": 5.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213719,
@@ -402,7 +446,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 89.0
   },
   {
     "playerId": 214083,
@@ -411,7 +456,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 4.8
+    "popularity": 4.8,
+    "fp_last": 129.0
   },
   {
     "playerId": 213940,
@@ -420,7 +466,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 14.6
+    "popularity": 14.6,
+    "fp_last": 111.0
   },
   {
     "playerId": 213696,
@@ -429,7 +476,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 4.6
+    "popularity": 4.6,
+    "fp_last": 82.0
   },
   {
     "playerId": 213944,
@@ -438,7 +486,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 14.1
+    "popularity": 14.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213725,
@@ -447,7 +496,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 8.0,
-    "popularity": 12.2
+    "popularity": 12.2,
+    "fp_last": 103.0
   },
   {
     "playerId": 214033,
@@ -456,7 +506,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 5.0
   },
   {
     "playerId": 213657,
@@ -465,7 +516,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214071,
@@ -474,7 +526,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 86.0
   },
   {
     "playerId": 214063,
@@ -483,7 +536,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 8.2
+    "popularity": 8.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214069,
@@ -492,7 +546,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 78.0
   },
   {
     "playerId": 213837,
@@ -501,7 +556,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 90.0
   },
   {
     "playerId": 214008,
@@ -510,7 +566,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 73.0
   },
   {
     "playerId": 214079,
@@ -519,7 +576,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 92.0
   },
   {
     "playerId": 213663,
@@ -528,7 +586,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 31.0
   },
   {
     "playerId": 213723,
@@ -537,7 +596,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 8.0,
-    "popularity": 16.9
+    "popularity": 16.9,
+    "fp_last": 129.0
   },
   {
     "playerId": 214087,
@@ -546,7 +606,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213754,
@@ -555,7 +616,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 67.0
   },
   {
     "playerId": 213857,
@@ -564,7 +626,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213980,
@@ -573,7 +636,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213858,
@@ -582,7 +646,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213693,
@@ -591,7 +656,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 4.3
+    "popularity": 4.3,
+    "fp_last": 81.0
   },
   {
     "playerId": 214085,
@@ -600,7 +666,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.4
+    "popularity": 0.5,
+    "fp_last": 111.0
   },
   {
     "playerId": 214077,
@@ -609,7 +676,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214096,
@@ -618,7 +686,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213781,
@@ -627,7 +696,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213892,
@@ -636,7 +706,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213747,
@@ -645,7 +716,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 2.0
+    "popularity": 2.0,
+    "fp_last": 65.0
   },
   {
     "playerId": 213907,
@@ -654,7 +726,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 8.0,
-    "popularity": 7.9
+    "popularity": 8.0,
+    "fp_last": 190.0
   },
   {
     "playerId": 213904,
@@ -663,7 +736,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 109.0
   },
   {
     "playerId": 214124,
@@ -672,7 +746,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 89.0
   },
   {
     "playerId": 214108,
@@ -681,7 +756,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214110,
@@ -690,7 +766,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213926,
@@ -699,7 +776,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 61.0
   },
   {
     "playerId": 213756,
@@ -708,7 +786,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 15.9
+    "popularity": 16.0,
+    "fp_last": 89.0
   },
   {
     "playerId": 214101,
@@ -717,7 +796,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 4.0
+    "popularity": 4.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213720,
@@ -726,7 +806,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 50.0
   },
   {
     "playerId": 213721,
@@ -735,7 +816,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 2.9
+    "popularity": 2.9,
+    "fp_last": 50.0
   },
   {
     "playerId": 213768,
@@ -744,7 +826,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 57.0
   },
   {
     "playerId": 214129,
@@ -753,7 +836,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 87.0
   },
   {
     "playerId": 213948,
@@ -762,7 +846,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 80.0
   },
   {
     "playerId": 213802,
@@ -771,7 +856,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 105.0
   },
   {
     "playerId": 214001,
@@ -780,7 +866,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 2.4
+    "popularity": 2.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213880,
@@ -789,7 +876,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 48.0
   },
   {
     "playerId": 214010,
@@ -798,7 +886,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 7.5,
-    "popularity": 14.2
+    "popularity": 14.2,
+    "fp_last": 108.0
   },
   {
     "playerId": 213662,
@@ -807,7 +896,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.5
+    "popularity": 0.4,
+    "fp_last": 60.0
   },
   {
     "playerId": 213665,
@@ -816,7 +906,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 89.0
   },
   {
     "playerId": 213877,
@@ -825,7 +916,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 94.0
   },
   {
     "playerId": 214000,
@@ -834,7 +926,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213952,
@@ -843,7 +936,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 8.0,
-    "popularity": 13.7
+    "popularity": 13.7,
+    "fp_last": 78.0
   },
   {
     "playerId": 213950,
@@ -852,7 +946,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 8.0,
-    "popularity": 13.7
+    "popularity": 13.7,
+    "fp_last": 151.0
   },
   {
     "playerId": 213947,
@@ -861,7 +956,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 2.3
+    "popularity": 2.4,
+    "fp_last": 94.0
   },
   {
     "playerId": 213695,
@@ -870,7 +966,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214135,
@@ -879,7 +976,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213627,
@@ -888,7 +986,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213822,
@@ -897,7 +996,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 79.0
   },
   {
     "playerId": 213975,
@@ -906,7 +1006,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213641,
@@ -915,7 +1016,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 144.0
   },
   {
     "playerId": 214105,
@@ -924,7 +1026,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 2.6
+    "popularity": 2.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213745,
@@ -933,7 +1036,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 44.0
   },
   {
     "playerId": 213897,
@@ -942,7 +1046,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 93.0
   },
   {
     "playerId": 213901,
@@ -951,7 +1056,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 59.0
   },
   {
     "playerId": 213899,
@@ -960,7 +1066,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 118.0
   },
   {
     "playerId": 214103,
@@ -969,7 +1076,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214102,
@@ -978,7 +1086,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213906,
@@ -987,7 +1096,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 126.0
   },
   {
     "playerId": 213625,
@@ -996,7 +1106,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213622,
@@ -1005,7 +1116,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213896,
@@ -1014,7 +1126,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 105.0
   },
   {
     "playerId": 214097,
@@ -1023,7 +1136,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213823,
@@ -1032,7 +1146,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 2.0
+    "popularity": 2.0,
+    "fp_last": 57.0
   },
   {
     "playerId": 214099,
@@ -1041,7 +1156,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213969,
@@ -1050,7 +1166,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214031,
@@ -1059,7 +1176,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 79.0
   },
   {
     "playerId": 214024,
@@ -1068,7 +1186,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214058,
@@ -1077,7 +1196,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 14.3
+    "popularity": 14.3,
+    "fp_last": 102.0
   },
   {
     "playerId": 213886,
@@ -1086,7 +1206,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 113.0
   },
   {
     "playerId": 213691,
@@ -1095,7 +1216,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 4.0
+    "popularity": 4.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213856,
@@ -1104,7 +1226,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214122,
@@ -1113,7 +1236,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 3.4
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213927,
@@ -1122,7 +1246,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 82.0
   },
   {
     "playerId": 214141,
@@ -1131,7 +1256,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.5,
-    "popularity": 2.3
+    "popularity": 2.3,
+    "fp_last": 163.0
   },
   {
     "playerId": 213925,
@@ -1140,7 +1266,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 2.4
+    "popularity": 2.4,
+    "fp_last": 110.0
   },
   {
     "playerId": 213924,
@@ -1149,7 +1276,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 111.0
   },
   {
     "playerId": 213922,
@@ -1158,7 +1286,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 53.0
   },
   {
     "playerId": 213669,
@@ -1167,7 +1296,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 8.0,
-    "popularity": 5.9
+    "popularity": 5.9,
+    "fp_last": 134.0
   },
   {
     "playerId": 213737,
@@ -1176,7 +1306,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 13.6
+    "popularity": 13.6,
+    "fp_last": 70.0
   },
   {
     "playerId": 213955,
@@ -1185,7 +1316,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 10.0,
-    "popularity": 12.0
+    "popularity": 12.0,
+    "fp_last": 146.0
   },
   {
     "playerId": 213779,
@@ -1194,7 +1326,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 120.0
   },
   {
     "playerId": 213915,
@@ -1203,7 +1336,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 85.0
   },
   {
     "playerId": 213698,
@@ -1212,7 +1346,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 8.5,
-    "popularity": 10.7
+    "popularity": 10.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213836,
@@ -1221,7 +1356,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214054,
@@ -1230,7 +1366,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 1.6
+    "popularity": 1.7,
+    "fp_last": 70.0
   },
   {
     "playerId": 213733,
@@ -1239,7 +1376,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 2.4
+    "popularity": 2.4,
+    "fp_last": 22.0
   },
   {
     "playerId": 213961,
@@ -1248,7 +1386,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213827,
@@ -1257,7 +1396,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 25.0
   },
   {
     "playerId": 213774,
@@ -1266,7 +1406,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 93.0
   },
   {
     "playerId": 213782,
@@ -1275,7 +1416,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 7.5,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 116.0
   },
   {
     "playerId": 214042,
@@ -1284,7 +1426,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 1.0,
+    "fp_last": 23.0
   },
   {
     "playerId": 213879,
@@ -1293,7 +1436,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 105.0
   },
   {
     "playerId": 213867,
@@ -1302,7 +1446,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 93.0
   },
   {
     "playerId": 213799,
@@ -1311,7 +1456,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 24.0
   },
   {
     "playerId": 214036,
@@ -1320,7 +1466,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 52.0
   },
   {
     "playerId": 213777,
@@ -1329,7 +1476,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 107.0
   },
   {
     "playerId": 213770,
@@ -1338,7 +1486,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 4.1
+    "popularity": 4.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213778,
@@ -1347,7 +1496,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 73.0
   },
   {
     "playerId": 213872,
@@ -1356,7 +1506,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 30.0
   },
   {
     "playerId": 214053,
@@ -1365,7 +1516,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 21.9
+    "popularity": 21.9,
+    "fp_last": 114.0
   },
   {
     "playerId": 213654,
@@ -1374,7 +1526,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 7.7
+    "popularity": 7.7,
+    "fp_last": 89.0
   },
   {
     "playerId": 214056,
@@ -1383,7 +1536,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 89.0
   },
   {
     "playerId": 213766,
@@ -1392,7 +1546,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213666,
@@ -1401,7 +1556,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 4.0
+    "popularity": 4.0,
+    "fp_last": 134.0
   },
   {
     "playerId": 213664,
@@ -1410,7 +1566,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 12.6
+    "popularity": 12.5,
+    "fp_last": 93.0
   },
   {
     "playerId": 213661,
@@ -1419,7 +1576,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 9.8
+    "popularity": 9.8,
+    "fp_last": 125.0
   },
   {
     "playerId": 213658,
@@ -1428,7 +1586,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 68.0
   },
   {
     "playerId": 213962,
@@ -1437,7 +1596,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214131,
@@ -1446,7 +1606,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 106.0
   },
   {
     "playerId": 215666,
@@ -1455,7 +1616,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213997,
@@ -1464,7 +1626,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 30.0
   },
   {
     "playerId": 214003,
@@ -1473,7 +1636,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 2.5
+    "popularity": 2.5,
+    "fp_last": 132.0
   },
   {
     "playerId": 213639,
@@ -1482,7 +1646,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 83.0
   },
   {
     "playerId": 213998,
@@ -1491,7 +1656,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 2.5
+    "popularity": 2.5,
+    "fp_last": 90.0
   },
   {
     "playerId": 213634,
@@ -1500,7 +1666,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214061,
@@ -1509,7 +1676,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 3.8
+    "popularity": 3.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214139,
@@ -1518,7 +1686,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 67.0
   },
   {
     "playerId": 213690,
@@ -1527,7 +1696,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 23.7
+    "popularity": 23.7,
+    "fp_last": 143.0
   },
   {
     "playerId": 213630,
@@ -1536,7 +1706,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 7.8
+    "popularity": 7.8,
+    "fp_last": 91.0
   },
   {
     "playerId": 214111,
@@ -1545,7 +1716,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214095,
@@ -1554,7 +1726,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 16.0
+    "popularity": 16.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214100,
@@ -1563,7 +1736,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213757,
@@ -1572,7 +1746,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 5.5
+    "popularity": 5.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213905,
@@ -1581,7 +1756,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 116.0
   },
   {
     "playerId": 213743,
@@ -1590,7 +1766,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 3.6
+    "popularity": 3.6,
+    "fp_last": 59.0
   },
   {
     "playerId": 213740,
@@ -1599,7 +1776,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 3.1
+    "popularity": 3.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213994,
@@ -1608,7 +1786,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 36.0
   },
   {
     "playerId": 214019,
@@ -1617,7 +1796,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 79.0
   },
   {
     "playerId": 213995,
@@ -1626,7 +1806,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 65.0
   },
   {
     "playerId": 213921,
@@ -1635,7 +1816,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 109.0
   },
   {
     "playerId": 214050,
@@ -1644,7 +1826,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 40.0
   },
   {
     "playerId": 213859,
@@ -1653,7 +1836,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214021,
@@ -1662,7 +1846,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 78.0
   },
   {
     "playerId": 214020,
@@ -1671,7 +1856,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 25.0
   },
   {
     "playerId": 213978,
@@ -1680,7 +1866,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214051,
@@ -1689,7 +1876,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 3.3
+    "popularity": 3.3,
+    "fp_last": 86.0
   },
   {
     "playerId": 214057,
@@ -1698,7 +1886,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.9
+    "popularity": 0.8,
+    "fp_last": 71.0
   },
   {
     "playerId": 213850,
@@ -1707,7 +1896,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213866,
@@ -1716,7 +1906,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 25.0
   },
   {
     "playerId": 213852,
@@ -1725,7 +1916,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214052,
@@ -1734,7 +1926,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 9.6
+    "popularity": 9.5,
+    "fp_last": 78.0
   },
   {
     "playerId": 213860,
@@ -1743,7 +1936,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213861,
@@ -1752,7 +1946,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213990,
@@ -1761,7 +1956,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 37.0
   },
   {
     "playerId": 214026,
@@ -1770,7 +1966,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214047,
@@ -1779,7 +1976,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 6.7
+    "popularity": 6.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213936,
@@ -1788,7 +1986,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 34.0
   },
   {
     "playerId": 213979,
@@ -1797,7 +1996,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213977,
@@ -1806,7 +2006,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213972,
@@ -1815,7 +2016,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213970,
@@ -1824,7 +2026,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213968,
@@ -1833,7 +2036,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.6
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213967,
@@ -1842,7 +2046,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214005,
@@ -1851,7 +2056,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 4.0
+    "popularity": 3.9,
+    "fp_last": 129.0
   },
   {
     "playerId": 213964,
@@ -1860,7 +2066,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214007,
@@ -1869,7 +2076,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 42.0
   },
   {
     "playerId": 214012,
@@ -1878,7 +2086,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 10.0
   },
   {
     "playerId": 213951,
@@ -1887,7 +2096,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 8.0,
-    "popularity": 3.1
+    "popularity": 3.0,
+    "fp_last": 6.0
   },
   {
     "playerId": 213942,
@@ -1896,7 +2106,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 41.0
   },
   {
     "playerId": 214022,
@@ -1905,7 +2116,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.1
+    "popularity": 1.0,
+    "fp_last": 97.0
   },
   {
     "playerId": 213874,
@@ -1914,7 +2126,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 69.0
   },
   {
     "playerId": 214023,
@@ -1923,7 +2136,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213919,
@@ -1932,7 +2146,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 61.0
   },
   {
     "playerId": 213918,
@@ -1941,7 +2156,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 49.0
   },
   {
     "playerId": 213917,
@@ -1950,7 +2166,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 28.0
   },
   {
     "playerId": 213916,
@@ -1959,7 +2176,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 22.0
   },
   {
     "playerId": 213848,
@@ -1968,7 +2186,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213910,
@@ -1977,7 +2196,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 6.0
   },
   {
     "playerId": 213903,
@@ -1986,7 +2206,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 52.0
   },
   {
     "playerId": 213902,
@@ -1995,7 +2216,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213900,
@@ -2004,7 +2226,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 34.0
   },
   {
     "playerId": 214035,
@@ -2013,7 +2236,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 72.0
   },
   {
     "playerId": 213883,
@@ -2022,7 +2246,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.6
+    "popularity": 0.5,
+    "fp_last": 106.0
   },
   {
     "playerId": 213881,
@@ -2031,7 +2256,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 48.0
   },
   {
     "playerId": 213849,
@@ -2040,7 +2266,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213805,
@@ -2049,7 +2276,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 1.6
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214059,
@@ -2058,7 +2286,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 4.2
+    "popularity": 4.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213718,
@@ -2067,7 +2296,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 17.4
+    "popularity": 17.3,
+    "fp_last": 102.0
   },
   {
     "playerId": 214134,
@@ -2076,7 +2306,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 89.0
   },
   {
     "playerId": 213687,
@@ -2085,7 +2316,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 5.4
+    "popularity": 5.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213688,
@@ -2094,7 +2326,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 70.0
   },
   {
     "playerId": 213692,
@@ -2103,7 +2336,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 93.0
   },
   {
     "playerId": 213697,
@@ -2112,7 +2346,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 8.0,
-    "popularity": 7.5
+    "popularity": 7.6,
+    "fp_last": 144.0
   },
   {
     "playerId": 213699,
@@ -2121,7 +2356,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 8.5,
-    "popularity": 4.9
+    "popularity": 4.8,
+    "fp_last": 131.0
   },
   {
     "playerId": 214123,
@@ -2130,7 +2366,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 35.0
   },
   {
     "playerId": 213722,
@@ -2139,7 +2376,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.5,
-    "popularity": 2.8
+    "popularity": 2.7,
+    "fp_last": 84.0
   },
   {
     "playerId": 214138,
@@ -2148,7 +2386,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213846,
@@ -2157,7 +2396,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213726,
@@ -2166,7 +2406,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 9.0,
-    "popularity": 2.3
+    "popularity": 2.3,
+    "fp_last": 106.0
   },
   {
     "playerId": 214109,
@@ -2175,7 +2416,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213750,
@@ -2184,7 +2426,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 24.0
   },
   {
     "playerId": 213751,
@@ -2193,7 +2436,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 42.0
   },
   {
     "playerId": 213752,
@@ -2202,7 +2446,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 3.0
+    "popularity": 3.0,
+    "fp_last": 115.0
   },
   {
     "playerId": 213769,
@@ -2211,7 +2456,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 29.0
   },
   {
     "playerId": 213771,
@@ -2220,7 +2466,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 5.9
+    "popularity": 5.9,
+    "fp_last": 62.0
   },
   {
     "playerId": 214137,
@@ -2229,7 +2476,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214140,
@@ -2238,7 +2486,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213776,
@@ -2247,7 +2496,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 78.0
   },
   {
     "playerId": 213647,
@@ -2256,7 +2506,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213624,
@@ -2265,7 +2516,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216529,
@@ -2274,7 +2526,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213629,
@@ -2283,7 +2536,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 12.0
   },
   {
     "playerId": 216527,
@@ -2292,7 +2546,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 2.0
   },
   {
     "playerId": 213633,
@@ -2301,7 +2556,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 71.0
   },
   {
     "playerId": 213635,
@@ -2310,7 +2566,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216525,
@@ -2319,7 +2576,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216524,
@@ -2328,7 +2586,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213649,
@@ -2337,7 +2596,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 65.0
   },
   {
     "playerId": 215655,
@@ -2346,7 +2606,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 215667,
@@ -2355,7 +2616,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215665,
@@ -2364,7 +2626,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213653,
@@ -2373,7 +2636,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 2.4
+    "popularity": 2.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213655,
@@ -2382,7 +2646,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.3,
+    "fp_last": 36.0
   },
   {
     "playerId": 215663,
@@ -2391,7 +2656,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 215662,
@@ -2400,7 +2666,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213667,
@@ -2409,7 +2676,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 2.4
+    "popularity": 2.4,
+    "fp_last": 87.0
   },
   {
     "playerId": 215661,
@@ -2418,7 +2686,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214091,
@@ -2427,7 +2696,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213724,
@@ -2436,7 +2706,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 8.0,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213991,
@@ -2445,7 +2716,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213841,
@@ -2454,7 +2726,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213804,
@@ -2463,7 +2736,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 89.0
   },
   {
     "playerId": 213803,
@@ -2472,7 +2746,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213831,
@@ -2481,7 +2756,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 45.0
   },
   {
     "playerId": 213832,
@@ -2490,7 +2766,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 2.0
+    "popularity": 2.0,
+    "fp_last": 63.0
   },
   {
     "playerId": 213825,
@@ -2499,7 +2776,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 39.0
   },
   {
     "playerId": 214080,
@@ -2508,7 +2786,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213833,
@@ -2517,7 +2796,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213820,
@@ -2526,7 +2806,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 5.3
+    "popularity": 5.2,
+    "fp_last": 82.0
   },
   {
     "playerId": 213838,
@@ -2535,7 +2816,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 7.4
+    "popularity": 7.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213801,
@@ -2544,7 +2826,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 11.7
+    "popularity": 11.5,
+    "fp_last": 43.0
   },
   {
     "playerId": 213842,
@@ -2553,7 +2836,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213810,
@@ -2562,7 +2846,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 2.3
+    "popularity": 2.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213817,
@@ -2571,7 +2856,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213790,
@@ -2580,7 +2866,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 24.0
   },
   {
     "playerId": 213845,
@@ -2589,7 +2876,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 215664,
@@ -2598,7 +2886,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214068,
@@ -2607,7 +2896,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 92.0
   },
   {
     "playerId": 215656,
@@ -2616,7 +2906,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214014,
@@ -2625,7 +2916,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 18.0
   },
   {
     "playerId": 214055,
@@ -2634,7 +2926,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 74.0
   },
   {
     "playerId": 215658,
@@ -2643,7 +2936,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215657,
@@ -2652,7 +2946,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 215660,
@@ -2661,7 +2956,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214070,
@@ -2670,7 +2966,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 54.0
   },
   {
     "playerId": 214011,
@@ -2679,7 +2976,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 215659,
@@ -2688,7 +2986,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 31.0
   },
   {
     "playerId": 214072,
@@ -2697,7 +2996,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 17.0
   },
   {
     "playerId": 214067,
@@ -2706,7 +3006,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214013,
@@ -2715,7 +3016,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 12.0
   },
   {
     "playerId": 214037,
@@ -2724,7 +3026,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 34.0
   },
   {
     "playerId": 215668,
@@ -2733,7 +3036,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214066,
@@ -2742,7 +3046,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214060,
@@ -2751,7 +3056,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 0.8
+    "popularity": 0.7,
+    "fp_last": 83.0
   },
   {
     "playerId": 213992,
@@ -2760,7 +3066,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 2.3
+    "popularity": 2.3,
+    "fp_last": 8.0
   },
   {
     "playerId": 213993,
@@ -2769,7 +3076,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216532,
@@ -2778,7 +3086,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216531,
@@ -2787,7 +3096,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213996,
@@ -2796,7 +3106,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 35.0
   },
   {
     "playerId": 216530,
@@ -2805,7 +3116,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213999,
@@ -2814,7 +3126,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216528,
@@ -2823,7 +3136,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214006,
@@ -2832,7 +3146,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.5
+    "popularity": 0.4,
+    "fp_last": 70.0
   },
   {
     "playerId": 214064,
@@ -2841,7 +3156,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 216526,
@@ -2850,7 +3166,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214002,
@@ -2859,7 +3176,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 42.0
   },
   {
     "playerId": 214065,
@@ -2868,7 +3186,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214004,
@@ -2877,7 +3196,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216523,
@@ -2886,7 +3206,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216522,
@@ -2895,7 +3216,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214073,
@@ -2904,7 +3226,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 5.0
   },
   {
     "playerId": 214015,
@@ -2913,7 +3236,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 20.0
   },
   {
     "playerId": 214048,
@@ -2922,7 +3246,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 29.0
   },
   {
     "playerId": 214074,
@@ -2931,7 +3256,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214098,
@@ -2940,7 +3266,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 9.3
+    "popularity": 9.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214112,
@@ -2949,7 +3276,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214028,
@@ -2958,7 +3286,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214029,
@@ -2967,7 +3296,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 13.0
   },
   {
     "playerId": 214043,
@@ -2976,7 +3306,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214030,
@@ -2985,7 +3316,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 45.0
   },
   {
     "playerId": 214107,
@@ -2994,7 +3326,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214104,
@@ -3003,7 +3336,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214081,
@@ -3012,7 +3346,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 33.0
   },
   {
     "playerId": 214041,
@@ -3021,7 +3356,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 31.0
   },
   {
     "playerId": 214094,
@@ -3030,7 +3366,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214114,
@@ -3039,7 +3376,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214093,
@@ -3048,7 +3386,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214082,
@@ -3057,7 +3396,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214040,
@@ -3066,7 +3406,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214092,
@@ -3075,7 +3416,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 2.0
+    "popularity": 2.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214039,
@@ -3084,7 +3426,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 6.6
+    "popularity": 6.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214090,
@@ -3093,7 +3436,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214034,
@@ -3102,7 +3446,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.3
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214089,
@@ -3111,7 +3456,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 12.5
+    "popularity": 12.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214088,
@@ -3120,7 +3466,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 58.0
   },
   {
     "playerId": 214113,
@@ -3129,7 +3476,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214115,
@@ -3138,7 +3486,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214016,
@@ -3147,7 +3496,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.9
+    "popularity": 0.8,
+    "fp_last": 79.0
   },
   {
     "playerId": 214045,
@@ -3156,7 +3506,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.1
+    "popularity": 1.0,
+    "fp_last": 59.0
   },
   {
     "playerId": 214049,
@@ -3165,7 +3516,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 8.0
   },
   {
     "playerId": 214017,
@@ -3174,7 +3526,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 16.0
   },
   {
     "playerId": 214084,
@@ -3183,7 +3536,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214133,
@@ -3192,7 +3546,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 35.0
   },
   {
     "playerId": 214075,
@@ -3201,7 +3556,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 32.0
   },
   {
     "playerId": 214018,
@@ -3210,7 +3566,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 83.0
   },
   {
     "playerId": 214078,
@@ -3219,7 +3576,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214130,
@@ -3228,7 +3586,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214046,
@@ -3237,7 +3596,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 66.0
   },
   {
     "playerId": 214128,
@@ -3246,7 +3606,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214116,
@@ -3255,7 +3616,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214127,
@@ -3264,7 +3626,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214126,
@@ -3273,7 +3636,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214121,
@@ -3282,7 +3646,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 3.1
+    "popularity": 3.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214120,
@@ -3291,7 +3656,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 2.5
+    "popularity": 2.5,
+    "fp_last": 6.0
   },
   {
     "playerId": 214119,
@@ -3300,7 +3666,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214118,
@@ -3309,7 +3676,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214117,
@@ -3318,7 +3686,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214044,
@@ -3327,7 +3696,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 13.0
   },
   {
     "playerId": 214025,
@@ -3336,7 +3706,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213619,
@@ -3345,7 +3716,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 7.8
+    "popularity": 7.8,
+    "fp_last": 2.0
   },
   {
     "playerId": 213893,
@@ -3354,7 +3726,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 59.0
   },
   {
     "playerId": 213989,
@@ -3363,7 +3736,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 52.0
   },
   {
     "playerId": 213732,
@@ -3372,7 +3746,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213744,
@@ -3381,7 +3756,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213742,
@@ -3390,7 +3766,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 85.0
   },
   {
     "playerId": 213741,
@@ -3399,7 +3776,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213739,
@@ -3408,7 +3786,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213738,
@@ -3417,7 +3796,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.6
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213736,
@@ -3426,7 +3806,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213735,
@@ -3435,7 +3816,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 53.0
   },
   {
     "playerId": 213734,
@@ -3444,7 +3826,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 15.0
   },
   {
     "playerId": 213731,
@@ -3453,7 +3836,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 8.0
   },
   {
     "playerId": 213749,
@@ -3462,7 +3846,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 4.7
+    "popularity": 4.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213730,
@@ -3471,7 +3856,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 18.1
+    "popularity": 18.1,
+    "fp_last": 52.0
   },
   {
     "playerId": 213727,
@@ -3480,7 +3866,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 10.0,
-    "popularity": 5.7
+    "popularity": 5.5,
+    "fp_last": 192.0
   },
   {
     "playerId": 213717,
@@ -3489,7 +3876,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 66.0
   },
   {
     "playerId": 213715,
@@ -3498,7 +3886,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213713,
@@ -3507,7 +3896,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 62.0
   },
   {
     "playerId": 213712,
@@ -3516,7 +3906,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 21.0
   },
   {
     "playerId": 213711,
@@ -3525,7 +3916,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 89.0
   },
   {
     "playerId": 213710,
@@ -3534,7 +3926,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 48.0
   },
   {
     "playerId": 213746,
@@ -3543,7 +3936,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 43.0
   },
   {
     "playerId": 213755,
@@ -3552,7 +3946,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 76.0
   },
   {
     "playerId": 213706,
@@ -3561,7 +3956,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 8.0
   },
   {
     "playerId": 213773,
@@ -3570,7 +3966,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 1.0
   },
   {
     "playerId": 213791,
@@ -3579,7 +3976,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.1
+    "popularity": 1.0,
+    "fp_last": 33.0
   },
   {
     "playerId": 213789,
@@ -3588,7 +3986,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 28.0
   },
   {
     "playerId": 213787,
@@ -3597,7 +3996,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213786,
@@ -3606,7 +4006,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213785,
@@ -3615,7 +4016,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213784,
@@ -3624,7 +4026,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213783,
@@ -3633,7 +4036,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213775,
@@ -3642,7 +4046,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213772,
@@ -3651,7 +4056,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 19.0
   },
   {
     "playerId": 213758,
@@ -3660,7 +4066,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 8.0,
-    "popularity": 4.4
+    "popularity": 4.3,
+    "fp_last": 115.0
   },
   {
     "playerId": 213767,
@@ -3669,7 +4076,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 25.0
   },
   {
     "playerId": 213765,
@@ -3678,7 +4086,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 11.0
   },
   {
     "playerId": 213764,
@@ -3687,7 +4096,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 30.0
   },
   {
     "playerId": 213763,
@@ -3696,7 +4106,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 14.0
   },
   {
     "playerId": 213762,
@@ -3705,7 +4116,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213761,
@@ -3714,7 +4126,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213760,
@@ -3723,7 +4136,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213759,
@@ -3732,7 +4146,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213707,
@@ -3741,7 +4156,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213705,
@@ -3750,7 +4166,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 2.0
   },
   {
     "playerId": 213797,
@@ -3759,7 +4176,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 22.0
   },
   {
     "playerId": 213645,
@@ -3768,7 +4186,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213660,
@@ -3777,7 +4196,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 59.0
   },
   {
     "playerId": 213659,
@@ -3786,7 +4206,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 60.0
   },
   {
     "playerId": 213656,
@@ -3795,7 +4216,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213652,
@@ -3804,7 +4226,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 5.0
   },
   {
     "playerId": 213651,
@@ -3813,7 +4236,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 8.0
   },
   {
     "playerId": 213650,
@@ -3822,7 +4246,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 82.0
   },
   {
     "playerId": 213648,
@@ -3831,7 +4256,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 42.0
   },
   {
     "playerId": 213646,
@@ -3840,7 +4266,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.3,
+    "fp_last": 11.0
   },
   {
     "playerId": 213644,
@@ -3849,7 +4276,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 2.0
+    "popularity": 2.0,
+    "fp_last": 1.0
   },
   {
     "playerId": 213671,
@@ -3858,7 +4286,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213643,
@@ -3867,7 +4296,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213642,
@@ -3876,7 +4306,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 32.0
   },
   {
     "playerId": 213632,
@@ -3885,7 +4316,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 23.0
   },
   {
     "playerId": 213631,
@@ -3894,7 +4326,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213628,
@@ -3903,7 +4336,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 5.0
   },
   {
     "playerId": 213626,
@@ -3912,7 +4346,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.7,
+    "fp_last": 38.0
   },
   {
     "playerId": 213623,
@@ -3921,7 +4356,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213621,
@@ -3930,7 +4366,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213668,
@@ -3939,7 +4376,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 8.0,
-    "popularity": 2.8
+    "popularity": 2.7,
+    "fp_last": 130.0
   },
   {
     "playerId": 213672,
@@ -3948,7 +4386,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213704,
@@ -3957,7 +4396,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213683,
@@ -3966,7 +4406,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 82.0
   },
   {
     "playerId": 213703,
@@ -3975,7 +4416,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213702,
@@ -3984,7 +4426,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213701,
@@ -3993,7 +4436,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213694,
@@ -4002,7 +4446,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213689,
@@ -4011,7 +4456,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 14.8
+    "popularity": 14.8,
+    "fp_last": 112.0
   },
   {
     "playerId": 213686,
@@ -4020,7 +4466,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 1.3
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213685,
@@ -4029,7 +4476,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213684,
@@ -4038,7 +4486,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 6.0
   },
   {
     "playerId": 213682,
@@ -4047,7 +4496,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 16.8
+    "popularity": 16.9,
+    "fp_last": 91.0
   },
   {
     "playerId": 213673,
@@ -4056,7 +4506,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213681,
@@ -4065,7 +4516,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 92.0
   },
   {
     "playerId": 213680,
@@ -4074,7 +4526,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 76.0
   },
   {
     "playerId": 213679,
@@ -4083,7 +4536,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213678,
@@ -4092,7 +4546,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213677,
@@ -4101,7 +4556,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213676,
@@ -4110,7 +4566,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213675,
@@ -4119,7 +4576,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213674,
@@ -4128,7 +4586,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213793,
@@ -4137,7 +4596,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.8
+    "popularity": 0.7,
+    "fp_last": 85.0
   },
   {
     "playerId": 213808,
@@ -4146,7 +4606,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 8.5,
-    "popularity": 4.0
+    "popularity": 3.8,
+    "fp_last": 164.0
   },
   {
     "playerId": 213988,
@@ -4155,7 +4616,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213920,
@@ -4164,7 +4626,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 29.0
   },
   {
     "playerId": 213941,
@@ -4173,7 +4636,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 3.3
+    "popularity": 3.2,
+    "fp_last": 90.0
   },
   {
     "playerId": 213937,
@@ -4182,7 +4646,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 32.0
   },
   {
     "playerId": 213935,
@@ -4191,7 +4656,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 79.0
   },
   {
     "playerId": 213934,
@@ -4200,7 +4666,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213933,
@@ -4209,7 +4676,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 40.0
   },
   {
     "playerId": 213932,
@@ -4218,7 +4686,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 11.0
   },
   {
     "playerId": 213931,
@@ -4227,7 +4696,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 1.0
   },
   {
     "playerId": 213923,
@@ -4236,7 +4706,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 51.0
   },
   {
     "playerId": 213914,
@@ -4245,7 +4716,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 72.0
   },
   {
     "playerId": 213946,
@@ -4254,7 +4726,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 52.0
   },
   {
     "playerId": 213913,
@@ -4263,7 +4736,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213912,
@@ -4272,7 +4746,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213911,
@@ -4281,7 +4756,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 46.0
   },
   {
     "playerId": 213909,
@@ -4290,7 +4766,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 22.0
   },
   {
     "playerId": 213908,
@@ -4299,7 +4776,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213898,
@@ -4308,7 +4786,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 28.0
   },
   {
     "playerId": 213895,
@@ -4317,7 +4796,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 15.0
   },
   {
     "playerId": 213894,
@@ -4326,7 +4806,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 45.0
   },
   {
     "playerId": 213943,
@@ -4335,7 +4816,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 92.0
   },
   {
     "playerId": 213949,
@@ -4344,7 +4826,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 7.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 29.0
   },
   {
     "playerId": 213809,
@@ -4353,7 +4836,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213973,
@@ -4362,7 +4846,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213987,
@@ -4371,7 +4856,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213986,
@@ -4380,7 +4866,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 17.0
   },
   {
     "playerId": 213985,
@@ -4389,7 +4876,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 18.0
   },
   {
     "playerId": 213984,
@@ -4398,7 +4886,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 11.0
   },
   {
     "playerId": 213983,
@@ -4407,7 +4896,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213982,
@@ -4416,7 +4906,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213981,
@@ -4425,7 +4916,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 2.5
+    "popularity": 2.5,
+    "fp_last": 1.0
   },
   {
     "playerId": 213976,
@@ -4434,7 +4926,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213971,
@@ -4443,7 +4936,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213953,
@@ -4452,7 +4946,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 8.5,
-    "popularity": 1.5
+    "popularity": 1.4,
+    "fp_last": 114.0
   },
   {
     "playerId": 213966,
@@ -4461,7 +4956,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213965,
@@ -4470,7 +4966,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213963,
@@ -4479,7 +4976,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213960,
@@ -4488,7 +4986,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213959,
@@ -4497,7 +4996,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 5.7
+    "popularity": 5.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213958,
@@ -4506,7 +5006,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213957,
@@ -4515,7 +5016,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213954,
@@ -4524,7 +5026,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 9.5,
-    "popularity": 4.4
+    "popularity": 4.3,
+    "fp_last": 145.0
   },
   {
     "playerId": 213620,
@@ -4533,7 +5036,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 10.5
+    "popularity": 10.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213891,
@@ -4542,7 +5046,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 78.0
   },
   {
     "playerId": 213890,
@@ -4551,7 +5056,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213828,
@@ -4560,7 +5066,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.8
+    "popularity": 0.7,
+    "fp_last": 51.0
   },
   {
     "playerId": 213843,
@@ -4569,7 +5076,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213840,
@@ -4578,7 +5086,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213839,
@@ -4587,7 +5096,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213835,
@@ -4596,7 +5106,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 2.5
+    "popularity": 2.4,
+    "fp_last": 84.0
   },
   {
     "playerId": 213834,
@@ -4605,7 +5116,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 71.0
   },
   {
     "playerId": 213830,
@@ -4614,7 +5126,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 84.0
   },
   {
     "playerId": 213829,
@@ -4623,7 +5136,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 61.0
   },
   {
     "playerId": 213824,
@@ -4632,7 +5146,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 81.0
   },
   {
     "playerId": 213889,
@@ -4641,7 +5156,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 7.0
   },
   {
     "playerId": 213819,
@@ -4650,7 +5166,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 32.0
   },
   {
     "playerId": 213818,
@@ -4659,7 +5176,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213816,
@@ -4668,7 +5186,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213815,
@@ -4677,7 +5196,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 2.4
+    "popularity": 2.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213814,
@@ -4686,7 +5206,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213813,
@@ -4695,7 +5216,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 5.2
+    "popularity": 5.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213812,
@@ -4704,7 +5226,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 2.3
+    "popularity": 2.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213811,
@@ -4713,7 +5236,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213844,
@@ -4722,7 +5246,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213847,
@@ -4731,7 +5256,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213853,
@@ -4740,7 +5266,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 2.3
+    "popularity": 2.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213854,
@@ -4749,7 +5276,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213888,
@@ -4758,7 +5286,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213885,
@@ -4767,7 +5296,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213884,
@@ -4776,7 +5306,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 85.0
   },
   {
     "playerId": 213882,
@@ -4785,7 +5316,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 86.0
   },
   {
     "playerId": 213878,
@@ -4794,7 +5326,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 34.0
   },
   {
     "playerId": 213875,
@@ -4803,7 +5336,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 1.1
+    "popularity": 1.0,
+    "fp_last": 77.0
   },
   {
     "playerId": 213873,
@@ -4812,7 +5346,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 97.0
   },
   {
     "playerId": 213870,
@@ -4821,7 +5356,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 1.0
   },
   {
     "playerId": 213869,
@@ -4830,7 +5366,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 2.0
   },
   {
     "playerId": 213868,
@@ -4839,7 +5376,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 2.0
+    "popularity": 2.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213865,
@@ -4848,7 +5386,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213864,
@@ -4857,7 +5396,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213863,
@@ -4866,7 +5406,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 4.5
+    "popularity": 4.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213862,
@@ -4875,7 +5416,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213855,
@@ -4884,7 +5426,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216533,
@@ -4893,7 +5436,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213871,
@@ -4902,7 +5446,8 @@
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 24.0
   },
   {
     "playerId": 213974,
@@ -4911,7 +5456,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213876,
@@ -4920,7 +5466,8 @@
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 40.0
   },
   {
     "playerId": 213887,
@@ -4929,7 +5476,8 @@
     "position": "FWD",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 88.0
   },
   {
     "playerId": 213821,
@@ -4938,7 +5486,8 @@
     "position": "GK",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 5.0
+    "popularity": 4.9,
+    "fp_last": 119.0
   },
   {
     "playerId": 214535,
@@ -4947,7 +5496,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 8.0,
-    "popularity": 7.9
+    "popularity": 8.2,
+    "fp_last": 175.0
   },
   {
     "playerId": 214915,
@@ -4956,7 +5506,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 6.5
+    "popularity": 6.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214416,
@@ -4965,7 +5516,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 7.1
+    "popularity": 7.3,
+    "fp_last": 38.0
   },
   {
     "playerId": 214795,
@@ -4974,7 +5526,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 20.2
+    "popularity": 20.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214735,
@@ -4983,7 +5536,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 12.5,
-    "popularity": 27.7
+    "popularity": 27.7,
+    "fp_last": 318.0
   },
   {
     "playerId": 214974,
@@ -4992,7 +5546,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 13.1
+    "popularity": 13.3,
+    "fp_last": 36.0
   },
   {
     "playerId": 214865,
@@ -5001,7 +5556,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 8.0,
-    "popularity": 10.3
+    "popularity": 10.4,
+    "fp_last": 173.0
   },
   {
     "playerId": 214977,
@@ -5010,7 +5566,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 15.9
+    "popularity": 16.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214802,
@@ -5019,7 +5576,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 12.0,
-    "popularity": 36.5
+    "popularity": 36.6,
+    "fp_last": 180.0
   },
   {
     "playerId": 214732,
@@ -5028,7 +5586,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 8.5,
-    "popularity": 8.8
+    "popularity": 8.9,
+    "fp_last": 127.0
   },
   {
     "playerId": 214733,
@@ -5037,7 +5596,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 8.5,
-    "popularity": 28.9
+    "popularity": 29.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214782,
@@ -5046,7 +5606,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 3.0
+    "popularity": 3.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214785,
@@ -5055,7 +5616,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 3.0
   },
   {
     "playerId": 214861,
@@ -5064,7 +5626,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 2.3
+    "popularity": 2.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214862,
@@ -5073,7 +5636,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 1.6
+    "popularity": 1.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214968,
@@ -5082,7 +5646,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 8.5
+    "popularity": 8.6,
+    "fp_last": 73.0
   },
   {
     "playerId": 214976,
@@ -5091,7 +5656,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 2.6
+    "popularity": 2.6,
+    "fp_last": 133.0
   },
   {
     "playerId": 214748,
@@ -5100,7 +5666,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214560,
@@ -5109,7 +5676,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 2.3
+    "popularity": 2.4,
+    "fp_last": 49.0
   },
   {
     "playerId": 214760,
@@ -5118,7 +5686,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.1
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 215024,
@@ -5127,7 +5696,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 2.3
+    "popularity": 2.3,
+    "fp_last": 82.0
   },
   {
     "playerId": 214922,
@@ -5136,7 +5706,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 4.1
+    "popularity": 4.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 215030,
@@ -5145,7 +5716,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 18.0
+    "popularity": 18.0,
+    "fp_last": 116.0
   },
   {
     "playerId": 215029,
@@ -5154,7 +5726,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 7.3
+    "popularity": 7.4,
+    "fp_last": 115.0
   },
   {
     "playerId": 214888,
@@ -5163,7 +5736,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 108.0
   },
   {
     "playerId": 214886,
@@ -5172,7 +5746,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 3.8
+    "popularity": 3.8,
+    "fp_last": 64.0
   },
   {
     "playerId": 214885,
@@ -5181,7 +5756,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 4.0
+    "popularity": 4.0,
+    "fp_last": 100.0
   },
   {
     "playerId": 214456,
@@ -5190,7 +5766,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 3.1
+    "popularity": 3.1,
+    "fp_last": 79.0
   },
   {
     "playerId": 214599,
@@ -5199,7 +5776,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 9.0
   },
   {
     "playerId": 214791,
@@ -5208,7 +5786,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 6.6
+    "popularity": 6.6,
+    "fp_last": 85.0
   },
   {
     "playerId": 214925,
@@ -5217,7 +5796,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 215026,
@@ -5226,7 +5806,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 6.6
+    "popularity": 6.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214744,
@@ -5235,7 +5816,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214964,
@@ -5244,7 +5826,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 13.5
+    "popularity": 13.5,
+    "fp_last": 30.0
   },
   {
     "playerId": 214883,
@@ -5253,7 +5836,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 2.0
+    "popularity": 2.0,
+    "fp_last": 110.0
   },
   {
     "playerId": 214965,
@@ -5262,7 +5846,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 10.7
+    "popularity": 10.6,
+    "fp_last": 64.0
   },
   {
     "playerId": 214967,
@@ -5271,7 +5856,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 6.1
+    "popularity": 6.0,
+    "fp_last": 43.0
   },
   {
     "playerId": 214973,
@@ -5280,7 +5866,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 15.1
+    "popularity": 15.1,
+    "fp_last": 92.0
   },
   {
     "playerId": 214777,
@@ -5289,7 +5876,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 2.3
+    "popularity": 2.3,
+    "fp_last": 27.0
   },
   {
     "playerId": 214684,
@@ -5298,7 +5886,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 120.0
   },
   {
     "playerId": 214784,
@@ -5307,7 +5896,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 11.4
+    "popularity": 11.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214778,
@@ -5316,7 +5906,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 4.4
+    "popularity": 4.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214999,
@@ -5325,7 +5916,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 72.0
   },
   {
     "playerId": 214906,
@@ -5334,7 +5926,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 11.4
+    "popularity": 11.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214889,
@@ -5343,7 +5936,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 2.9
+    "popularity": 2.9,
+    "fp_last": 99.0
   },
   {
     "playerId": 214421,
@@ -5352,7 +5946,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 13.5
+    "popularity": 13.6,
+    "fp_last": 132.0
   },
   {
     "playerId": 214424,
@@ -5361,7 +5956,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 50.0
   },
   {
     "playerId": 215006,
@@ -5370,7 +5966,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 3.9
+    "popularity": 4.1,
+    "fp_last": 4.0
   },
   {
     "playerId": 214430,
@@ -5379,7 +5976,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 10.7
+    "popularity": 10.8,
+    "fp_last": 133.0
   },
   {
     "playerId": 214422,
@@ -5388,7 +5986,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 16.4
+    "popularity": 16.5,
+    "fp_last": 117.0
   },
   {
     "playerId": 214753,
@@ -5397,7 +5996,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214443,
@@ -5406,7 +6006,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 4.0
+    "popularity": 4.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214692,
@@ -5415,7 +6016,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 7.4
+    "popularity": 7.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214752,
@@ -5424,7 +6026,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214683,
@@ -5433,7 +6036,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 102.0
   },
   {
     "playerId": 214751,
@@ -5442,7 +6046,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 3.7
+    "popularity": 3.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214447,
@@ -5451,7 +6056,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 39.0
   },
   {
     "playerId": 214723,
@@ -5460,7 +6066,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 5.7
+    "popularity": 5.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214936,
@@ -5469,7 +6076,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.0
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214935,
@@ -5478,7 +6086,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214725,
@@ -5487,7 +6096,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 7.0
   },
   {
     "playerId": 214961,
@@ -5496,7 +6106,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 3.0
+    "popularity": 3.0,
+    "fp_last": 47.0
   },
   {
     "playerId": 214726,
@@ -5505,7 +6116,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 32.7
+    "popularity": 32.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214681,
@@ -5514,7 +6126,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 8.2
+    "popularity": 8.2,
+    "fp_last": 111.0
   },
   {
     "playerId": 214435,
@@ -5523,7 +6136,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 8.0,
-    "popularity": 8.2
+    "popularity": 8.3,
+    "fp_last": 116.0
   },
   {
     "playerId": 214420,
@@ -5532,7 +6146,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 11.3
+    "popularity": 11.3,
+    "fp_last": 107.0
   },
   {
     "playerId": 214799,
@@ -5541,7 +6156,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 8.0,
-    "popularity": 9.6
+    "popularity": 9.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214594,
@@ -5550,7 +6166,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 49.0
   },
   {
     "playerId": 214568,
@@ -5559,7 +6176,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 4.6
+    "popularity": 4.6,
+    "fp_last": 88.0
   },
   {
     "playerId": 214676,
@@ -5568,7 +6186,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 2.5
+    "popularity": 2.5,
+    "fp_last": 65.0
   },
   {
     "playerId": 214460,
@@ -5577,7 +6196,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 67.0
   },
   {
     "playerId": 214453,
@@ -5586,7 +6206,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 75.0
   },
   {
     "playerId": 214531,
@@ -5595,7 +6216,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 88.0
   },
   {
     "playerId": 214933,
@@ -5604,7 +6226,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 2.5
+    "popularity": 2.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214892,
@@ -5613,7 +6236,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 2.9
+    "popularity": 2.9,
+    "fp_last": 120.0
   },
   {
     "playerId": 214524,
@@ -5622,7 +6246,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 47.0
   },
   {
     "playerId": 214564,
@@ -5631,7 +6256,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 3.0
+    "popularity": 3.0,
+    "fp_last": 95.0
   },
   {
     "playerId": 214763,
@@ -5640,7 +6266,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214864,
@@ -5649,7 +6276,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 4.1
+    "popularity": 4.0,
+    "fp_last": 142.0
   },
   {
     "playerId": 214556,
@@ -5658,7 +6286,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 80.0
   },
   {
     "playerId": 214790,
@@ -5667,7 +6296,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 33.0
   },
   {
     "playerId": 214937,
@@ -5676,7 +6306,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214457,
@@ -5685,7 +6316,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 66.0
   },
   {
     "playerId": 214891,
@@ -5694,7 +6326,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 4.6
+    "popularity": 4.6,
+    "fp_last": 146.0
   },
   {
     "playerId": 214463,
@@ -5703,7 +6336,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 90.0
   },
   {
     "playerId": 215063,
@@ -5712,7 +6346,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 107.0
   },
   {
     "playerId": 214691,
@@ -5721,7 +6356,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 1.0
+    "popularity": 1.1,
+    "fp_last": 46.0
   },
   {
     "playerId": 214466,
@@ -5730,7 +6366,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 8.0,
-    "popularity": 2.5
+    "popularity": 2.5,
+    "fp_last": 164.0
   },
   {
     "playerId": 214694,
@@ -5739,7 +6376,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 130.0
   },
   {
     "playerId": 214931,
@@ -5748,7 +6386,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214428,
@@ -5757,7 +6396,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214697,
@@ -5766,7 +6406,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 129.0
   },
   {
     "playerId": 214730,
@@ -5775,7 +6416,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 4.8
+    "popularity": 4.8,
+    "fp_last": 130.0
   },
   {
     "playerId": 214897,
@@ -5784,7 +6426,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 8.5,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214635,
@@ -5793,7 +6436,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 8.5,
-    "popularity": 5.9
+    "popularity": 5.9,
+    "fp_last": 191.0
   },
   {
     "playerId": 214837,
@@ -5802,7 +6446,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 10.0,
-    "popularity": 11.0
+    "popularity": 11.0,
+    "fp_last": 168.0
   },
   {
     "playerId": 215038,
@@ -5811,7 +6456,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 5.4
+    "popularity": 5.4,
+    "fp_last": 110.0
   },
   {
     "playerId": 215041,
@@ -5820,7 +6466,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 11.0,
-    "popularity": 34.7
+    "popularity": 34.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214719,
@@ -5829,7 +6476,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 21.0
   },
   {
     "playerId": 214985,
@@ -5838,7 +6486,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 2.8
+    "popularity": 2.9,
+    "fp_last": 10.0
   },
   {
     "playerId": 214582,
@@ -5847,7 +6496,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 2.0
   },
   {
     "playerId": 214836,
@@ -5856,7 +6506,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 8.5,
-    "popularity": 5.9
+    "popularity": 5.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214437,
@@ -5865,7 +6516,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 10.5,
-    "popularity": 10.5
+    "popularity": 10.6,
+    "fp_last": 115.0
   },
   {
     "playerId": 214525,
@@ -5874,7 +6526,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214433,
@@ -5883,7 +6536,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 8.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 129.0
   },
   {
     "playerId": 214731,
@@ -5892,7 +6546,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 3.4
+    "popularity": 3.3,
+    "fp_last": 134.0
   },
   {
     "playerId": 214896,
@@ -5901,7 +6556,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 3.0
+    "popularity": 3.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214558,
@@ -5910,7 +6566,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 52.0
   },
   {
     "playerId": 214567,
@@ -5919,7 +6576,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 94.0
   },
   {
     "playerId": 215060,
@@ -5928,7 +6586,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 109.0
   },
   {
     "playerId": 215000,
@@ -5937,7 +6596,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 72.0
   },
   {
     "playerId": 214698,
@@ -5946,7 +6606,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 8.5,
-    "popularity": 4.9
+    "popularity": 4.9,
+    "fp_last": 148.0
   },
   {
     "playerId": 214734,
@@ -5955,7 +6616,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 9.0,
-    "popularity": 30.4
+    "popularity": 30.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214634,
@@ -5964,7 +6626,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 3.7
+    "popularity": 3.7,
+    "fp_last": 88.0
   },
   {
     "playerId": 214893,
@@ -5973,7 +6636,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214958,
@@ -5982,7 +6646,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214853,
@@ -5991,7 +6656,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 4.6
+    "popularity": 4.6,
+    "fp_last": 113.0
   },
   {
     "playerId": 214758,
@@ -6000,7 +6666,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214923,
@@ -6009,7 +6676,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214658,
@@ -6018,7 +6686,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 52.0
   },
   {
     "playerId": 214494,
@@ -6027,7 +6696,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214467,
@@ -6036,7 +6706,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 9.5,
-    "popularity": 10.2
+    "popularity": 10.2,
+    "fp_last": 169.0
   },
   {
     "playerId": 214465,
@@ -6045,7 +6716,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 133.0
   },
   {
     "playerId": 215035,
@@ -6054,7 +6726,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 4.9
+    "popularity": 4.9,
+    "fp_last": 125.0
   },
   {
     "playerId": 214857,
@@ -6063,7 +6736,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 6.3
+    "popularity": 6.3,
+    "fp_last": 112.0
   },
   {
     "playerId": 214793,
@@ -6072,7 +6746,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 3.0
+    "popularity": 3.0,
+    "fp_last": 125.0
   },
   {
     "playerId": 214598,
@@ -6081,7 +6756,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 34.0
   },
   {
     "playerId": 214927,
@@ -6090,7 +6766,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 10.7
+    "popularity": 10.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214517,
@@ -6099,7 +6776,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 72.0
   },
   {
     "playerId": 214655,
@@ -6108,7 +6786,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 73.0
   },
   {
     "playerId": 214626,
@@ -6117,7 +6796,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 39.0
   },
   {
     "playerId": 214628,
@@ -6126,7 +6806,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 5.4
+    "popularity": 5.3,
+    "fp_last": 102.0
   },
   {
     "playerId": 214894,
@@ -6135,7 +6816,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 104.0
   },
   {
     "playerId": 214992,
@@ -6144,7 +6826,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 107.0
   },
   {
     "playerId": 214552,
@@ -6153,7 +6836,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 43.0
   },
   {
     "playerId": 214633,
@@ -6162,7 +6846,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 40.0
   },
   {
     "playerId": 214559,
@@ -6171,7 +6856,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 5.5
+    "popularity": 5.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214765,
@@ -6180,7 +6866,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214696,
@@ -6189,7 +6876,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 8.9
+    "popularity": 8.9,
+    "fp_last": 142.0
   },
   {
     "playerId": 214661,
@@ -6198,7 +6886,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 101.0
   },
   {
     "playerId": 214693,
@@ -6207,7 +6896,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 64.0
   },
   {
     "playerId": 214766,
@@ -6216,7 +6906,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214981,
@@ -6225,7 +6916,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 9.0
   },
   {
     "playerId": 214742,
@@ -6234,7 +6926,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 8.5
+    "popularity": 8.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214767,
@@ -6243,7 +6936,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214963,
@@ -6252,7 +6946,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 47.0
   },
   {
     "playerId": 214835,
@@ -6261,7 +6956,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 8.0,
-    "popularity": 6.5
+    "popularity": 6.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 215048,
@@ -6270,7 +6966,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 3.2
+    "popularity": 3.2,
+    "fp_last": 60.0
   },
   {
     "playerId": 214816,
@@ -6279,7 +6976,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 65.0
   },
   {
     "playerId": 214549,
@@ -6288,7 +6986,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 80.0
   },
   {
     "playerId": 215047,
@@ -6297,7 +6996,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 44.0
   },
   {
     "playerId": 215052,
@@ -6306,7 +7006,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 25.0
   },
   {
     "playerId": 214798,
@@ -6315,7 +7016,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 91.0
   },
   {
     "playerId": 214452,
@@ -6324,7 +7026,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 3.0
+    "popularity": 3.0,
+    "fp_last": 93.0
   },
   {
     "playerId": 215055,
@@ -6333,7 +7036,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 53.0
   },
   {
     "playerId": 215059,
@@ -6342,7 +7046,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 2.0
+    "popularity": 2.0,
+    "fp_last": 82.0
   },
   {
     "playerId": 215061,
@@ -6351,7 +7056,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214496,
@@ -6360,7 +7066,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214818,
@@ -6369,7 +7076,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 3.3
+    "popularity": 3.3,
+    "fp_last": 22.0
   },
   {
     "playerId": 214822,
@@ -6378,7 +7086,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 7.0
   },
   {
     "playerId": 214863,
@@ -6387,7 +7096,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 103.0
   },
   {
     "playerId": 214995,
@@ -6396,7 +7106,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 65.0
   },
   {
     "playerId": 214994,
@@ -6405,7 +7116,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 49.0
   },
   {
     "playerId": 214504,
@@ -6414,7 +7126,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 215039,
@@ -6423,7 +7136,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 5.4
+    "popularity": 5.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214497,
@@ -6432,7 +7146,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 215040,
@@ -6441,7 +7156,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 8.0,
-    "popularity": 32.2
+    "popularity": 32.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214855,
@@ -6450,7 +7166,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 11.0
+    "popularity": 11.0,
+    "fp_last": 136.0
   },
   {
     "playerId": 214873,
@@ -6459,7 +7176,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 3.1
+    "popularity": 3.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214501,
@@ -6468,7 +7186,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214608,
@@ -6477,7 +7196,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214623,
@@ -6486,7 +7206,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 3.8
+    "popularity": 3.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214630,
@@ -6495,7 +7216,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 57.0
   },
   {
     "playerId": 214551,
@@ -6504,7 +7226,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 6.6
+    "popularity": 6.6,
+    "fp_last": 97.0
   },
   {
     "playerId": 214803,
@@ -6513,7 +7236,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 14.8
+    "popularity": 14.9,
+    "fp_last": 8.0
   },
   {
     "playerId": 214852,
@@ -6522,7 +7246,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 21.0
   },
   {
     "playerId": 214657,
@@ -6531,7 +7256,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 86.0
   },
   {
     "playerId": 214851,
@@ -6540,7 +7266,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 74.0
   },
   {
     "playerId": 214663,
@@ -6549,7 +7276,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 139.0
   },
   {
     "playerId": 214601,
@@ -6558,7 +7286,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 0.4
+    "popularity": 0.3,
+    "fp_last": 140.0
   },
   {
     "playerId": 215054,
@@ -6567,7 +7296,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 41.0
   },
   {
     "playerId": 215056,
@@ -6576,7 +7306,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 9.0
+    "popularity": 8.9,
+    "fp_last": 143.0
   },
   {
     "playerId": 214436,
@@ -6585,7 +7316,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 9.5,
-    "popularity": 24.3
+    "popularity": 24.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214907,
@@ -6594,7 +7326,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214724,
@@ -6603,7 +7336,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 102.0
   },
   {
     "playerId": 214721,
@@ -6612,7 +7346,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 16.8
+    "popularity": 16.7,
+    "fp_last": 135.0
   },
   {
     "playerId": 214828,
@@ -6621,7 +7356,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 52.0
   },
   {
     "playerId": 214830,
@@ -6630,7 +7366,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 25.0
   },
   {
     "playerId": 214856,
@@ -6639,7 +7376,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 9.4
+    "popularity": 9.4,
+    "fp_last": 143.0
   },
   {
     "playerId": 214486,
@@ -6648,7 +7386,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 3.0
+    "popularity": 3.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215002,
@@ -6657,7 +7396,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 154.0
   },
   {
     "playerId": 214570,
@@ -6666,7 +7406,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 4.5
+    "popularity": 4.5,
+    "fp_last": 144.0
   },
   {
     "playerId": 215004,
@@ -6675,7 +7416,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 132.0
   },
   {
     "playerId": 214988,
@@ -6684,7 +7426,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 75.0
   },
   {
     "playerId": 214593,
@@ -6693,7 +7436,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214987,
@@ -6702,7 +7446,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 51.0
   },
   {
     "playerId": 214534,
@@ -6711,7 +7456,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 113.0
   },
   {
     "playerId": 214522,
@@ -6720,7 +7466,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 26.0
   },
   {
     "playerId": 214589,
@@ -6729,7 +7476,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 39.0
   },
   {
     "playerId": 214520,
@@ -6738,7 +7486,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 3.4
+    "popularity": 3.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214577,
@@ -6747,7 +7496,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 65.0
   },
   {
     "playerId": 214662,
@@ -6756,7 +7506,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 33.0
   },
   {
     "playerId": 214859,
@@ -6765,7 +7516,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214660,
@@ -6774,7 +7526,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214980,
@@ -6783,7 +7536,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 8.0,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 115.0
   },
   {
     "playerId": 214595,
@@ -6792,7 +7546,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 116.0
   },
   {
     "playerId": 214596,
@@ -6801,7 +7556,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214579,
@@ -6810,7 +7566,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 26.0
   },
   {
     "playerId": 214654,
@@ -6819,7 +7576,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214652,
@@ -6828,7 +7586,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214722,
@@ -6837,7 +7596,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214523,
@@ -6846,7 +7606,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214649,
@@ -6855,7 +7616,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214881,
@@ -6864,7 +7626,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.5,
+    "fp_last": 18.0
   },
   {
     "playerId": 214647,
@@ -6873,7 +7636,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 73.0
   },
   {
     "playerId": 214880,
@@ -6882,7 +7646,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 21.0
   },
   {
     "playerId": 214475,
@@ -6891,7 +7656,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 215003,
@@ -6900,7 +7666,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 100.0
   },
   {
     "playerId": 214932,
@@ -6909,7 +7676,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 215058,
@@ -6918,7 +7686,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214690,
@@ -6927,7 +7696,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.1,
+    "fp_last": 74.0
   },
   {
     "playerId": 214565,
@@ -6936,7 +7706,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 44.0
   },
   {
     "playerId": 214431,
@@ -6945,7 +7716,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 215652,
@@ -6954,7 +7726,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 8.3
+    "popularity": 8.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214429,
@@ -6963,7 +7736,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 95.0
   },
   {
     "playerId": 214817,
@@ -6972,7 +7746,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 83.0
   },
   {
     "playerId": 214682,
@@ -6981,7 +7756,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 31.0
   },
   {
     "playerId": 216508,
@@ -6990,7 +7766,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 3.0
   },
   {
     "playerId": 214823,
@@ -6999,7 +7776,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 18.0
   },
   {
     "playerId": 214860,
@@ -7008,7 +7786,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 51.0
   },
   {
     "playerId": 214819,
@@ -7017,7 +7796,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 45.0
   },
   {
     "playerId": 214569,
@@ -7026,7 +7806,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 2.1
+    "popularity": 2.0,
+    "fp_last": 112.0
   },
   {
     "playerId": 214787,
@@ -7035,7 +7816,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 4.8
+    "popularity": 4.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 216510,
@@ -7044,7 +7826,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214773,
@@ -7053,7 +7836,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 16.0
   },
   {
     "playerId": 214464,
@@ -7062,7 +7846,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 31.0
   },
   {
     "playerId": 214930,
@@ -7071,7 +7856,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 215001,
@@ -7080,7 +7866,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 89.0
   },
   {
     "playerId": 214643,
@@ -7089,7 +7876,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 41.0
   },
   {
     "playerId": 214644,
@@ -7098,7 +7886,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 71.0
   },
   {
     "playerId": 214591,
@@ -7107,7 +7896,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 108.0
   },
   {
     "playerId": 214617,
@@ -7116,7 +7906,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 53.0
   },
   {
     "playerId": 214762,
@@ -7125,7 +7916,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214972,
@@ -7134,7 +7926,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 34.0
   },
   {
     "playerId": 214764,
@@ -7143,7 +7936,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214500,
@@ -7152,7 +7946,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214590,
@@ -7161,7 +7956,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 4.7
+    "popularity": 4.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214962,
@@ -7170,7 +7966,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 55.0
   },
   {
     "playerId": 214609,
@@ -7179,7 +7976,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 9.0
   },
   {
     "playerId": 214502,
@@ -7188,7 +7986,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214761,
@@ -7197,7 +7996,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214503,
@@ -7206,7 +8006,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.2
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214554,
@@ -7215,7 +8016,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 6.0
   },
   {
     "playerId": 214966,
@@ -7224,7 +8026,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 215022,
@@ -7233,7 +8036,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214858,
@@ -7242,7 +8046,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 101.0
   },
   {
     "playerId": 215021,
@@ -7251,7 +8056,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214512,
@@ -7260,7 +8066,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 18.0
   },
   {
     "playerId": 215018,
@@ -7269,7 +8076,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 2.5
+    "popularity": 2.5,
+    "fp_last": 58.0
   },
   {
     "playerId": 214514,
@@ -7278,7 +8086,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214479,
@@ -7287,7 +8096,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 3.7
+    "popularity": 3.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214834,
@@ -7296,7 +8106,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214587,
@@ -7305,7 +8116,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 4.0
   },
   {
     "playerId": 214789,
@@ -7314,7 +8126,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 88.0
   },
   {
     "playerId": 214720,
@@ -7323,7 +8136,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 11.3
+    "popularity": 11.3,
+    "fp_last": 103.0
   },
   {
     "playerId": 214825,
@@ -7332,7 +8146,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 58.0
   },
   {
     "playerId": 215037,
@@ -7341,7 +8156,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 215034,
@@ -7350,7 +8166,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 3.7
+    "popularity": 3.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214637,
@@ -7359,7 +8176,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214712,
@@ -7368,7 +8186,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 14.0
   },
   {
     "playerId": 214487,
@@ -7377,7 +8196,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214800,
@@ -7386,7 +8206,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 9.0,
-    "popularity": 6.5
+    "popularity": 6.4,
+    "fp_last": 79.0
   },
   {
     "playerId": 214632,
@@ -7395,7 +8216,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 130.0
   },
   {
     "playerId": 214629,
@@ -7404,7 +8226,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214516,
@@ -7413,7 +8236,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 57.0
   },
   {
     "playerId": 214489,
@@ -7422,7 +8246,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214990,
@@ -7431,7 +8256,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 46.0
   },
   {
     "playerId": 214493,
@@ -7440,7 +8266,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214756,
@@ -7449,7 +8276,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214895,
@@ -7458,7 +8286,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 154.0
   },
   {
     "playerId": 214975,
@@ -7467,7 +8296,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 45.0
   },
   {
     "playerId": 214434,
@@ -7476,7 +8306,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 8.0,
-    "popularity": 2.0
+    "popularity": 2.0,
+    "fp_last": 101.0
   },
   {
     "playerId": 214838,
@@ -7485,7 +8316,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214839,
@@ -7494,7 +8326,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214890,
@@ -7503,7 +8336,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 46.0
   },
   {
     "playerId": 214841,
@@ -7512,7 +8346,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 6.0
   },
   {
     "playerId": 214840,
@@ -7521,7 +8356,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214870,
@@ -7530,7 +8366,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214842,
@@ -7539,7 +8376,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214869,
@@ -7548,7 +8386,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214872,
@@ -7557,7 +8396,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214874,
@@ -7566,7 +8406,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214875,
@@ -7575,7 +8416,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214876,
@@ -7584,7 +8426,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 2.0
   },
   {
     "playerId": 214854,
@@ -7593,7 +8436,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 61.0
   },
   {
     "playerId": 214877,
@@ -7602,7 +8446,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214878,
@@ -7611,7 +8456,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214879,
@@ -7620,7 +8466,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214871,
@@ -7629,7 +8476,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214850,
@@ -7638,7 +8486,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214868,
@@ -7647,7 +8496,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 17.0
   },
   {
     "playerId": 214843,
@@ -7656,7 +8506,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214882,
@@ -7665,7 +8516,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214849,
@@ -7674,7 +8526,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 2.0
   },
   {
     "playerId": 214848,
@@ -7683,7 +8536,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.3,
+    "fp_last": 32.0
   },
   {
     "playerId": 214847,
@@ -7692,7 +8546,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214884,
@@ -7701,7 +8556,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 18.0
   },
   {
     "playerId": 214846,
@@ -7710,7 +8566,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214887,
@@ -7719,7 +8576,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 82.0
   },
   {
     "playerId": 214845,
@@ -7728,7 +8586,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214867,
@@ -7737,7 +8596,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214844,
@@ -7746,7 +8606,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 34.0
   },
   {
     "playerId": 214866,
@@ -7755,7 +8616,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214405,
@@ -7764,7 +8626,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214898,
@@ -7773,7 +8636,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 10.5,
-    "popularity": 3.1
+    "popularity": 3.1,
+    "fp_last": 192.0
   },
   {
     "playerId": 215015,
@@ -7782,7 +8646,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 64.0
   },
   {
     "playerId": 215033,
@@ -7791,7 +8656,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 215032,
@@ -7800,7 +8666,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 215031,
@@ -7809,7 +8676,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 215028,
@@ -7818,7 +8686,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 26.0
   },
   {
     "playerId": 215027,
@@ -7827,7 +8696,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 103.0
   },
   {
     "playerId": 215025,
@@ -7836,7 +8706,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 215023,
@@ -7845,7 +8716,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 215020,
@@ -7854,7 +8726,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 215019,
@@ -7863,7 +8736,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 15.0
   },
   {
     "playerId": 215017,
@@ -7872,7 +8746,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 3.4
+    "popularity": 3.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 215016,
@@ -7881,7 +8756,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 215014,
@@ -7890,7 +8766,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 215042,
@@ -7899,7 +8776,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 12.2
+    "popularity": 12.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 215013,
@@ -7908,7 +8786,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 215012,
@@ -7917,7 +8796,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215011,
@@ -7926,7 +8806,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 215010,
@@ -7935,7 +8816,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 7.0
   },
   {
     "playerId": 215009,
@@ -7944,7 +8826,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 215008,
@@ -7953,7 +8836,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 215007,
@@ -7962,7 +8846,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 215005,
@@ -7971,7 +8856,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214998,
@@ -7980,7 +8866,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 48.0
   },
   {
     "playerId": 214997,
@@ -7989,7 +8876,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 78.0
   },
   {
     "playerId": 214996,
@@ -7998,7 +8886,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 98.0
   },
   {
     "playerId": 215036,
@@ -8007,7 +8896,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 57.0
   },
   {
     "playerId": 215043,
@@ -8016,7 +8906,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 5.0
   },
   {
     "playerId": 214991,
@@ -8025,7 +8916,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 33.0
   },
   {
     "playerId": 216509,
@@ -8034,7 +8926,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 216521,
@@ -8043,7 +8936,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 216520,
@@ -8052,7 +8946,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216519,
@@ -8061,7 +8956,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216518,
@@ -8070,7 +8966,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216517,
@@ -8079,7 +8976,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 216516,
@@ -8088,7 +8986,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 216515,
@@ -8097,7 +8996,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216514,
@@ -8106,7 +9006,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216513,
@@ -8115,7 +9016,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 216512,
@@ -8124,7 +9026,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216511,
@@ -8133,7 +9036,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 4.0
   },
   {
     "playerId": 216507,
@@ -8142,7 +9046,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 215044,
@@ -8151,7 +9056,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 216506,
@@ -8160,7 +9066,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 216505,
@@ -8169,7 +9076,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 215653,
@@ -8178,7 +9086,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215651,
@@ -8187,7 +9096,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 215062,
@@ -8196,7 +9106,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.2
+    "popularity": 0.1,
+    "fp_last": 88.0
   },
   {
     "playerId": 215057,
@@ -8205,7 +9116,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 2.7
+    "popularity": 2.6,
+    "fp_last": 97.0
   },
   {
     "playerId": 215053,
@@ -8214,7 +9126,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 109.0
   },
   {
     "playerId": 215051,
@@ -8223,7 +9136,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 85.0
   },
   {
     "playerId": 215050,
@@ -8232,7 +9146,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 3.0
   },
   {
     "playerId": 215049,
@@ -8241,7 +9156,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 14.0
   },
   {
     "playerId": 215046,
@@ -8250,7 +9166,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215045,
@@ -8259,7 +9176,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214993,
@@ -8268,7 +9186,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 10.0
   },
   {
     "playerId": 214989,
@@ -8277,7 +9196,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 67.0
   },
   {
     "playerId": 214899,
@@ -8286,7 +9206,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214914,
@@ -8295,7 +9216,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214934,
@@ -8304,7 +9226,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214929,
@@ -8313,7 +9236,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214928,
@@ -8322,7 +9246,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214926,
@@ -8331,7 +9256,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214924,
@@ -8340,7 +9266,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214921,
@@ -8349,7 +9276,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214920,
@@ -8358,7 +9286,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214919,
@@ -8367,7 +9296,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214918,
@@ -8376,7 +9306,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214917,
@@ -8385,7 +9316,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214916,
@@ -8394,7 +9326,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214913,
@@ -8403,7 +9336,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214939,
@@ -8412,7 +9346,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214912,
@@ -8421,7 +9356,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214911,
@@ -8430,7 +9366,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 6.8
+    "popularity": 6.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214910,
@@ -8439,7 +9376,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214909,
@@ -8448,7 +9386,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214908,
@@ -8457,7 +9396,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214905,
@@ -8466,7 +9406,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214904,
@@ -8475,7 +9416,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214903,
@@ -8484,7 +9426,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214902,
@@ -8493,7 +9436,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214901,
@@ -8502,7 +9446,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214900,
@@ -8511,7 +9456,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 4.1
+    "popularity": 4.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214938,
@@ -8520,7 +9466,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214940,
@@ -8529,7 +9476,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 1.0
   },
   {
     "playerId": 214986,
@@ -8538,7 +9486,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214956,
@@ -8547,7 +9496,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214984,
@@ -8556,7 +9506,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 33.0
   },
   {
     "playerId": 214983,
@@ -8565,7 +9516,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 2.0
   },
   {
     "playerId": 214982,
@@ -8574,7 +9526,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214979,
@@ -8583,7 +9536,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 116.0
   },
   {
     "playerId": 214978,
@@ -8592,7 +9546,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 130.0
   },
   {
     "playerId": 214971,
@@ -8601,7 +9556,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214970,
@@ -8610,7 +9566,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 45.0
   },
   {
     "playerId": 214969,
@@ -8619,7 +9576,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214960,
@@ -8628,7 +9586,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214959,
@@ -8637,7 +9596,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 16.0
   },
   {
     "playerId": 214957,
@@ -8646,7 +9606,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 50.0
   },
   {
     "playerId": 214954,
@@ -8655,7 +9616,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214941,
@@ -8664,7 +9626,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214953,
@@ -8673,7 +9636,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 6.0
   },
   {
     "playerId": 214952,
@@ -8682,7 +9646,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214951,
@@ -8691,7 +9656,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214950,
@@ -8700,7 +9666,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214949,
@@ -8709,7 +9676,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 1.0
   },
   {
     "playerId": 214948,
@@ -8718,7 +9686,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214947,
@@ -8727,7 +9696,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 17.0
   },
   {
     "playerId": 214946,
@@ -8736,7 +9706,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214945,
@@ -8745,7 +9716,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 24.0
   },
   {
     "playerId": 214944,
@@ -8754,7 +9726,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214943,
@@ -8763,7 +9736,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214942,
@@ -8772,7 +9746,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214955,
@@ -8781,7 +9756,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214745,
@@ -8790,7 +9766,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 2.0
+    "popularity": 2.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214833,
@@ -8799,7 +9776,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 76.0
   },
   {
     "playerId": 214536,
@@ -8808,7 +9786,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 18.0
   },
   {
     "playerId": 214548,
@@ -8817,7 +9796,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214547,
@@ -8826,7 +9806,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 34.0
   },
   {
     "playerId": 214546,
@@ -8835,7 +9816,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214545,
@@ -8844,7 +9826,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 1.0
   },
   {
     "playerId": 214544,
@@ -8853,7 +9836,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214543,
@@ -8862,7 +9846,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 41.0
   },
   {
     "playerId": 214542,
@@ -8871,7 +9856,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214541,
@@ -8880,7 +9866,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 19.0
   },
   {
     "playerId": 214540,
@@ -8889,7 +9876,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214539,
@@ -8898,7 +9886,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214538,
@@ -8907,7 +9896,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 8.0
   },
   {
     "playerId": 214537,
@@ -8916,7 +9906,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214533,
@@ -8925,7 +9916,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 151.0
   },
   {
     "playerId": 214553,
@@ -8934,7 +9926,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214532,
@@ -8943,7 +9936,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214530,
@@ -8952,7 +9946,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 21.0
   },
   {
     "playerId": 214529,
@@ -8961,7 +9956,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 106.0
   },
   {
     "playerId": 214528,
@@ -8970,7 +9966,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 82.0
   },
   {
     "playerId": 214527,
@@ -8979,7 +9976,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214526,
@@ -8988,7 +9986,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 28.0
   },
   {
     "playerId": 214521,
@@ -8997,7 +9996,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 28.0
   },
   {
     "playerId": 214519,
@@ -9006,7 +10006,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 86.0
   },
   {
     "playerId": 214518,
@@ -9015,7 +10016,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 10.0
   },
   {
     "playerId": 214515,
@@ -9024,7 +10026,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214513,
@@ -9033,7 +10036,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 12.0
   },
   {
     "playerId": 214511,
@@ -9042,7 +10046,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214510,
@@ -9051,7 +10056,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214550,
@@ -9060,7 +10066,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 52.0
   },
   {
     "playerId": 214555,
@@ -9069,7 +10076,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214508,
@@ -9078,7 +10086,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214584,
@@ -9087,7 +10096,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214610,
@@ -9096,7 +10106,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214607,
@@ -9105,7 +10116,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214606,
@@ -9114,7 +10126,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214605,
@@ -9123,7 +10136,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 27.0
   },
   {
     "playerId": 214604,
@@ -9132,7 +10146,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214603,
@@ -9141,7 +10156,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 1.0
   },
   {
     "playerId": 214602,
@@ -9150,7 +10166,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 8.0,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 199.0
   },
   {
     "playerId": 214600,
@@ -9159,7 +10176,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.6
+    "popularity": 0.5,
+    "fp_last": 129.0
   },
   {
     "playerId": 214597,
@@ -9168,7 +10186,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 85.0
   },
   {
     "playerId": 214592,
@@ -9177,7 +10196,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 3.0
   },
   {
     "playerId": 214588,
@@ -9186,7 +10206,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214586,
@@ -9195,7 +10216,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 1.0
   },
   {
     "playerId": 214585,
@@ -9204,7 +10226,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 36.0
   },
   {
     "playerId": 214583,
@@ -9213,7 +10236,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 49.0
   },
   {
     "playerId": 214557,
@@ -9222,7 +10246,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214581,
@@ -9231,7 +10256,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 8.0
   },
   {
     "playerId": 214580,
@@ -9240,7 +10266,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 10.0
   },
   {
     "playerId": 214578,
@@ -9249,7 +10276,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214576,
@@ -9258,7 +10286,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 39.0
   },
   {
     "playerId": 214575,
@@ -9267,7 +10296,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 1.0
   },
   {
     "playerId": 214574,
@@ -9276,7 +10306,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214573,
@@ -9285,7 +10316,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.7,
+    "fp_last": 3.0
   },
   {
     "playerId": 214572,
@@ -9294,7 +10326,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 2.0
   },
   {
     "playerId": 214571,
@@ -9303,7 +10336,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 3.2
+    "popularity": 3.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214566,
@@ -9312,7 +10346,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 7.0
   },
   {
     "playerId": 214563,
@@ -9321,7 +10356,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214562,
@@ -9330,7 +10366,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214561,
@@ -9339,7 +10376,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 90.0
   },
   {
     "playerId": 214509,
@@ -9348,7 +10386,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214507,
@@ -9357,7 +10396,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214612,
@@ -9366,7 +10406,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214426,
@@ -9375,7 +10416,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 63.0
   },
   {
     "playerId": 214449,
@@ -9384,7 +10426,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 41.0
   },
   {
     "playerId": 214448,
@@ -9393,7 +10436,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214446,
@@ -9402,7 +10446,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214445,
@@ -9411,7 +10456,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214444,
@@ -9420,7 +10466,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 6.0
   },
   {
     "playerId": 214442,
@@ -9429,7 +10476,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214441,
@@ -9438,7 +10486,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214440,
@@ -9447,7 +10496,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214439,
@@ -9456,7 +10506,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214438,
@@ -9465,7 +10516,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 9.0
   },
   {
     "playerId": 214432,
@@ -9474,7 +10526,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 146.0
   },
   {
     "playerId": 214427,
@@ -9483,7 +10536,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214425,
@@ -9492,7 +10546,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 33.0
   },
   {
     "playerId": 214451,
@@ -9501,7 +10556,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214423,
@@ -9510,7 +10566,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 105.0
   },
   {
     "playerId": 214419,
@@ -9519,7 +10576,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214418,
@@ -9528,7 +10586,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 44.0
   },
   {
     "playerId": 214417,
@@ -9537,7 +10596,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 41.0
   },
   {
     "playerId": 214415,
@@ -9546,7 +10606,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214414,
@@ -9555,7 +10616,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214413,
@@ -9564,7 +10626,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214412,
@@ -9573,7 +10636,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 38.0
   },
   {
     "playerId": 214411,
@@ -9582,7 +10646,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214410,
@@ -9591,7 +10656,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214409,
@@ -9600,7 +10666,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214408,
@@ -9609,7 +10676,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214407,
@@ -9618,7 +10686,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214450,
@@ -9627,7 +10696,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214454,
@@ -9636,7 +10706,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 57.0
   },
   {
     "playerId": 214506,
@@ -9645,7 +10716,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214480,
@@ -9654,7 +10726,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 2.4
+    "popularity": 2.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214505,
@@ -9663,7 +10736,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 4.8
+    "popularity": 4.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214499,
@@ -9672,7 +10746,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214498,
@@ -9681,7 +10756,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214495,
@@ -9690,7 +10766,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214492,
@@ -9699,7 +10776,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214491,
@@ -9708,7 +10786,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214490,
@@ -9717,7 +10796,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214488,
@@ -9726,7 +10806,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214485,
@@ -9735,7 +10816,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214484,
@@ -9744,7 +10826,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214483,
@@ -9753,7 +10836,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214482,
@@ -9762,7 +10846,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214481,
@@ -9771,7 +10856,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214478,
@@ -9780,7 +10866,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214455,
@@ -9789,7 +10876,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 52.0
   },
   {
     "playerId": 214477,
@@ -9798,7 +10886,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214476,
@@ -9807,7 +10896,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214474,
@@ -9816,7 +10906,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214473,
@@ -9825,7 +10916,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214472,
@@ -9834,7 +10926,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214471,
@@ -9843,7 +10936,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214470,
@@ -9852,7 +10946,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214469,
@@ -9861,7 +10956,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214468,
@@ -9870,7 +10966,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214462,
@@ -9879,7 +10976,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 49.0
   },
   {
     "playerId": 214461,
@@ -9888,7 +10986,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214459,
@@ -9897,7 +10996,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 11.0
   },
   {
     "playerId": 214458,
@@ -9906,7 +11006,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 2.4
+    "popularity": 2.3,
+    "fp_last": 106.0
   },
   {
     "playerId": 214611,
@@ -9915,7 +11016,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214613,
@@ -9924,7 +11026,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 42.0
   },
   {
     "playerId": 214832,
@@ -9933,7 +11036,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.5
+    "popularity": 0.4,
+    "fp_last": 107.0
   },
   {
     "playerId": 214747,
@@ -9942,7 +11046,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214774,
@@ -9951,7 +11056,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 2.0
+    "popularity": 1.9,
+    "fp_last": 25.0
   },
   {
     "playerId": 214772,
@@ -9960,7 +11066,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 1.0
   },
   {
     "playerId": 214771,
@@ -9969,7 +11076,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214770,
@@ -9978,7 +11086,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214769,
@@ -9987,7 +11096,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214768,
@@ -9996,7 +11106,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214759,
@@ -10005,7 +11116,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214757,
@@ -10014,7 +11126,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214755,
@@ -10023,7 +11136,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214754,
@@ -10032,7 +11146,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214750,
@@ -10041,7 +11156,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214749,
@@ -10050,7 +11166,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214746,
@@ -10059,7 +11176,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214776,
@@ -10068,7 +11186,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 35.0
   },
   {
     "playerId": 214406,
@@ -10077,7 +11196,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214743,
@@ -10086,7 +11206,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214741,
@@ -10095,7 +11216,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214740,
@@ -10104,7 +11226,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 2.0
+    "popularity": 2.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214739,
@@ -10113,7 +11236,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214738,
@@ -10122,7 +11246,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 5.4
+    "popularity": 5.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214737,
@@ -10131,7 +11256,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214736,
@@ -10140,7 +11266,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214729,
@@ -10149,7 +11276,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 61.0
   },
   {
     "playerId": 214728,
@@ -10158,7 +11286,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 118.0
   },
   {
     "playerId": 214727,
@@ -10167,7 +11296,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.3
+    "popularity": 0.2,
+    "fp_last": 31.0
   },
   {
     "playerId": 214718,
@@ -10176,7 +11306,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 90.0
   },
   {
     "playerId": 214717,
@@ -10185,7 +11316,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214775,
@@ -10194,7 +11326,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 31.0
   },
   {
     "playerId": 214779,
@@ -10203,7 +11336,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214715,
@@ -10212,7 +11346,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 45.0
   },
   {
     "playerId": 214809,
@@ -10221,7 +11356,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 214831,
@@ -10230,7 +11366,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214829,
@@ -10239,7 +11376,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 50.0
   },
   {
     "playerId": 214827,
@@ -10248,7 +11386,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 61.0
   },
   {
     "playerId": 214826,
@@ -10257,7 +11396,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 8.0
   },
   {
     "playerId": 214824,
@@ -10266,7 +11406,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 112.0
   },
   {
     "playerId": 214821,
@@ -10275,7 +11416,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 63.0
   },
   {
     "playerId": 214820,
@@ -10284,7 +11426,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 83.0
   },
   {
     "playerId": 214815,
@@ -10293,7 +11436,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214814,
@@ -10302,7 +11446,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214813,
@@ -10311,7 +11456,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214812,
@@ -10320,7 +11466,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214811,
@@ -10329,7 +11476,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214810,
@@ -10338,7 +11486,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 6.0
   },
   {
     "playerId": 214808,
@@ -10347,7 +11496,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 8.0
   },
   {
     "playerId": 214780,
@@ -10356,7 +11506,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 1.0
   },
   {
     "playerId": 214807,
@@ -10365,7 +11516,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214806,
@@ -10374,7 +11526,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214805,
@@ -10383,7 +11536,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 2.0
   },
   {
     "playerId": 214804,
@@ -10392,7 +11546,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214801,
@@ -10401,7 +11556,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 9.0,
-    "popularity": 2.1
+    "popularity": 2.0,
+    "fp_last": 102.0
   },
   {
     "playerId": 214797,
@@ -10410,7 +11566,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 93.0
   },
   {
     "playerId": 214796,
@@ -10419,7 +11576,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 3.0
   },
   {
     "playerId": 214794,
@@ -10428,7 +11586,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 102.0
   },
   {
     "playerId": 214792,
@@ -10437,7 +11596,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 2.5
+    "popularity": 2.4,
+    "fp_last": 102.0
   },
   {
     "playerId": 214788,
@@ -10446,7 +11606,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 106.0
   },
   {
     "playerId": 214786,
@@ -10455,7 +11616,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 11.3
+    "popularity": 11.2,
+    "fp_last": 138.0
   },
   {
     "playerId": 214783,
@@ -10464,7 +11626,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214781,
@@ -10473,7 +11636,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 60.0
   },
   {
     "playerId": 214716,
@@ -10482,7 +11646,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 38.0
   },
   {
     "playerId": 214714,
@@ -10491,7 +11656,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214614,
@@ -10500,7 +11666,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214640,
@@ -10509,7 +11676,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214666,
@@ -10518,7 +11686,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214665,
@@ -10527,7 +11696,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 1.0
   },
   {
     "playerId": 214664,
@@ -10536,7 +11706,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 18.0
   },
   {
     "playerId": 214659,
@@ -10545,7 +11716,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214656,
@@ -10554,7 +11726,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214653,
@@ -10563,7 +11736,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214651,
@@ -10572,7 +11746,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214650,
@@ -10581,7 +11756,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 1.0
   },
   {
     "playerId": 214648,
@@ -10590,7 +11766,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 89.0
   },
   {
     "playerId": 214646,
@@ -10599,7 +11776,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.1,
+    "fp_last": 12.0
   },
   {
     "playerId": 214645,
@@ -10608,7 +11786,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214642,
@@ -10617,7 +11796,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 50.0
   },
   {
     "playerId": 214641,
@@ -10626,7 +11806,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 44.0
   },
   {
     "playerId": 214639,
@@ -10635,7 +11816,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 2.0
   },
   {
     "playerId": 214668,
@@ -10644,7 +11826,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214638,
@@ -10653,7 +11836,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214636,
@@ -10662,7 +11846,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 3.1
+    "popularity": 3.1,
+    "fp_last": 8.0
   },
   {
     "playerId": 214631,
@@ -10671,7 +11856,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 32.0
   },
   {
     "playerId": 214627,
@@ -10680,7 +11866,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214625,
@@ -10689,7 +11876,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214624,
@@ -10698,7 +11886,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 77.0
   },
   {
     "playerId": 214622,
@@ -10707,7 +11896,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 12.0
   },
   {
     "playerId": 214621,
@@ -10716,7 +11906,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 70.0
   },
   {
     "playerId": 214620,
@@ -10725,7 +11916,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214619,
@@ -10734,7 +11926,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 72.0
   },
   {
     "playerId": 214618,
@@ -10743,7 +11936,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214616,
@@ -10752,7 +11946,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 214615,
@@ -10761,7 +11956,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 2.0
   },
   {
     "playerId": 214667,
@@ -10770,7 +11966,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 214669,
@@ -10779,7 +11976,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 214713,
@@ -10788,7 +11986,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214695,
@@ -10797,7 +11996,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 50.0
   },
   {
     "playerId": 214711,
@@ -10806,7 +12006,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214710,
@@ -10815,7 +12016,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214709,
@@ -10824,7 +12026,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214708,
@@ -10833,7 +12036,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214707,
@@ -10842,7 +12046,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214706,
@@ -10851,7 +12056,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214705,
@@ -10860,7 +12066,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 1.0
   },
   {
     "playerId": 214704,
@@ -10869,7 +12076,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214703,
@@ -10878,7 +12086,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214702,
@@ -10887,7 +12096,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214701,
@@ -10896,7 +12106,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214700,
@@ -10905,7 +12116,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214699,
@@ -10914,7 +12126,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214689,
@@ -10923,7 +12136,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 52.0
   },
   {
     "playerId": 214670,
@@ -10932,7 +12146,8 @@
     "position": "GK",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214688,
@@ -10941,7 +12156,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 214687,
@@ -10950,7 +12166,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 10.0
   },
   {
     "playerId": 214686,
@@ -10959,7 +12176,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 214685,
@@ -10968,7 +12186,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214680,
@@ -10977,7 +12196,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214679,
@@ -10986,7 +12206,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214678,
@@ -10995,7 +12216,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 214677,
@@ -11004,7 +12226,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214675,
@@ -11013,7 +12236,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 1.0
   },
   {
     "playerId": 214674,
@@ -11022,7 +12246,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 214673,
@@ -11031,7 +12256,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 214672,
@@ -11040,7 +12266,8 @@
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 9.0
   },
   {
     "playerId": 214671,
@@ -11049,7 +12276,8 @@
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 216536,
@@ -11058,7 +12286,8 @@
     "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216211,
@@ -11067,7 +12296,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 11.0,
-    "popularity": 10.5
+    "popularity": 10.5,
+    "fp_last": 151.0
   },
   {
     "playerId": 216212,
@@ -11076,7 +12306,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 11.0,
-    "popularity": 9.1
+    "popularity": 9.1,
+    "fp_last": 184.0
   },
   {
     "playerId": 215982,
@@ -11085,7 +12316,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 10.5,
-    "popularity": 10.5
+    "popularity": 10.5,
+    "fp_last": 131.0
   },
   {
     "playerId": 216183,
@@ -11094,7 +12326,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 10.5,
-    "popularity": 10.5
+    "popularity": 10.5,
+    "fp_last": 161.0
   },
   {
     "playerId": 215852,
@@ -11103,7 +12336,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 10.0,
-    "popularity": 4.9
+    "popularity": 4.9,
+    "fp_last": 158.0
   },
   {
     "playerId": 216469,
@@ -11112,7 +12346,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 10.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 161.0
   },
   {
     "playerId": 215981,
@@ -11121,7 +12356,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 9.5,
-    "popularity": 9.8
+    "popularity": 9.8,
+    "fp_last": 142.0
   },
   {
     "playerId": 216210,
@@ -11130,7 +12366,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 9.5,
-    "popularity": 13.3
+    "popularity": 13.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 216504,
@@ -11139,7 +12376,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 9.0,
-    "popularity": 8.4
+    "popularity": 8.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216182,
@@ -11148,7 +12386,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 9.0,
-    "popularity": 6.3
+    "popularity": 6.3,
+    "fp_last": 137.0
   },
   {
     "playerId": 215882,
@@ -11157,7 +12396,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 9.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 145.0
   },
   {
     "playerId": 216331,
@@ -11166,7 +12406,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 9.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 93.0
   },
   {
     "playerId": 216502,
@@ -11175,7 +12416,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 8.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216126,
@@ -11184,7 +12426,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 8.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 138.0
   },
   {
     "playerId": 215850,
@@ -11193,7 +12436,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 8.5,
-    "popularity": 7.7
+    "popularity": 7.7,
+    "fp_last": 129.0
   },
   {
     "playerId": 215851,
@@ -11202,7 +12446,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 8.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 1.0
   },
   {
     "playerId": 216503,
@@ -11211,7 +12456,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 8.5,
-    "popularity": 11.2
+    "popularity": 11.2,
+    "fp_last": 130.0
   },
   {
     "playerId": 216127,
@@ -11220,7 +12466,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 8.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 111.0
   },
   {
     "playerId": 215980,
@@ -11229,7 +12476,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 8.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 103.0
   },
   {
     "playerId": 216208,
@@ -11238,7 +12486,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 8.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215979,
@@ -11247,7 +12496,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 8.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 118.0
   },
   {
     "playerId": 216052,
@@ -11256,7 +12506,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 8.0,
-    "popularity": 5.6
+    "popularity": 5.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 216181,
@@ -11265,7 +12516,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 8.0,
-    "popularity": 4.9
+    "popularity": 4.9,
+    "fp_last": 39.0
   },
   {
     "playerId": 215881,
@@ -11274,7 +12526,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 8.0,
-    "popularity": 4.9
+    "popularity": 4.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 216209,
@@ -11283,7 +12536,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 8.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 118.0
   },
   {
     "playerId": 216329,
@@ -11292,7 +12546,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 8.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 123.0
   },
   {
     "playerId": 216330,
@@ -11301,7 +12556,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 8.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 101.0
   },
   {
     "playerId": 216401,
@@ -11310,7 +12566,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 8.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 29.0
   },
   {
     "playerId": 215978,
@@ -11319,7 +12576,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 98.0
   },
   {
     "playerId": 216125,
@@ -11328,7 +12586,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 88.0
   },
   {
     "playerId": 216159,
@@ -11337,7 +12596,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 4.9
+    "popularity": 4.9,
+    "fp_last": 145.0
   },
   {
     "playerId": 216206,
@@ -11346,7 +12606,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 145.0
   },
   {
     "playerId": 216124,
@@ -11355,7 +12616,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 108.0
   },
   {
     "playerId": 216364,
@@ -11364,7 +12626,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216400,
@@ -11373,7 +12636,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 106.0
   },
   {
     "playerId": 215848,
@@ -11382,7 +12646,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 141.0
   },
   {
     "playerId": 215849,
@@ -11391,7 +12656,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 120.0
   },
   {
     "playerId": 216365,
@@ -11400,7 +12666,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216180,
@@ -11409,7 +12676,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216500,
@@ -11418,7 +12686,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 96.0
   },
   {
     "playerId": 216123,
@@ -11427,7 +12696,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 121.0
   },
   {
     "playerId": 216207,
@@ -11436,7 +12706,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216399,
@@ -11445,7 +12716,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 125.0
   },
   {
     "playerId": 216051,
@@ -11454,7 +12726,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 216050,
@@ -11463,7 +12736,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216501,
@@ -11472,7 +12746,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 67.0
   },
   {
     "playerId": 216122,
@@ -11481,7 +12756,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 50.0
   },
   {
     "playerId": 216010,
@@ -11490,7 +12766,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 134.0
   },
   {
     "playerId": 215947,
@@ -11499,7 +12776,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 116.0
   },
   {
     "playerId": 215977,
@@ -11508,7 +12786,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 78.0
   },
   {
     "playerId": 216328,
@@ -11517,7 +12796,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 71.0
   },
   {
     "playerId": 215846,
@@ -11526,7 +12806,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 77.0
   },
   {
     "playerId": 215847,
@@ -11535,7 +12816,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 93.0
   },
   {
     "playerId": 216204,
@@ -11544,7 +12826,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 92.0
   },
   {
     "playerId": 215976,
@@ -11553,7 +12836,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 45.0
   },
   {
     "playerId": 215975,
@@ -11562,7 +12846,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216363,
@@ -11571,7 +12856,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216468,
@@ -11580,7 +12866,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 216497,
@@ -11589,7 +12876,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 79.0
   },
   {
     "playerId": 216498,
@@ -11598,7 +12886,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 112.0
   },
   {
     "playerId": 216499,
@@ -11607,7 +12896,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 117.0
   },
   {
     "playerId": 215880,
@@ -11616,7 +12906,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 104.0
   },
   {
     "playerId": 216205,
@@ -11625,7 +12916,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 69.0
   },
   {
     "playerId": 216327,
@@ -11634,7 +12926,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 95.0
   },
   {
     "playerId": 216177,
@@ -11643,7 +12936,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 216178,
@@ -11652,7 +12946,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216467,
@@ -11661,7 +12956,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 4.9
+    "popularity": 4.9,
+    "fp_last": 76.0
   },
   {
     "playerId": 216179,
@@ -11670,7 +12966,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 7.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 61.0
   },
   {
     "playerId": 216293,
@@ -11679,7 +12976,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216292,
@@ -11688,7 +12986,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216121,
@@ -11697,7 +12996,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 90.0
   },
   {
     "playerId": 216464,
@@ -11706,7 +13006,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 97.0
   },
   {
     "playerId": 216495,
@@ -11715,7 +13016,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 103.0
   },
   {
     "playerId": 215845,
@@ -11724,7 +13026,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 51.0
   },
   {
     "playerId": 216325,
@@ -11733,7 +13036,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 62.0
   },
   {
     "playerId": 216435,
@@ -11742,7 +13046,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 113.0
   },
   {
     "playerId": 216158,
@@ -11751,7 +13056,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216324,
@@ -11760,7 +13066,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216048,
@@ -11769,7 +13076,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 98.0
   },
   {
     "playerId": 215876,
@@ -11778,7 +13086,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 39.0
   },
   {
     "playerId": 215877,
@@ -11787,7 +13096,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 81.0
   },
   {
     "playerId": 215878,
@@ -11796,7 +13106,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 215879,
@@ -11805,7 +13116,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 116.0
   },
   {
     "playerId": 216009,
@@ -11814,7 +13126,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216120,
@@ -11823,7 +13136,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 52.0
   },
   {
     "playerId": 216326,
@@ -11832,7 +13146,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 216246,
@@ -11841,7 +13156,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 41.0
   },
   {
     "playerId": 215946,
@@ -11850,7 +13166,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216465,
@@ -11859,7 +13176,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215972,
@@ -11868,7 +13186,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 56.0
   },
   {
     "playerId": 215974,
@@ -11877,7 +13196,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 59.0
   },
   {
     "playerId": 215973,
@@ -11886,7 +13206,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216173,
@@ -11895,7 +13216,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216046,
@@ -11904,7 +13226,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 30.0
   },
   {
     "playerId": 216049,
@@ -11913,7 +13236,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216047,
@@ -11922,7 +13246,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 104.0
   },
   {
     "playerId": 216174,
@@ -11931,7 +13256,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 35.0
   },
   {
     "playerId": 216175,
@@ -11940,7 +13266,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216176,
@@ -11949,7 +13276,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 108.0
   },
   {
     "playerId": 216092,
@@ -11958,7 +13286,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216009,
@@ -11967,7 +13296,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216158,
@@ -11976,7 +13306,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216461,
@@ -11985,7 +13316,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 121.0
   },
   {
     "playerId": 216462,
@@ -11994,7 +13326,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216202,
@@ -12003,7 +13336,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216245,
@@ -12012,7 +13346,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 60.0
   },
   {
     "playerId": 216460,
@@ -12021,7 +13356,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 5.6
+    "popularity": 5.6,
+    "fp_last": 119.0
   },
   {
     "playerId": 216463,
@@ -12030,7 +13366,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 67.0
   },
   {
     "playerId": 216493,
@@ -12039,7 +13376,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 123.0
   },
   {
     "playerId": 215839,
@@ -12048,7 +13386,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 5.6
+    "popularity": 5.6,
+    "fp_last": 120.0
   },
   {
     "playerId": 215840,
@@ -12057,7 +13396,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 61.0
   },
   {
     "playerId": 215841,
@@ -12066,7 +13406,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 130.0
   },
   {
     "playerId": 215842,
@@ -12075,7 +13416,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215843,
@@ -12084,7 +13426,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215844,
@@ -12093,7 +13436,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216244,
@@ -12102,7 +13446,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 70.0
   },
   {
     "playerId": 216118,
@@ -12111,7 +13456,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 83.0
   },
   {
     "playerId": 216491,
@@ -12120,7 +13466,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 34.0
   },
   {
     "playerId": 216322,
@@ -12129,7 +13476,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 4.9
+    "popularity": 4.9,
+    "fp_last": 137.0
   },
   {
     "playerId": 215873,
@@ -12138,7 +13486,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 215874,
@@ -12147,7 +13496,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 62.0
   },
   {
     "playerId": 215875,
@@ -12156,7 +13506,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 64.0
   },
   {
     "playerId": 216434,
@@ -12165,7 +13516,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 91.0
   },
   {
     "playerId": 216203,
@@ -12174,7 +13526,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 159.0
   },
   {
     "playerId": 216091,
@@ -12183,7 +13536,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216119,
@@ -12192,7 +13546,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 88.0
   },
   {
     "playerId": 216117,
@@ -12201,7 +13556,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216291,
@@ -12210,7 +13566,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216290,
@@ -12219,7 +13576,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215915,
@@ -12228,7 +13586,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 59.0
   },
   {
     "playerId": 216170,
@@ -12237,7 +13596,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 5.0
   },
   {
     "playerId": 216172,
@@ -12246,7 +13606,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216171,
@@ -12255,7 +13616,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 56.0
   },
   {
     "playerId": 216396,
@@ -12264,7 +13626,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216395,
@@ -12273,7 +13636,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 65.0
   },
   {
     "playerId": 216398,
@@ -12282,7 +13646,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216397,
@@ -12291,7 +13656,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 55.0
   },
   {
     "playerId": 215942,
@@ -12300,7 +13666,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215943,
@@ -12309,7 +13676,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 35.0
   },
   {
     "playerId": 215944,
@@ -12318,7 +13686,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 215945,
@@ -12327,7 +13696,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 16.0
   },
   {
     "playerId": 216459,
@@ -12336,7 +13706,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216201,
@@ -12345,7 +13716,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 149.0
   },
   {
     "playerId": 216200,
@@ -12354,7 +13726,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 11.9
+    "popularity": 11.9,
+    "fp_last": 158.0
   },
   {
     "playerId": 216494,
@@ -12363,7 +13736,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 5.6
+    "popularity": 5.6,
+    "fp_last": 119.0
   },
   {
     "playerId": 216492,
@@ -12372,7 +13746,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 106.0
   },
   {
     "playerId": 215966,
@@ -12381,7 +13756,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 142.0
   },
   {
     "playerId": 215967,
@@ -12390,7 +13766,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 7.0
+    "popularity": 7.0,
+    "fp_last": 157.0
   },
   {
     "playerId": 215968,
@@ -12399,7 +13776,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 10.5
+    "popularity": 10.5,
+    "fp_last": 123.0
   },
   {
     "playerId": 215969,
@@ -12408,7 +13786,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 41.0
   },
   {
     "playerId": 215970,
@@ -12417,7 +13796,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 4.9
+    "popularity": 4.9,
+    "fp_last": 130.0
   },
   {
     "playerId": 215971,
@@ -12426,7 +13806,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216045,
@@ -12435,7 +13816,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 30.0
   },
   {
     "playerId": 216044,
@@ -12444,7 +13826,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216199,
@@ -12453,7 +13836,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 90.0
   },
   {
     "playerId": 216323,
@@ -12462,7 +13846,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 154.0
   },
   {
     "playerId": 216007,
@@ -12471,7 +13856,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216008,
@@ -12480,7 +13866,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216157,
@@ -12489,7 +13876,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 75.0
   },
   {
     "playerId": 216155,
@@ -12498,7 +13886,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216156,
@@ -12507,7 +13896,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 80.0
   },
   {
     "playerId": 216362,
@@ -12516,7 +13906,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216154,
@@ -12525,7 +13916,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 50.0
   },
   {
     "playerId": 216360,
@@ -12534,7 +13926,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216394,
@@ -12543,7 +13936,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 41.0
   },
   {
     "playerId": 215835,
@@ -12552,7 +13946,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 111.0
   },
   {
     "playerId": 216359,
@@ -12561,7 +13956,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215868,
@@ -12570,7 +13966,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 215869,
@@ -12579,7 +13976,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215870,
@@ -12588,7 +13986,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 49.0
   },
   {
     "playerId": 215871,
@@ -12597,7 +13996,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 90.0
   },
   {
     "playerId": 215872,
@@ -12606,7 +14006,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 53.0
   },
   {
     "playerId": 216358,
@@ -12615,7 +14016,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216315,
@@ -12624,7 +14026,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 45.0
   },
   {
     "playerId": 216320,
@@ -12633,7 +14036,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216319,
@@ -12642,7 +14046,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 55.0
   },
   {
     "playerId": 215911,
@@ -12651,7 +14056,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215912,
@@ -12660,7 +14066,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 63.0
   },
   {
     "playerId": 215913,
@@ -12669,7 +14076,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 73.0
   },
   {
     "playerId": 215914,
@@ -12678,7 +14086,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 52.0
   },
   {
     "playerId": 216151,
@@ -12687,7 +14096,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 24.0
   },
   {
     "playerId": 216152,
@@ -12696,7 +14106,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216169,
@@ -12705,7 +14116,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 216391,
@@ -12714,7 +14126,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216393,
@@ -12723,7 +14136,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 36.0
   },
   {
     "playerId": 216392,
@@ -12732,7 +14146,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215939,
@@ -12741,7 +14156,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 119.0
   },
   {
     "playerId": 215940,
@@ -12750,7 +14166,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 58.0
   },
   {
     "playerId": 215941,
@@ -12759,7 +14176,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 65.0
   },
   {
     "playerId": 216316,
@@ -12768,7 +14186,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216321,
@@ -12777,7 +14196,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216318,
@@ -12786,7 +14206,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 132.0
   },
   {
     "playerId": 216317,
@@ -12795,7 +14216,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 122.0
   },
   {
     "playerId": 216003,
@@ -12804,7 +14226,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 81.0
   },
   {
     "playerId": 216004,
@@ -12813,7 +14236,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 54.0
   },
   {
     "playerId": 216005,
@@ -12822,7 +14246,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 56.0
   },
   {
     "playerId": 216006,
@@ -12831,7 +14256,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 20.0
   },
   {
     "playerId": 216153,
@@ -12840,7 +14266,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 65.0
   },
   {
     "playerId": 216361,
@@ -12849,7 +14276,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216168,
@@ -12858,7 +14286,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 5.6
+    "popularity": 5.6,
+    "fp_last": 129.0
   },
   {
     "playerId": 216457,
@@ -12867,7 +14296,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 118.0
   },
   {
     "playerId": 215961,
@@ -12876,7 +14306,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 53.0
   },
   {
     "playerId": 215962,
@@ -12885,7 +14316,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 110.0
   },
   {
     "playerId": 215963,
@@ -12894,7 +14326,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 92.0
   },
   {
     "playerId": 215964,
@@ -12903,7 +14336,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 59.0
   },
   {
     "playerId": 215965,
@@ -12912,7 +14346,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216154,
@@ -12921,7 +14356,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 50.0
   },
   {
     "playerId": 216455,
@@ -12930,7 +14366,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 9.8
+    "popularity": 9.8,
+    "fp_last": 133.0
   },
   {
     "playerId": 216393,
@@ -12939,7 +14376,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 36.0
   },
   {
     "playerId": 216003,
@@ -12948,7 +14386,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 81.0
   },
   {
     "playerId": 216004,
@@ -12957,7 +14396,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 54.0
   },
   {
     "playerId": 216005,
@@ -12966,7 +14406,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 56.0
   },
   {
     "playerId": 216006,
@@ -12975,7 +14416,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 20.0
   },
   {
     "playerId": 216167,
@@ -12984,7 +14426,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 93.0
   },
   {
     "playerId": 216316,
@@ -12993,7 +14436,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216315,
@@ -13002,7 +14446,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 45.0
   },
   {
     "playerId": 216319,
@@ -13011,7 +14456,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 55.0
   },
   {
     "playerId": 216317,
@@ -13020,7 +14466,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 122.0
   },
   {
     "playerId": 216321,
@@ -13029,7 +14476,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216320,
@@ -13038,7 +14486,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216359,
@@ -13047,7 +14496,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216041,
@@ -13056,7 +14506,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 47.0
   },
   {
     "playerId": 216042,
@@ -13065,7 +14516,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 3.0
   },
   {
     "playerId": 216043,
@@ -13074,7 +14526,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 51.0
   },
   {
     "playerId": 216392,
@@ -13083,7 +14536,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216391,
@@ -13092,7 +14546,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216196,
@@ -13101,7 +14556,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216197,
@@ -13110,7 +14566,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 117.0
   },
   {
     "playerId": 216429,
@@ -13119,7 +14576,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216430,
@@ -13128,7 +14586,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 24.0
   },
   {
     "playerId": 216433,
@@ -13137,7 +14596,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 81.0
   },
   {
     "playerId": 216432,
@@ -13146,7 +14606,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 16.0
   },
   {
     "playerId": 216087,
@@ -13155,7 +14616,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216088,
@@ -13164,7 +14626,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216089,
@@ -13173,7 +14636,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216090,
@@ -13182,7 +14646,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216454,
@@ -13191,7 +14656,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 1.0
   },
   {
     "playerId": 216487,
@@ -13200,7 +14666,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 24.0
   },
   {
     "playerId": 216489,
@@ -13209,7 +14676,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216488,
@@ -13218,7 +14686,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 92.0
   },
   {
     "playerId": 216113,
@@ -13227,7 +14696,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 45.0
   },
   {
     "playerId": 216114,
@@ -13236,7 +14706,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 44.0
   },
   {
     "playerId": 216115,
@@ -13245,7 +14716,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 90.0
   },
   {
     "playerId": 216116,
@@ -13254,7 +14726,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 73.0
   },
   {
     "playerId": 216313,
@@ -13263,7 +14736,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 91.0
   },
   {
     "playerId": 216311,
@@ -13272,7 +14746,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215833,
@@ -13281,7 +14756,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 96.0
   },
   {
     "playerId": 215834,
@@ -13290,7 +14766,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 31.0
   },
   {
     "playerId": 215863,
@@ -13299,7 +14776,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215864,
@@ -13308,7 +14786,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 42.0
   },
   {
     "playerId": 215865,
@@ -13317,7 +14796,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 80.0
   },
   {
     "playerId": 215866,
@@ -13326,7 +14806,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215867,
@@ -13335,7 +14816,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 52.0
   },
   {
     "playerId": 216286,
@@ -13344,7 +14826,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215906,
@@ -13353,7 +14836,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 36.0
   },
   {
     "playerId": 215907,
@@ -13362,7 +14846,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 21.0
   },
   {
     "playerId": 215908,
@@ -13371,7 +14856,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 215909,
@@ -13380,7 +14866,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 93.0
   },
   {
     "playerId": 215910,
@@ -13389,7 +14876,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 26.0
   },
   {
     "playerId": 216356,
@@ -13398,7 +14886,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 215929,
@@ -13407,7 +14896,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 107.0
   },
   {
     "playerId": 215930,
@@ -13416,7 +14906,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215931,
@@ -13425,7 +14916,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 215932,
@@ -13434,7 +14926,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 114.0
   },
   {
     "playerId": 215933,
@@ -13443,7 +14936,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 57.0
   },
   {
     "playerId": 215934,
@@ -13452,7 +14946,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215935,
@@ -13461,7 +14956,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215936,
@@ -13470,7 +14966,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 32.0
   },
   {
     "playerId": 215937,
@@ -13479,7 +14976,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215938,
@@ -13488,7 +14986,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 35.0
   },
   {
     "playerId": 216164,
@@ -13497,7 +14996,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 75.0
   },
   {
     "playerId": 215996,
@@ -13506,7 +15006,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 215997,
@@ -13515,7 +15016,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 112.0
   },
   {
     "playerId": 215998,
@@ -13524,7 +15026,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 58.0
   },
   {
     "playerId": 215999,
@@ -13533,7 +15036,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216000,
@@ -13542,7 +15046,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 30.0
   },
   {
     "playerId": 216001,
@@ -13551,7 +15056,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216002,
@@ -13560,7 +15066,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 40.0
   },
   {
     "playerId": 216166,
@@ -13569,7 +15076,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 43.0
   },
   {
     "playerId": 216314,
@@ -13578,7 +15086,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 4.0
   },
   {
     "playerId": 216357,
@@ -13587,7 +15096,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216355,
@@ -13596,7 +15106,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216354,
@@ -13605,7 +15116,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216353,
@@ -13614,7 +15126,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216033,
@@ -13623,7 +15136,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": -2.0
   },
   {
     "playerId": 216034,
@@ -13632,7 +15146,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 59.0
   },
   {
     "playerId": 216035,
@@ -13641,7 +15156,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 73.0
   },
   {
     "playerId": 216036,
@@ -13650,7 +15166,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 68.0
   },
   {
     "playerId": 216037,
@@ -13659,7 +15176,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 66.0
   },
   {
     "playerId": 216038,
@@ -13668,7 +15186,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 65.0
   },
   {
     "playerId": 216039,
@@ -13677,7 +15196,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 15.0
   },
   {
     "playerId": 216040,
@@ -13686,7 +15206,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 5.0
   },
   {
     "playerId": 216312,
@@ -13695,7 +15216,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216165,
@@ -13704,7 +15226,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 46.0
   },
   {
     "playerId": 216384,
@@ -13713,7 +15236,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 54.0
   },
   {
     "playerId": 216388,
@@ -13722,7 +15246,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 71.0
   },
   {
     "playerId": 216387,
@@ -13731,7 +15256,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 91.0
   },
   {
     "playerId": 216386,
@@ -13740,7 +15266,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 93.0
   },
   {
     "playerId": 216390,
@@ -13749,7 +15276,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 20.0
   },
   {
     "playerId": 216389,
@@ -13758,7 +15286,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 71.0
   },
   {
     "playerId": 215999,
@@ -13767,7 +15296,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216000,
@@ -13776,7 +15306,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 30.0
   },
   {
     "playerId": 216001,
@@ -13785,7 +15316,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216002,
@@ -13794,7 +15326,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 40.0
   },
   {
     "playerId": 216033,
@@ -13803,7 +15336,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": -2.0
   },
   {
     "playerId": 216034,
@@ -13812,7 +15346,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 59.0
   },
   {
     "playerId": 216035,
@@ -13821,7 +15356,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 73.0
   },
   {
     "playerId": 216036,
@@ -13830,7 +15366,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 68.0
   },
   {
     "playerId": 216037,
@@ -13839,7 +15376,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 66.0
   },
   {
     "playerId": 216038,
@@ -13848,7 +15386,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 65.0
   },
   {
     "playerId": 216039,
@@ -13857,7 +15396,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 15.0
   },
   {
     "playerId": 216040,
@@ -13866,7 +15406,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 5.0
   },
   {
     "playerId": 216313,
@@ -13875,7 +15416,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 91.0
   },
   {
     "playerId": 216312,
@@ -13884,7 +15426,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216314,
@@ -13893,7 +15436,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 4.0
   },
   {
     "playerId": 216311,
@@ -13902,7 +15446,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216310,
@@ -13911,7 +15456,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216284,
@@ -13920,7 +15466,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216079,
@@ -13929,7 +15476,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216080,
@@ -13938,7 +15486,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216081,
@@ -13947,7 +15496,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216082,
@@ -13956,7 +15506,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216083,
@@ -13965,7 +15516,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216084,
@@ -13974,7 +15526,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216085,
@@ -13983,7 +15536,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216086,
@@ -13992,7 +15546,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216390,
@@ -14001,7 +15556,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 20.0
   },
   {
     "playerId": 216449,
@@ -14010,7 +15566,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216355,
@@ -14019,7 +15576,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216354,
@@ -14028,7 +15586,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216357,
@@ -14037,7 +15596,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216356,
@@ -14046,7 +15606,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 216106,
@@ -14055,7 +15616,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 61.0
   },
   {
     "playerId": 216107,
@@ -14064,7 +15626,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216108,
@@ -14073,7 +15636,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 35.0
   },
   {
     "playerId": 216109,
@@ -14082,7 +15646,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 54.0
   },
   {
     "playerId": 216110,
@@ -14091,7 +15656,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 72.0
   },
   {
     "playerId": 216111,
@@ -14100,7 +15666,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216112,
@@ -14109,7 +15676,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 82.0
   },
   {
     "playerId": 216452,
@@ -14118,7 +15686,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 44.0
   },
   {
     "playerId": 216279,
@@ -14127,7 +15696,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216427,
@@ -14136,7 +15706,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216426,
@@ -14145,7 +15716,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 41.0
   },
   {
     "playerId": 216144,
@@ -14154,7 +15726,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 91.0
   },
   {
     "playerId": 216145,
@@ -14163,7 +15736,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 11.0
   },
   {
     "playerId": 216146,
@@ -14172,7 +15746,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216147,
@@ -14181,7 +15756,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216148,
@@ -14190,7 +15766,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 53.0
   },
   {
     "playerId": 216149,
@@ -14199,7 +15776,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 33.0
   },
   {
     "playerId": 216150,
@@ -14208,7 +15786,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 129.0
   },
   {
     "playerId": 216428,
@@ -14217,7 +15796,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 55.0
   },
   {
     "playerId": 216164,
@@ -14226,7 +15806,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 75.0
   },
   {
     "playerId": 216165,
@@ -14235,7 +15816,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 46.0
   },
   {
     "playerId": 216166,
@@ -14244,7 +15826,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 43.0
   },
   {
     "playerId": 216283,
@@ -14253,7 +15836,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216483,
@@ -14262,7 +15846,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 216482,
@@ -14271,7 +15856,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216486,
@@ -14280,7 +15866,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 80.0
   },
   {
     "playerId": 216485,
@@ -14289,7 +15876,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 23.0
   },
   {
     "playerId": 216484,
@@ -14298,7 +15886,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 38.0
   },
   {
     "playerId": 216192,
@@ -14307,7 +15896,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 53.0
   },
   {
     "playerId": 216193,
@@ -14316,7 +15906,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 41.0
   },
   {
     "playerId": 216194,
@@ -14325,7 +15916,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 36.0
   },
   {
     "playerId": 216195,
@@ -14334,7 +15926,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 1.0
   },
   {
     "playerId": 216282,
@@ -14343,7 +15936,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216281,
@@ -14352,7 +15946,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216305,
@@ -14361,7 +15956,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215827,
@@ -14370,7 +15966,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215920,
@@ -14379,7 +15976,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 4.0
   },
   {
     "playerId": 215921,
@@ -14388,7 +15986,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 5.6
+    "popularity": 5.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 215922,
@@ -14397,7 +15996,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 6.0
   },
   {
     "playerId": 215924,
@@ -14406,7 +16006,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 215925,
@@ -14415,7 +16016,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215926,
@@ -14424,7 +16026,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 15.0
   },
   {
     "playerId": 215927,
@@ -14433,7 +16036,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 75.0
   },
   {
     "playerId": 215928,
@@ -14442,7 +16046,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216307,
@@ -14451,7 +16056,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 21.0
   },
   {
     "playerId": 216309,
@@ -14460,7 +16066,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 16.0
   },
   {
     "playerId": 216020,
@@ -14469,7 +16076,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 7.0
   },
   {
     "playerId": 216021,
@@ -14478,7 +16086,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 28.0
   },
   {
     "playerId": 216023,
@@ -14487,7 +16096,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 21.0
   },
   {
     "playerId": 216024,
@@ -14496,7 +16106,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 2.0
   },
   {
     "playerId": 216025,
@@ -14505,7 +16116,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 43.0
   },
   {
     "playerId": 216026,
@@ -14514,7 +16126,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216028,
@@ -14523,7 +16136,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216029,
@@ -14532,7 +16146,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216030,
@@ -14541,7 +16156,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216031,
@@ -14550,7 +16166,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216032,
@@ -14559,7 +16176,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 14.0
   },
   {
     "playerId": 216308,
@@ -14568,7 +16186,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216306,
@@ -14577,7 +16196,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216304,
@@ -14586,7 +16206,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 18.0
   },
   {
     "playerId": 216067,
@@ -14595,7 +16216,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216068,
@@ -14604,7 +16226,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216069,
@@ -14613,7 +16236,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216070,
@@ -14622,7 +16246,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216071,
@@ -14631,7 +16256,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216072,
@@ -14640,7 +16266,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216073,
@@ -14649,7 +16276,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216074,
@@ -14658,7 +16286,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216422,
@@ -14667,7 +16296,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 42.0
   },
   {
     "playerId": 216015,
@@ -14676,7 +16306,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 5.6
+    "popularity": 5.6,
+    "fp_last": 1.0
   },
   {
     "playerId": 216016,
@@ -14685,7 +16316,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 216017,
@@ -14694,7 +16326,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 48.0
   },
   {
     "playerId": 216018,
@@ -14703,7 +16336,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 216019,
@@ -14712,7 +16346,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216020,
@@ -14721,7 +16356,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 7.0
   },
   {
     "playerId": 216021,
@@ -14730,7 +16366,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 28.0
   },
   {
     "playerId": 216022,
@@ -14739,7 +16376,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 37.0
   },
   {
     "playerId": 216023,
@@ -14748,7 +16386,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 21.0
   },
   {
     "playerId": 216024,
@@ -14757,7 +16396,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 2.0
   },
   {
     "playerId": 216025,
@@ -14766,7 +16406,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 43.0
   },
   {
     "playerId": 216026,
@@ -14775,7 +16416,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216027,
@@ -14784,7 +16426,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216028,
@@ -14793,7 +16436,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216029,
@@ -14802,7 +16446,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216030,
@@ -14811,7 +16456,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216031,
@@ -14820,7 +16466,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216032,
@@ -14829,7 +16476,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 14.0
   },
   {
     "playerId": 216425,
@@ -14838,7 +16486,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 75.0
   },
   {
     "playerId": 216421,
@@ -14847,7 +16496,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 2.0
   },
   {
     "playerId": 216420,
@@ -14856,7 +16506,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216424,
@@ -14865,7 +16516,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 49.0
   },
   {
     "playerId": 216441,
@@ -14874,7 +16526,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216443,
@@ -14883,7 +16536,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216442,
@@ -14892,7 +16546,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216067,
@@ -14901,7 +16556,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216068,
@@ -14910,7 +16566,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216069,
@@ -14919,7 +16576,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216070,
@@ -14928,7 +16586,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216071,
@@ -14937,7 +16596,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216072,
@@ -14946,7 +16606,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216073,
@@ -14955,7 +16616,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216074,
@@ -14964,7 +16626,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216075,
@@ -14973,7 +16636,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216137,
@@ -14982,7 +16646,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 76.0
   },
   {
     "playerId": 216138,
@@ -14991,7 +16656,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 13.0
   },
   {
     "playerId": 216140,
@@ -15000,7 +16666,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 1.0
   },
   {
     "playerId": 216141,
@@ -15009,7 +16676,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216142,
@@ -15018,7 +16686,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 11.0
   },
   {
     "playerId": 216143,
@@ -15027,7 +16696,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216381,
@@ -15036,7 +16706,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216162,
@@ -15045,7 +16716,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216163,
@@ -15054,7 +16726,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216186,
@@ -15063,7 +16736,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 4.9
+    "popularity": 4.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 216187,
@@ -15072,7 +16746,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216188,
@@ -15081,7 +16756,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216189,
@@ -15090,7 +16766,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216190,
@@ -15099,7 +16776,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216191,
@@ -15108,7 +16786,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216216,
@@ -15117,7 +16796,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 63.0
   },
   {
     "playerId": 216217,
@@ -15126,7 +16806,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 49.0
   },
   {
     "playerId": 216218,
@@ -15135,7 +16816,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 1.0
   },
   {
     "playerId": 216219,
@@ -15144,7 +16826,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216220,
@@ -15153,7 +16836,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 5.0
   },
   {
     "playerId": 216221,
@@ -15162,7 +16846,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 34.0
   },
   {
     "playerId": 216222,
@@ -15171,7 +16856,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216223,
@@ -15180,7 +16866,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216224,
@@ -15189,7 +16876,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216225,
@@ -15198,7 +16886,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216226,
@@ -15207,7 +16896,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216227,
@@ -15216,7 +16906,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 12.0
   },
   {
     "playerId": 216228,
@@ -15225,7 +16916,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216229,
@@ -15234,7 +16926,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 50.0
   },
   {
     "playerId": 216230,
@@ -15243,7 +16936,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 19.0
   },
   {
     "playerId": 216409,
@@ -15252,7 +16946,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 40.0
   },
   {
     "playerId": 216408,
@@ -15261,7 +16956,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 216411,
@@ -15270,7 +16966,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216413,
@@ -15279,7 +16976,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 49.0
   },
   {
     "playerId": 216412,
@@ -15288,7 +16986,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 46.0
   },
   {
     "playerId": 216410,
@@ -15297,7 +16996,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216414,
@@ -15306,7 +17006,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216423,
@@ -15315,7 +17016,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 37.0
   },
   {
     "playerId": 216261,
@@ -15324,7 +17026,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216262,
@@ -15333,7 +17036,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 5.6
+    "popularity": 5.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 216263,
@@ -15342,7 +17046,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216264,
@@ -15351,7 +17056,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 216265,
@@ -15360,7 +17066,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216266,
@@ -15369,7 +17076,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216267,
@@ -15378,7 +17086,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216268,
@@ -15387,7 +17096,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216269,
@@ -15396,7 +17106,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216270,
@@ -15405,7 +17116,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216271,
@@ -15414,7 +17126,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216272,
@@ -15423,7 +17136,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216273,
@@ -15432,7 +17146,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216274,
@@ -15441,7 +17156,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216275,
@@ -15450,7 +17166,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216276,
@@ -15459,7 +17176,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216277,
@@ -15468,7 +17186,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216278,
@@ -15477,7 +17196,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216419,
@@ -15486,7 +17206,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216417,
@@ -15495,7 +17216,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 72.0
   },
   {
     "playerId": 216416,
@@ -15504,7 +17226,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 27.0
   },
   {
     "playerId": 216415,
@@ -15513,7 +17236,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 83.0
   },
   {
     "playerId": 216304,
@@ -15522,7 +17246,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 18.0
   },
   {
     "playerId": 216305,
@@ -15531,7 +17256,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216306,
@@ -15540,7 +17266,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216307,
@@ -15549,7 +17276,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 21.0
   },
   {
     "playerId": 216308,
@@ -15558,7 +17286,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216276,
@@ -15567,7 +17296,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216277,
@@ -15576,7 +17306,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216278,
@@ -15585,7 +17316,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216441,
@@ -15594,7 +17326,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216304,
@@ -15603,7 +17336,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 18.0
   },
   {
     "playerId": 216305,
@@ -15612,7 +17346,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216306,
@@ -15621,7 +17356,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216307,
@@ -15630,7 +17366,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 21.0
   },
   {
     "playerId": 216308,
@@ -15639,7 +17376,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216309,
@@ -15648,7 +17386,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 16.0
   },
   {
     "playerId": 216443,
@@ -15657,7 +17396,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216341,
@@ -15666,7 +17406,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216342,
@@ -15675,7 +17416,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216343,
@@ -15684,7 +17426,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216344,
@@ -15693,7 +17436,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216345,
@@ -15702,7 +17446,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216346,
@@ -15711,7 +17456,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216347,
@@ -15720,7 +17466,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216348,
@@ -15729,7 +17476,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216349,
@@ -15738,7 +17486,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216350,
@@ -15747,7 +17496,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216351,
@@ -15756,7 +17506,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216352,
@@ -15765,7 +17516,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216425,
@@ -15774,7 +17526,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 75.0
   },
   {
     "playerId": 216479,
@@ -15783,7 +17536,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216478,
@@ -15792,7 +17546,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216477,
@@ -15801,7 +17556,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 19.0
   },
   {
     "playerId": 216374,
@@ -15810,7 +17566,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216375,
@@ -15819,7 +17576,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216376,
@@ -15828,7 +17586,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216377,
@@ -15837,7 +17596,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 52.0
   },
   {
     "playerId": 216378,
@@ -15846,7 +17606,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 5.0
   },
   {
     "playerId": 216379,
@@ -15855,7 +17616,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216380,
@@ -15864,7 +17626,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216381,
@@ -15873,7 +17636,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216382,
@@ -15882,7 +17646,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 23.0
   },
   {
     "playerId": 216383,
@@ -15891,7 +17656,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 1.0
   },
   {
     "playerId": 216476,
@@ -15900,7 +17666,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 6.0
   },
   {
     "playerId": 216424,
@@ -15909,7 +17676,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 49.0
   },
   {
     "playerId": 216423,
@@ -15918,7 +17686,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 37.0
   },
   {
     "playerId": 216422,
@@ -15927,7 +17696,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 42.0
   },
   {
     "playerId": 216408,
@@ -15936,7 +17706,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 216409,
@@ -15945,7 +17716,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 40.0
   },
   {
     "playerId": 216410,
@@ -15954,7 +17726,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216411,
@@ -15963,7 +17736,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216412,
@@ -15972,7 +17746,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 46.0
   },
   {
     "playerId": 216413,
@@ -15981,7 +17756,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 49.0
   },
   {
     "playerId": 216414,
@@ -15990,7 +17766,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216415,
@@ -15999,7 +17776,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 83.0
   },
   {
     "playerId": 216416,
@@ -16008,7 +17786,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 27.0
   },
   {
     "playerId": 216417,
@@ -16017,7 +17796,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 72.0
   },
   {
     "playerId": 216418,
@@ -16026,7 +17806,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 9.0
   },
   {
     "playerId": 216419,
@@ -16035,7 +17816,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216420,
@@ -16044,7 +17826,8 @@
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216421,
@@ -16053,7 +17836,8 @@
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 2.0
   },
   {
     "playerId": 215822,
@@ -16062,7 +17846,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215856,
@@ -16071,7 +17856,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 17.0
   },
   {
     "playerId": 215890,
@@ -16080,7 +17866,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 215916,
@@ -16089,7 +17876,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 9.0
   },
   {
     "playerId": 215917,
@@ -16098,7 +17886,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 215918,
@@ -16107,7 +17896,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216011,
@@ -16116,7 +17906,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 216012,
@@ -16125,7 +17916,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216013,
@@ -16134,7 +17926,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216014,
@@ -16143,7 +17936,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 4.0
   },
   {
     "playerId": 216053,
@@ -16152,7 +17946,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 14.7
+    "popularity": 14.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216054,
@@ -16161,7 +17956,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 9.1
+    "popularity": 9.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216055,
@@ -16170,7 +17966,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 5.6
+    "popularity": 5.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 216056,
@@ -16179,7 +17976,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216057,
@@ -16188,7 +17986,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216058,
@@ -16197,7 +17996,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216059,
@@ -16206,7 +18006,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216060,
@@ -16215,7 +18016,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216061,
@@ -16224,7 +18026,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216062,
@@ -16233,7 +18036,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216063,
@@ -16242,7 +18046,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216064,
@@ -16251,7 +18056,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216213,
@@ -16260,7 +18066,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 9.8
+    "popularity": 9.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 216214,
@@ -16269,7 +18076,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216215,
@@ -16278,7 +18086,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216247,
@@ -16287,7 +18096,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 216248,
@@ -16296,7 +18106,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 216249,
@@ -16305,7 +18116,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216250,
@@ -16314,7 +18126,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216251,
@@ -16323,7 +18136,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216252,
@@ -16332,7 +18146,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216253,
@@ -16341,7 +18156,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216254,
@@ -16350,7 +18166,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216255,
@@ -16359,7 +18176,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216256,
@@ -16368,7 +18186,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216257,
@@ -16377,7 +18196,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216259,
@@ -16386,7 +18206,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216260,
@@ -16395,7 +18216,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216294,
@@ -16404,7 +18226,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 216295,
@@ -16413,7 +18236,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216296,
@@ -16422,7 +18246,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 19.0
   },
   {
     "playerId": 216297,
@@ -16431,7 +18256,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216298,
@@ -16440,7 +18266,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216299,
@@ -16449,7 +18276,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216300,
@@ -16458,7 +18286,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216058,
@@ -16467,7 +18296,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216059,
@@ -16476,7 +18306,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216060,
@@ -16485,7 +18316,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216061,
@@ -16494,7 +18326,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216062,
@@ -16503,7 +18336,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216063,
@@ -16512,7 +18346,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216064,
@@ -16521,7 +18356,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216065,
@@ -16530,7 +18366,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216066,
@@ -16539,7 +18376,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216093,
@@ -16548,7 +18386,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216094,
@@ -16557,7 +18396,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216095,
@@ -16566,7 +18406,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216128,
@@ -16575,7 +18416,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 216129,
@@ -16584,7 +18426,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 3.0
   },
   {
     "playerId": 216130,
@@ -16593,7 +18436,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 36.0
   },
   {
     "playerId": 216131,
@@ -16602,7 +18446,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216132,
@@ -16611,7 +18456,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216133,
@@ -16620,7 +18466,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216134,
@@ -16629,7 +18476,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216160,
@@ -16638,7 +18486,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 4.2
+    "popularity": 4.2,
+    "fp_last": 6.0
   },
   {
     "playerId": 216161,
@@ -16647,7 +18496,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216184,
@@ -16656,7 +18506,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216185,
@@ -16665,7 +18516,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216213,
@@ -16674,7 +18526,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 9.8
+    "popularity": 9.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 216214,
@@ -16683,7 +18536,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216215,
@@ -16692,7 +18546,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216247,
@@ -16701,7 +18556,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 216248,
@@ -16710,7 +18566,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 216249,
@@ -16719,7 +18576,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216250,
@@ -16728,7 +18586,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216251,
@@ -16737,7 +18596,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216252,
@@ -16746,7 +18606,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216253,
@@ -16755,7 +18616,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216254,
@@ -16764,7 +18626,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216255,
@@ -16773,7 +18636,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216256,
@@ -16782,7 +18646,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216257,
@@ -16791,7 +18656,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216258,
@@ -16800,7 +18666,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 216259,
@@ -16809,7 +18676,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216260,
@@ -16818,7 +18686,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216294,
@@ -16827,7 +18696,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 216295,
@@ -16836,7 +18706,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216296,
@@ -16845,7 +18716,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 19.0
   },
   {
     "playerId": 216297,
@@ -16854,7 +18726,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216298,
@@ -16863,7 +18736,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216299,
@@ -16872,7 +18746,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216300,
@@ -16881,7 +18756,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216301,
@@ -16890,7 +18766,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216302,
@@ -16899,7 +18776,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216303,
@@ -16908,7 +18786,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216332,
@@ -16917,7 +18796,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216333,
@@ -16926,7 +18806,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216334,
@@ -16935,7 +18816,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216335,
@@ -16944,7 +18826,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216336,
@@ -16953,7 +18836,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216337,
@@ -16962,7 +18846,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216338,
@@ -16971,7 +18856,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216339,
@@ -16980,7 +18866,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216340,
@@ -16989,7 +18876,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216366,
@@ -16998,7 +18886,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216367,
@@ -17007,7 +18896,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216368,
@@ -17016,7 +18906,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 15.0
   },
   {
     "playerId": 216369,
@@ -17025,7 +18916,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216370,
@@ -17034,7 +18926,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216371,
@@ -17043,7 +18936,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 2.0
   },
   {
     "playerId": 216372,
@@ -17052,7 +18946,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216373,
@@ -17061,7 +18956,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216402,
@@ -17070,7 +18966,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 216403,
@@ -17079,7 +18976,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 28.0
   },
   {
     "playerId": 216404,
@@ -17088,7 +18986,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216405,
@@ -17097,7 +18996,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216406,
@@ -17106,7 +19006,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 7.0
   },
   {
     "playerId": 216407,
@@ -17115,7 +19016,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 1.0
   },
   {
     "playerId": 216436,
@@ -17124,7 +19026,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 216437,
@@ -17133,7 +19036,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 216438,
@@ -17142,7 +19046,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216439,
@@ -17151,7 +19056,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216440,
@@ -17160,7 +19066,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216470,
@@ -17169,7 +19076,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 216471,
@@ -17178,7 +19086,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216472,
@@ -17187,7 +19096,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 10.0
   },
   {
     "playerId": 216473,
@@ -17196,7 +19106,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216474,
@@ -17205,7 +19116,8 @@
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216475,
@@ -17214,7 +19126,8 @@
     "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213183,
@@ -17223,7 +19136,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 11.5,
-    "popularity": 58.7
+    "popularity": 58.7,
+    "fp_last": 199.0
   },
   {
     "playerId": 213182,
@@ -17232,7 +19146,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 11.0,
-    "popularity": 40.8
+    "popularity": 40.8,
+    "fp_last": 190.0
   },
   {
     "playerId": 213239,
@@ -17241,7 +19156,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 10.5,
-    "popularity": 37.5
+    "popularity": 37.5,
+    "fp_last": 171.0
   },
   {
     "playerId": 213181,
@@ -17250,7 +19166,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 10.5,
-    "popularity": 8.4
+    "popularity": 8.4,
+    "fp_last": 127.0
   },
   {
     "playerId": 213444,
@@ -17259,7 +19176,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 10.0,
-    "popularity": 7.6
+    "popularity": 7.6,
+    "fp_last": 146.0
   },
   {
     "playerId": 213207,
@@ -17268,7 +19186,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 9.0,
-    "popularity": 14.2
+    "popularity": 14.2,
+    "fp_last": 139.0
   },
   {
     "playerId": 213238,
@@ -17277,7 +19196,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 9.0,
-    "popularity": 12.4
+    "popularity": 12.4,
+    "fp_last": 96.0
   },
   {
     "playerId": 213618,
@@ -17286,7 +19206,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 9.0,
-    "popularity": 8.8
+    "popularity": 8.8,
+    "fp_last": 112.0
   },
   {
     "playerId": 213443,
@@ -17295,7 +19216,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 9.0,
-    "popularity": 2.4
+    "popularity": 2.4,
+    "fp_last": 136.0
   },
   {
     "playerId": 213180,
@@ -17304,7 +19226,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 9.0,
-    "popularity": 16.6
+    "popularity": 16.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213237,
@@ -17313,7 +19236,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 8.5,
-    "popularity": 8.6
+    "popularity": 8.6,
+    "fp_last": 126.0
   },
   {
     "playerId": 213442,
@@ -17322,7 +19246,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 8.5,
-    "popularity": 10.0
+    "popularity": 10.0,
+    "fp_last": 123.0
   },
   {
     "playerId": 213533,
@@ -17331,7 +19256,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 8.5,
-    "popularity": 6.1
+    "popularity": 6.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213268,
@@ -17340,7 +19266,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 8.5,
-    "popularity": 8.8
+    "popularity": 8.8,
+    "fp_last": 166.0
   },
   {
     "playerId": 213206,
@@ -17349,7 +19276,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 8.0,
-    "popularity": 5.7
+    "popularity": 5.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213532,
@@ -17358,7 +19286,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 8.0,
-    "popularity": 9.7
+    "popularity": 9.7,
+    "fp_last": 144.0
   },
   {
     "playerId": 213236,
@@ -17367,7 +19296,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 8.0,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 93.0
   },
   {
     "playerId": 213591,
@@ -17376,7 +19306,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 8.0,
-    "popularity": 11.6
+    "popularity": 11.6,
+    "fp_last": 162.0
   },
   {
     "playerId": 213127,
@@ -17385,7 +19316,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 8.0,
-    "popularity": 15.2
+    "popularity": 15.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213205,
@@ -17394,7 +19326,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 8.0,
-    "popularity": 9.2
+    "popularity": 9.2,
+    "fp_last": 61.0
   },
   {
     "playerId": 213617,
@@ -17403,7 +19336,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 8.0,
-    "popularity": 9.2
+    "popularity": 9.2,
+    "fp_last": 99.0
   },
   {
     "playerId": 213441,
@@ -17412,7 +19346,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 8.0,
-    "popularity": 5.7
+    "popularity": 5.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213204,
@@ -17421,7 +19356,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 67.0
   },
   {
     "playerId": 213406,
@@ -17430,7 +19366,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 4.1
+    "popularity": 4.1,
+    "fp_last": 137.0
   },
   {
     "playerId": 213266,
@@ -17439,7 +19376,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 3.0
+    "popularity": 3.0,
+    "fp_last": 84.0
   },
   {
     "playerId": 213235,
@@ -17448,7 +19386,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 27.0
+    "popularity": 27.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213616,
@@ -17457,7 +19396,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 3.2
+    "popularity": 3.2,
+    "fp_last": 117.0
   },
   {
     "playerId": 213126,
@@ -17466,7 +19406,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 3.0
+    "popularity": 3.0,
+    "fp_last": 21.0
   },
   {
     "playerId": 213440,
@@ -17475,7 +19416,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 3.0
+    "popularity": 3.0,
+    "fp_last": 81.0
   },
   {
     "playerId": 213404,
@@ -17484,7 +19426,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 7.8
+    "popularity": 7.8,
+    "fp_last": 120.0
   },
   {
     "playerId": 213405,
@@ -17493,7 +19436,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 138.0
   },
   {
     "playerId": 213265,
@@ -17502,7 +19446,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213321,
@@ -17511,7 +19456,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 3.7
+    "popularity": 3.7,
+    "fp_last": 131.0
   },
   {
     "playerId": 213177,
@@ -17520,7 +19466,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 2.3
+    "popularity": 2.3,
+    "fp_last": 98.0
   },
   {
     "playerId": 213178,
@@ -17529,7 +19476,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 17.5
+    "popularity": 17.5,
+    "fp_last": 147.0
   },
   {
     "playerId": 213179,
@@ -17538,7 +19486,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 88.0
   },
   {
     "playerId": 213267,
@@ -17547,7 +19496,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.5,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 110.0
   },
   {
     "playerId": 213201,
@@ -17556,7 +19506,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 4.5
+    "popularity": 4.5,
+    "fp_last": 38.0
   },
   {
     "playerId": 213234,
@@ -17565,7 +19516,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 5.4
+    "popularity": 5.4,
+    "fp_last": 100.0
   },
   {
     "playerId": 213264,
@@ -17574,7 +19526,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 79.0
   },
   {
     "playerId": 213531,
@@ -17583,7 +19536,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 90.0
   },
   {
     "playerId": 213614,
@@ -17592,7 +19546,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 85.0
   },
   {
     "playerId": 213123,
@@ -17601,7 +19556,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 2.6
+    "popularity": 2.6,
+    "fp_last": 8.0
   },
   {
     "playerId": 213124,
@@ -17610,7 +19566,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 3.3
+    "popularity": 3.3,
+    "fp_last": 82.0
   },
   {
     "playerId": 213125,
@@ -17619,7 +19576,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 50.0
   },
   {
     "playerId": 213203,
@@ -17628,7 +19586,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 33.0
   },
   {
     "playerId": 213613,
@@ -17637,7 +19596,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 2.4
+    "popularity": 2.4,
+    "fp_last": 68.0
   },
   {
     "playerId": 213292,
@@ -17646,7 +19606,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 120.0
   },
   {
     "playerId": 213294,
@@ -17655,7 +19616,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213293,
@@ -17664,7 +19626,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 3.1
+    "popularity": 3.1,
+    "fp_last": 134.0
   },
   {
     "playerId": 213403,
@@ -17673,7 +19636,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213156,
@@ -17682,7 +19646,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 120.0
   },
   {
     "playerId": 213202,
@@ -17691,7 +19656,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 77.0
   },
   {
     "playerId": 213318,
@@ -17700,7 +19666,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 2.9
+    "popularity": 2.9,
+    "fp_last": 101.0
   },
   {
     "playerId": 213317,
@@ -17709,7 +19676,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 2.3
+    "popularity": 2.3,
+    "fp_last": 78.0
   },
   {
     "playerId": 213319,
@@ -17718,7 +19686,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 24.0
   },
   {
     "playerId": 213320,
@@ -17727,7 +19696,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213175,
@@ -17736,7 +19706,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213176,
@@ -17745,7 +19716,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 71.0
   },
   {
     "playerId": 213615,
@@ -17754,7 +19726,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
-    "popularity": 5.3
+    "popularity": 5.3,
+    "fp_last": 119.0
   },
   {
     "playerId": 213200,
@@ -17763,7 +19736,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213199,
@@ -17772,7 +19746,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 32.0
+    "popularity": 32.0,
+    "fp_last": 122.0
   },
   {
     "playerId": 213471,
@@ -17781,7 +19756,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 111.0
   },
   {
     "playerId": 213233,
@@ -17790,7 +19766,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213530,
@@ -17799,7 +19776,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213529,
@@ -17808,7 +19786,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213590,
@@ -17817,7 +19796,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 2.3
+    "popularity": 2.3,
+    "fp_last": 99.0
   },
   {
     "playerId": 213379,
@@ -17826,7 +19806,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213118,
@@ -17835,7 +19816,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213119,
@@ -17844,7 +19826,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 54.0
   },
   {
     "playerId": 213120,
@@ -17853,7 +19836,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 2.9
+    "popularity": 2.9,
+    "fp_last": 72.0
   },
   {
     "playerId": 213121,
@@ -17862,7 +19846,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 94.0
   },
   {
     "playerId": 213122,
@@ -17871,7 +19856,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 50.0
   },
   {
     "playerId": 213439,
@@ -17880,7 +19866,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213349,
@@ -17889,7 +19876,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213437,
@@ -17898,7 +19886,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 2.9
+    "popularity": 2.9,
+    "fp_last": 69.0
   },
   {
     "playerId": 213230,
@@ -17907,7 +19896,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213232,
@@ -17916,7 +19906,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 3.2
+    "popularity": 3.2,
+    "fp_last": 58.0
   },
   {
     "playerId": 213380,
@@ -17925,7 +19916,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213290,
@@ -17934,7 +19926,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213289,
@@ -17943,7 +19936,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 80.0
   },
   {
     "playerId": 213291,
@@ -17952,7 +19946,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 32.0
   },
   {
     "playerId": 213402,
@@ -17961,7 +19956,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 106.0
   },
   {
     "playerId": 213401,
@@ -17970,7 +19966,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 46.0
   },
   {
     "playerId": 213154,
@@ -17979,7 +19976,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 82.0
   },
   {
     "playerId": 213155,
@@ -17988,7 +19986,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 75.0
   },
   {
     "playerId": 213314,
@@ -17997,7 +19996,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 4.4
+    "popularity": 4.4,
+    "fp_last": 102.0
   },
   {
     "playerId": 213316,
@@ -18006,7 +20006,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213315,
@@ -18015,7 +20016,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213527,
@@ -18024,7 +20026,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 52.0
   },
   {
     "playerId": 213528,
@@ -18033,7 +20036,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 54.0
   },
   {
     "playerId": 213173,
@@ -18042,7 +20046,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213174,
@@ -18051,7 +20056,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 56.0
   },
   {
     "playerId": 213438,
@@ -18060,7 +20066,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 4.4
+    "popularity": 4.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213472,
@@ -18069,7 +20076,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213589,
@@ -18078,7 +20086,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213231,
@@ -18087,7 +20096,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 11.0
   },
   {
     "playerId": 213612,
@@ -18096,7 +20106,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 101.0
   },
   {
     "playerId": 213152,
@@ -18105,7 +20116,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 38.0
   },
   {
     "playerId": 213153,
@@ -18114,7 +20126,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213347,
@@ -18123,7 +20136,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213374,
@@ -18132,7 +20146,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213378,
@@ -18141,7 +20156,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213558,
@@ -18150,7 +20166,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 68.0
   },
   {
     "playerId": 213432,
@@ -18159,7 +20176,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 6.9
+    "popularity": 6.9,
+    "fp_last": 127.0
   },
   {
     "playerId": 213433,
@@ -18168,7 +20186,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 70.0
   },
   {
     "playerId": 213470,
@@ -18177,7 +20196,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 54.0
   },
   {
     "playerId": 213116,
@@ -18186,7 +20206,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 7.3
+    "popularity": 7.3,
+    "fp_last": 108.0
   },
   {
     "playerId": 213117,
@@ -18195,7 +20216,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 82.0
   },
   {
     "playerId": 213346,
@@ -18204,7 +20226,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 2.5
+    "popularity": 2.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213376,
@@ -18213,7 +20236,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213375,
@@ -18222,7 +20246,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213377,
@@ -18231,7 +20256,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213501,
@@ -18240,7 +20266,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 62.0
   },
   {
     "playerId": 213523,
@@ -18249,7 +20276,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 35.0
   },
   {
     "playerId": 213526,
@@ -18258,7 +20286,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213152,
@@ -18267,7 +20296,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 38.0
   },
   {
     "playerId": 213153,
@@ -18276,7 +20306,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213434,
@@ -18285,7 +20316,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 9.6
+    "popularity": 9.6,
+    "fp_last": 92.0
   },
   {
     "playerId": 213168,
@@ -18294,7 +20326,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 5.4
+    "popularity": 5.4,
+    "fp_last": 112.0
   },
   {
     "playerId": 213169,
@@ -18303,7 +20336,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 6.8
+    "popularity": 6.8,
+    "fp_last": 76.0
   },
   {
     "playerId": 213170,
@@ -18312,7 +20346,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 3.3
+    "popularity": 3.3,
+    "fp_last": 73.0
   },
   {
     "playerId": 213171,
@@ -18321,7 +20356,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 9.5
+    "popularity": 9.5,
+    "fp_last": 100.0
   },
   {
     "playerId": 213172,
@@ -18330,7 +20366,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 8.9
+    "popularity": 8.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213588,
@@ -18339,7 +20376,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213524,
@@ -18348,7 +20386,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213522,
@@ -18357,7 +20396,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 15.0
   },
   {
     "playerId": 213525,
@@ -18366,7 +20406,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 36.0
   },
   {
     "playerId": 213195,
@@ -18375,7 +20416,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 3.4
+    "popularity": 3.4,
+    "fp_last": 61.0
   },
   {
     "playerId": 213196,
@@ -18384,7 +20426,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213197,
@@ -18393,7 +20436,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 66.0
   },
   {
     "playerId": 213198,
@@ -18402,7 +20446,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 6.0
+    "popularity": 6.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213557,
@@ -18411,7 +20456,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 99.0
   },
   {
     "playerId": 213587,
@@ -18420,7 +20466,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213430,
@@ -18429,7 +20476,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213431,
@@ -18438,7 +20486,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 5.1
+    "popularity": 5.1,
+    "fp_last": 112.0
   },
   {
     "playerId": 213429,
@@ -18447,7 +20496,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 46.0
   },
   {
     "playerId": 213227,
@@ -18456,7 +20506,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 14.9
+    "popularity": 14.9,
+    "fp_last": 90.0
   },
   {
     "playerId": 213228,
@@ -18465,7 +20516,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 6.0
+    "popularity": 6.0,
+    "fp_last": 84.0
   },
   {
     "playerId": 213229,
@@ -18474,7 +20526,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 7.9
+    "popularity": 7.9,
+    "fp_last": 42.0
   },
   {
     "playerId": 213313,
@@ -18483,7 +20536,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 25.0
   },
   {
     "playerId": 213435,
@@ -18492,7 +20546,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 5.0
   },
   {
     "playerId": 213348,
@@ -18501,7 +20556,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213499,
@@ -18510,7 +20566,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 36.0
   },
   {
     "playerId": 213469,
@@ -18519,7 +20576,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 71.0
   },
   {
     "playerId": 213260,
@@ -18528,7 +20586,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 3.8
+    "popularity": 3.8,
+    "fp_last": 97.0
   },
   {
     "playerId": 213261,
@@ -18537,7 +20596,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 46.0
   },
   {
     "playerId": 213262,
@@ -18546,7 +20606,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 69.0
   },
   {
     "playerId": 213263,
@@ -18555,7 +20616,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213400,
@@ -18564,7 +20626,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 5.0
   },
   {
     "playerId": 213500,
@@ -18573,7 +20636,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 53.0
   },
   {
     "playerId": 213286,
@@ -18582,7 +20646,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 6.6
+    "popularity": 6.6,
+    "fp_last": 128.0
   },
   {
     "playerId": 213287,
@@ -18591,7 +20656,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 85.0
   },
   {
     "playerId": 213288,
@@ -18600,7 +20666,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 59.0
   },
   {
     "playerId": 213308,
@@ -18609,7 +20676,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213311,
@@ -18618,7 +20686,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 6.0
   },
   {
     "playerId": 213494,
@@ -18627,7 +20696,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213582,
@@ -18636,7 +20706,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 1.0
   },
   {
     "playerId": 213556,
@@ -18645,7 +20716,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 60.0
   },
   {
     "playerId": 213112,
@@ -18654,7 +20726,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 11.5
+    "popularity": 11.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213113,
@@ -18663,7 +20736,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 3.1
+    "popularity": 3.1,
+    "fp_last": 77.0
   },
   {
     "playerId": 213114,
@@ -18672,7 +20746,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 9.6
+    "popularity": 9.6,
+    "fp_last": 92.0
   },
   {
     "playerId": 213115,
@@ -18681,7 +20756,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 32.0
   },
   {
     "playerId": 213345,
@@ -18690,7 +20766,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213310,
@@ -18699,7 +20776,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 3.0
+    "popularity": 3.0,
+    "fp_last": 89.0
   },
   {
     "playerId": 213344,
@@ -18708,7 +20786,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213519,
@@ -18717,7 +20796,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 26.0
   },
   {
     "playerId": 213555,
@@ -18726,7 +20806,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 42.0
   },
   {
     "playerId": 213554,
@@ -18735,7 +20816,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 78.0
   },
   {
     "playerId": 213149,
@@ -18744,7 +20826,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 33.0
   },
   {
     "playerId": 213150,
@@ -18753,7 +20836,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 18.0
   },
   {
     "playerId": 213151,
@@ -18762,7 +20846,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 60.0
   },
   {
     "playerId": 213343,
@@ -18771,7 +20856,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213163,
@@ -18780,7 +20866,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 99.0
   },
   {
     "playerId": 213164,
@@ -18789,7 +20876,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 24.0
   },
   {
     "playerId": 213165,
@@ -18798,7 +20886,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 42.0
   },
   {
     "playerId": 213166,
@@ -18807,7 +20896,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 3.3
+    "popularity": 3.3,
+    "fp_last": 81.0
   },
   {
     "playerId": 213167,
@@ -18816,7 +20906,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 23.0
   },
   {
     "playerId": 213521,
@@ -18825,7 +20916,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 2.0
   },
   {
     "playerId": 213192,
@@ -18834,7 +20926,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 3.8
+    "popularity": 3.8,
+    "fp_last": 37.0
   },
   {
     "playerId": 213193,
@@ -18843,7 +20936,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 5.9
+    "popularity": 5.9,
+    "fp_last": 92.0
   },
   {
     "playerId": 213194,
@@ -18852,7 +20946,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 4.7
+    "popularity": 4.7,
+    "fp_last": 68.0
   },
   {
     "playerId": 213518,
@@ -18861,7 +20956,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213583,
@@ -18870,7 +20966,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 19.0
   },
   {
     "playerId": 213467,
@@ -18879,7 +20976,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213468,
@@ -18888,7 +20986,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213496,
@@ -18897,7 +20996,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 71.0
   },
   {
     "playerId": 213495,
@@ -18906,7 +21006,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213498,
@@ -18915,7 +21016,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 54.0
   },
   {
     "playerId": 213497,
@@ -18924,7 +21026,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 46.0
   },
   {
     "playerId": 213259,
@@ -18933,7 +21036,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 54.0
   },
   {
     "playerId": 213312,
@@ -18942,7 +21046,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 54.0
   },
   {
     "playerId": 213309,
@@ -18951,7 +21056,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 56.0
   },
   {
     "playerId": 213398,
@@ -18960,7 +21066,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 2.6
+    "popularity": 2.6,
+    "fp_last": 97.0
   },
   {
     "playerId": 213397,
@@ -18969,7 +21076,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 6.2
+    "popularity": 6.2,
+    "fp_last": 107.0
   },
   {
     "playerId": 213515,
@@ -18978,7 +21086,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 7.1
+    "popularity": 7.1,
+    "fp_last": 104.0
   },
   {
     "playerId": 213399,
@@ -18987,7 +21096,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 3.3
+    "popularity": 3.3,
+    "fp_last": 110.0
   },
   {
     "playerId": 213517,
@@ -18996,7 +21106,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 6.9
+    "popularity": 6.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213520,
@@ -19005,7 +21116,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 81.0
   },
   {
     "playerId": 213284,
@@ -19014,7 +21126,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 48.0
   },
   {
     "playerId": 213311,
@@ -19023,7 +21136,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 6.0
   },
   {
     "playerId": 213312,
@@ -19032,7 +21146,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 54.0
   },
   {
     "playerId": 213428,
@@ -19041,7 +21156,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 3.0
   },
   {
     "playerId": 213398,
@@ -19050,7 +21166,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 2.6
+    "popularity": 2.6,
+    "fp_last": 97.0
   },
   {
     "playerId": 213582,
@@ -19059,7 +21176,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 1.0
   },
   {
     "playerId": 213584,
@@ -19068,7 +21186,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 13.0
   },
   {
     "playerId": 213583,
@@ -19077,7 +21196,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 19.0
   },
   {
     "playerId": 213585,
@@ -19086,7 +21206,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 31.0
   },
   {
     "playerId": 213343,
@@ -19095,7 +21216,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213344,
@@ -19104,7 +21226,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213345,
@@ -19113,7 +21236,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213397,
@@ -19122,7 +21246,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 6.2
+    "popularity": 6.2,
+    "fp_last": 107.0
   },
   {
     "playerId": 213610,
@@ -19131,7 +21256,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 18.3
+    "popularity": 18.3,
+    "fp_last": 86.0
   },
   {
     "playerId": 213607,
@@ -19140,7 +21266,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 11.0
   },
   {
     "playerId": 213467,
@@ -19149,7 +21276,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213468,
@@ -19158,7 +21286,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213606,
@@ -19167,7 +21296,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 3.3
+    "popularity": 3.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213611,
@@ -19176,7 +21306,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 9.3
+    "popularity": 9.3,
+    "fp_last": 101.0
   },
   {
     "playerId": 213494,
@@ -19185,7 +21316,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213497,
@@ -19194,7 +21326,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 46.0
   },
   {
     "playerId": 213496,
@@ -19203,7 +21336,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.5,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 71.0
   },
   {
     "playerId": 213419,
@@ -19212,7 +21346,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 10.0
   },
   {
     "playerId": 213422,
@@ -19221,7 +21356,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 61.0
   },
   {
     "playerId": 213418,
@@ -19230,7 +21366,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 3.3
+    "popularity": 3.3,
+    "fp_last": 64.0
   },
   {
     "playerId": 213553,
@@ -19239,7 +21376,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 39.0
   },
   {
     "playerId": 213576,
@@ -19248,7 +21386,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 28.0
   },
   {
     "playerId": 213580,
@@ -19257,7 +21396,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 5.0
   },
   {
     "playerId": 213108,
@@ -19266,7 +21406,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 62.0
   },
   {
     "playerId": 213109,
@@ -19275,7 +21416,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 96.0
   },
   {
     "playerId": 213110,
@@ -19284,7 +21426,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 16.0
   },
   {
     "playerId": 213111,
@@ -19293,7 +21436,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 35.0
   },
   {
     "playerId": 213421,
@@ -19302,7 +21446,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 71.0
   },
   {
     "playerId": 213550,
@@ -19311,7 +21456,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 23.0
   },
   {
     "playerId": 213552,
@@ -19320,7 +21466,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213140,
@@ -19329,7 +21476,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 2.4
+    "popularity": 2.4,
+    "fp_last": 104.0
   },
   {
     "playerId": 213141,
@@ -19338,7 +21486,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 101.0
   },
   {
     "playerId": 213142,
@@ -19347,7 +21496,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 82.0
   },
   {
     "playerId": 213143,
@@ -19356,7 +21506,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213144,
@@ -19365,7 +21516,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 10.0
   },
   {
     "playerId": 213145,
@@ -19374,7 +21526,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213146,
@@ -19383,7 +21536,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213147,
@@ -19392,7 +21546,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 81.0
   },
   {
     "playerId": 213148,
@@ -19401,7 +21556,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 91.0
   },
   {
     "playerId": 213416,
@@ -19410,7 +21566,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 38.0
   },
   {
     "playerId": 213161,
@@ -19419,7 +21576,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 21.0
   },
   {
     "playerId": 213188,
@@ -19428,7 +21586,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 3.0
   },
   {
     "playerId": 213189,
@@ -19437,7 +21596,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213190,
@@ -19446,7 +21606,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 4.4
+    "popularity": 4.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213191,
@@ -19455,7 +21616,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213461,
@@ -19464,7 +21626,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 11.0
   },
   {
     "playerId": 213551,
@@ -19473,7 +21636,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 54.0
   },
   {
     "playerId": 213488,
@@ -19482,7 +21646,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 110.0
   },
   {
     "playerId": 213217,
@@ -19491,7 +21656,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 2.0
+    "popularity": 2.0,
+    "fp_last": 31.0
   },
   {
     "playerId": 213218,
@@ -19500,7 +21666,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 4.0
   },
   {
     "playerId": 213424,
@@ -19509,7 +21676,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 15.0
   },
   {
     "playerId": 213511,
@@ -19518,7 +21686,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 9.4
+    "popularity": 9.4,
+    "fp_last": 91.0
   },
   {
     "playerId": 213510,
@@ -19527,7 +21696,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 7.2
+    "popularity": 7.2,
+    "fp_last": 98.0
   },
   {
     "playerId": 213514,
@@ -19536,7 +21706,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 32.0
   },
   {
     "playerId": 213250,
@@ -19545,7 +21716,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 82.0
   },
   {
     "playerId": 213251,
@@ -19554,7 +21726,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213252,
@@ -19563,7 +21736,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 63.0
   },
   {
     "playerId": 213253,
@@ -19572,7 +21746,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 31.0
   },
   {
     "playerId": 213254,
@@ -19581,7 +21756,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 64.0
   },
   {
     "playerId": 213255,
@@ -19590,7 +21766,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213256,
@@ -19599,7 +21776,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213257,
@@ -19608,7 +21786,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 10.0
   },
   {
     "playerId": 213258,
@@ -19617,7 +21796,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 3.1
+    "popularity": 3.1,
+    "fp_last": 66.0
   },
   {
     "playerId": 213423,
@@ -19626,7 +21806,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213420,
@@ -19635,7 +21816,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 53.0
   },
   {
     "playerId": 213282,
@@ -19644,7 +21826,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 3.3
+    "popularity": 3.3,
+    "fp_last": 79.0
   },
   {
     "playerId": 213283,
@@ -19653,7 +21836,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 63.0
   },
   {
     "playerId": 213303,
@@ -19662,7 +21846,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 20.0
   },
   {
     "playerId": 213304,
@@ -19671,7 +21856,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 53.0
   },
   {
     "playerId": 213305,
@@ -19680,7 +21866,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 71.0
   },
   {
     "playerId": 213306,
@@ -19689,7 +21876,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 5.2
+    "popularity": 5.2,
+    "fp_last": 87.0
   },
   {
     "playerId": 213307,
@@ -19698,7 +21886,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213574,
@@ -19707,7 +21896,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213577,
@@ -19716,7 +21906,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213575,
@@ -19725,7 +21916,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 4.6
+    "popularity": 4.6,
+    "fp_last": 90.0
   },
   {
     "playerId": 213579,
@@ -19734,7 +21926,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 24.0
   },
   {
     "playerId": 213581,
@@ -19743,7 +21936,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 16.0
   },
   {
     "playerId": 213578,
@@ -19752,7 +21946,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213340,
@@ -19761,7 +21956,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213341,
@@ -19770,7 +21966,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213342,
@@ -19779,7 +21976,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213512,
@@ -19788,7 +21986,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 92.0
   },
   {
     "playerId": 213490,
@@ -19797,7 +21996,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 60.0
   },
   {
     "playerId": 213462,
@@ -19806,7 +22006,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 2.3
+    "popularity": 2.3,
+    "fp_last": 89.0
   },
   {
     "playerId": 213466,
@@ -19815,7 +22016,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 80.0
   },
   {
     "playerId": 213485,
@@ -19824,7 +22026,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 86.0
   },
   {
     "playerId": 213487,
@@ -19833,7 +22036,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213486,
@@ -19842,7 +22046,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 33.0
   },
   {
     "playerId": 213369,
@@ -19851,7 +22056,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213370,
@@ -19860,7 +22066,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213371,
@@ -19869,7 +22076,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213372,
@@ -19878,7 +22086,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213373,
@@ -19887,7 +22096,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213489,
@@ -19896,7 +22106,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 43.0
   },
   {
     "playerId": 213492,
@@ -19905,7 +22116,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 60.0
   },
   {
     "playerId": 213493,
@@ -19914,7 +22126,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 97.0
   },
   {
     "playerId": 213423,
@@ -19923,7 +22136,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213424,
@@ -19932,7 +22146,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 15.0
   },
   {
     "playerId": 213575,
@@ -19941,7 +22156,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 4.6
+    "popularity": 4.6,
+    "fp_last": 90.0
   },
   {
     "playerId": 213461,
@@ -19950,7 +22166,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 11.0
   },
   {
     "playerId": 213462,
@@ -19959,7 +22176,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 2.3
+    "popularity": 2.3,
+    "fp_last": 89.0
   },
   {
     "playerId": 213463,
@@ -19968,7 +22186,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 9.6
+    "popularity": 9.6,
+    "fp_last": 127.0
   },
   {
     "playerId": 213464,
@@ -19977,7 +22196,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 10.0
   },
   {
     "playerId": 213465,
@@ -19986,7 +22206,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 106.0
   },
   {
     "playerId": 213466,
@@ -19995,7 +22216,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 80.0
   },
   {
     "playerId": 213493,
@@ -20004,7 +22226,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 97.0
   },
   {
     "playerId": 213484,
@@ -20013,7 +22236,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 91.0
   },
   {
     "playerId": 213485,
@@ -20022,7 +22246,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 86.0
   },
   {
     "playerId": 213486,
@@ -20031,7 +22256,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 33.0
   },
   {
     "playerId": 213487,
@@ -20040,7 +22266,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213488,
@@ -20049,7 +22276,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 110.0
   },
   {
     "playerId": 213489,
@@ -20058,7 +22286,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 43.0
   },
   {
     "playerId": 213490,
@@ -20067,7 +22296,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 60.0
   },
   {
     "playerId": 213491,
@@ -20076,7 +22306,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 21.0
   },
   {
     "playerId": 213492,
@@ -20085,7 +22316,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 60.0
   },
   {
     "playerId": 213566,
@@ -20094,7 +22326,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 46.0
   },
   {
     "playerId": 213101,
@@ -20103,7 +22336,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 12.0
   },
   {
     "playerId": 213102,
@@ -20112,7 +22346,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213103,
@@ -20121,7 +22356,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213104,
@@ -20130,7 +22366,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213105,
@@ -20139,7 +22376,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 78.0
   },
   {
     "playerId": 213106,
@@ -20148,7 +22386,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213133,
@@ -20157,7 +22396,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 6.0
   },
   {
     "playerId": 213134,
@@ -20166,7 +22406,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213135,
@@ -20175,7 +22416,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 33.0
   },
   {
     "playerId": 213136,
@@ -20184,7 +22426,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213137,
@@ -20193,7 +22436,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 95.0
   },
   {
     "playerId": 213138,
@@ -20202,7 +22446,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 61.0
   },
   {
     "playerId": 213139,
@@ -20211,7 +22456,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 51.0
   },
   {
     "playerId": 213540,
@@ -20220,7 +22466,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 35.0
   },
   {
     "playerId": 213185,
@@ -20229,7 +22476,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213186,
@@ -20238,7 +22486,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 87.0
   },
   {
     "playerId": 213187,
@@ -20247,7 +22496,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213568,
@@ -20256,7 +22506,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 40.0
   },
   {
     "playerId": 213567,
@@ -20265,7 +22516,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213549,
@@ -20274,7 +22526,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213214,
@@ -20283,7 +22536,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213215,
@@ -20292,7 +22546,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213216,
@@ -20301,7 +22556,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213539,
@@ -20310,7 +22566,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 67.0
   },
   {
     "playerId": 213249,
@@ -20319,7 +22576,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 42.0
   },
   {
     "playerId": 213548,
@@ -20328,7 +22586,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 12.0
   },
   {
     "playerId": 213273,
@@ -20337,7 +22596,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 10.3
+    "popularity": 10.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213274,
@@ -20346,7 +22606,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 3.4
+    "popularity": 3.4,
+    "fp_last": 11.0
   },
   {
     "playerId": 213275,
@@ -20355,7 +22616,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213276,
@@ -20364,7 +22626,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 8.0
   },
   {
     "playerId": 213277,
@@ -20373,7 +22636,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213278,
@@ -20382,7 +22646,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 49.0
   },
   {
     "playerId": 213279,
@@ -20391,7 +22656,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213280,
@@ -20400,7 +22666,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213281,
@@ -20409,7 +22676,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 67.0
   },
   {
     "playerId": 213547,
@@ -20418,7 +22686,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 69.0
   },
   {
     "playerId": 213546,
@@ -20427,7 +22696,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213299,
@@ -20436,7 +22706,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 77.0
   },
   {
     "playerId": 213300,
@@ -20445,7 +22716,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 20.0
   },
   {
     "playerId": 213301,
@@ -20454,7 +22726,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 65.0
   },
   {
     "playerId": 213302,
@@ -20463,7 +22736,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213545,
@@ -20472,7 +22746,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 7.0
   },
   {
     "playerId": 213328,
@@ -20481,7 +22756,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213329,
@@ -20490,7 +22766,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 4.4
+    "popularity": 4.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213330,
@@ -20499,7 +22776,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213331,
@@ -20508,7 +22786,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213332,
@@ -20517,7 +22796,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213333,
@@ -20526,7 +22806,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 3.5
+    "popularity": 3.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213334,
@@ -20535,7 +22816,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213335,
@@ -20544,7 +22826,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213336,
@@ -20553,7 +22836,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213337,
@@ -20562,7 +22846,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213338,
@@ -20571,7 +22856,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213339,
@@ -20580,7 +22866,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213410,
@@ -20589,7 +22876,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213411,
@@ -20598,7 +22886,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213412,
@@ -20607,7 +22896,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213413,
@@ -20616,7 +22906,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213414,
@@ -20625,7 +22916,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213415,
@@ -20634,7 +22926,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 32.0
   },
   {
     "playerId": 213542,
@@ -20643,7 +22936,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 36.0
   },
   {
     "playerId": 213450,
@@ -20652,7 +22946,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213451,
@@ -20661,7 +22956,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 11.4
+    "popularity": 11.4,
+    "fp_last": 5.0
   },
   {
     "playerId": 213452,
@@ -20670,7 +22966,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213453,
@@ -20679,7 +22976,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 31.0
   },
   {
     "playerId": 213454,
@@ -20688,7 +22986,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 59.0
   },
   {
     "playerId": 213455,
@@ -20697,7 +22996,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213456,
@@ -20706,7 +23006,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213457,
@@ -20715,7 +23016,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 40.0
   },
   {
     "playerId": 213458,
@@ -20724,7 +23026,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 6.0
   },
   {
     "playerId": 213459,
@@ -20733,7 +23036,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 15.0
   },
   {
     "playerId": 213460,
@@ -20742,7 +23046,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213544,
@@ -20751,7 +23056,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 95.0
   },
   {
     "playerId": 213543,
@@ -20760,7 +23066,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 81.0
   },
   {
     "playerId": 213477,
@@ -20769,7 +23076,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213478,
@@ -20778,7 +23086,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 52.0
   },
   {
     "playerId": 213479,
@@ -20787,7 +23096,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 19.0
   },
   {
     "playerId": 213480,
@@ -20796,7 +23106,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213481,
@@ -20805,7 +23116,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213482,
@@ -20814,7 +23126,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 5.0
   },
   {
     "playerId": 213413,
@@ -20823,7 +23136,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213414,
@@ -20832,7 +23146,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213415,
@@ -20841,7 +23156,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 32.0
   },
   {
     "playerId": 213450,
@@ -20850,7 +23166,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213451,
@@ -20859,7 +23176,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 11.4
+    "popularity": 11.4,
+    "fp_last": 5.0
   },
   {
     "playerId": 213452,
@@ -20868,7 +23186,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 2.1
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213453,
@@ -20877,7 +23196,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 31.0
   },
   {
     "playerId": 213454,
@@ -20886,7 +23206,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 59.0
   },
   {
     "playerId": 213455,
@@ -20895,7 +23216,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213456,
@@ -20904,7 +23226,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213457,
@@ -20913,7 +23236,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 40.0
   },
   {
     "playerId": 213458,
@@ -20922,7 +23246,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 6.0
   },
   {
     "playerId": 213459,
@@ -20931,7 +23256,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 15.0
   },
   {
     "playerId": 213460,
@@ -20940,7 +23266,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213596,
@@ -20949,7 +23276,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 16.0
   },
   {
     "playerId": 213477,
@@ -20958,7 +23286,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213478,
@@ -20967,7 +23296,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 52.0
   },
   {
     "playerId": 213479,
@@ -20976,7 +23306,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 19.0
   },
   {
     "playerId": 213480,
@@ -20985,7 +23316,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.1
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213481,
@@ -20994,7 +23326,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213482,
@@ -21003,7 +23336,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 5.0
   },
   {
     "playerId": 213483,
@@ -21012,7 +23346,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 37.0
   },
   {
     "playerId": 213505,
@@ -21021,7 +23356,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213506,
@@ -21030,7 +23366,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 21.0
   },
   {
     "playerId": 213507,
@@ -21039,7 +23376,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 9.0
   },
   {
     "playerId": 213508,
@@ -21048,7 +23386,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 44.0
   },
   {
     "playerId": 213509,
@@ -21057,7 +23396,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213539,
@@ -21066,7 +23406,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 67.0
   },
   {
     "playerId": 213540,
@@ -21075,7 +23416,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 35.0
   },
   {
     "playerId": 213541,
@@ -21084,7 +23426,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 11.0
   },
   {
     "playerId": 213542,
@@ -21093,7 +23436,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 36.0
   },
   {
     "playerId": 213543,
@@ -21102,7 +23446,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 81.0
   },
   {
     "playerId": 213544,
@@ -21111,7 +23456,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 95.0
   },
   {
     "playerId": 213545,
@@ -21120,7 +23466,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 7.0
   },
   {
     "playerId": 213546,
@@ -21129,7 +23476,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213547,
@@ -21138,7 +23486,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 69.0
   },
   {
     "playerId": 213548,
@@ -21147,7 +23496,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 12.0
   },
   {
     "playerId": 213549,
@@ -21156,7 +23506,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213566,
@@ -21165,7 +23516,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 46.0
   },
   {
     "playerId": 213567,
@@ -21174,7 +23526,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213568,
@@ -21183,7 +23536,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.2
+    "popularity": 0.2,
+    "fp_last": 40.0
   },
   {
     "playerId": 213569,
@@ -21192,7 +23546,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213570,
@@ -21201,7 +23556,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 2.0
   },
   {
     "playerId": 213571,
@@ -21210,7 +23566,8 @@
     "position": "MID",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213572,
@@ -21219,7 +23576,8 @@
     "position": "FWD",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213573,
@@ -21228,7 +23586,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 41.0
   },
   {
     "playerId": 213595,
@@ -21237,7 +23596,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.5,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213092,
@@ -21246,7 +23606,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 7.2
+    "popularity": 7.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213093,
@@ -21255,7 +23616,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 2.2
+    "popularity": 2.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213094,
@@ -21264,7 +23626,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213095,
@@ -21273,7 +23636,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213096,
@@ -21282,7 +23646,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213097,
@@ -21291,7 +23656,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 3.0
   },
   {
     "playerId": 213129,
@@ -21300,7 +23666,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 10.0
   },
   {
     "playerId": 213130,
@@ -21309,7 +23676,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213158,
@@ -21318,7 +23686,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213184,
@@ -21327,7 +23696,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213208,
@@ -21336,7 +23706,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.8
+    "popularity": 1.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213209,
@@ -21345,7 +23716,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.3
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213210,
@@ -21354,7 +23726,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213211,
@@ -21363,7 +23736,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 2.0
   },
   {
     "playerId": 213212,
@@ -21372,7 +23746,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.4
+    "popularity": 0.4,
+    "fp_last": 2.0
   },
   {
     "playerId": 213241,
@@ -21381,7 +23756,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 22.0
   },
   {
     "playerId": 213242,
@@ -21390,7 +23766,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213269,
@@ -21399,7 +23776,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 15.5
+    "popularity": 15.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213270,
@@ -21408,7 +23786,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213272,
@@ -21417,7 +23796,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213295,
@@ -21426,7 +23806,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 2.7
+    "popularity": 2.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213296,
@@ -21435,7 +23816,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213297,
@@ -21444,7 +23826,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.5
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213298,
@@ -21453,7 +23836,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213322,
@@ -21462,7 +23846,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 7.6
+    "popularity": 7.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213323,
@@ -21471,7 +23856,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213324,
@@ -21480,7 +23866,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213325,
@@ -21489,7 +23876,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213326,
@@ -21498,7 +23886,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.3
+    "popularity": 1.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213383,
@@ -21507,7 +23896,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213408,
@@ -21516,7 +23906,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 213409,
@@ -21525,7 +23916,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213445,
@@ -21534,7 +23926,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 11.0
   },
   {
     "playerId": 213446,
@@ -21543,7 +23936,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213447,
@@ -21552,7 +23946,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 1.0
   },
   {
     "playerId": 213448,
@@ -21561,7 +23956,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 2.0
   },
   {
     "playerId": 213449,
@@ -21570,7 +23966,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213474,
@@ -21579,7 +23976,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213475,
@@ -21588,7 +23986,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213476,
@@ -21597,7 +23996,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213502,
@@ -21606,7 +24006,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 17.0
   },
   {
     "playerId": 213503,
@@ -21615,7 +24016,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 2.0
   },
   {
     "playerId": 213504,
@@ -21624,7 +24026,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213534,
@@ -21633,7 +24036,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 4.3
+    "popularity": 4.3,
+    "fp_last": 47.0
   },
   {
     "playerId": 213535,
@@ -21642,7 +24046,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 4.0
   },
   {
     "playerId": 213536,
@@ -21651,7 +24056,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 7.0
   },
   {
     "playerId": 213537,
@@ -21660,7 +24066,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 47.0
   },
   {
     "playerId": 213538,
@@ -21669,7 +24076,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213560,
@@ -21678,7 +24086,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 7.5
+    "popularity": 7.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213561,
@@ -21687,7 +24096,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 2.0
   },
   {
     "playerId": 213562,
@@ -21696,7 +24106,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 3.0
   },
   {
     "playerId": 213563,
@@ -21705,7 +24116,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213564,
@@ -21714,7 +24126,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213409,
@@ -21723,7 +24136,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213445,
@@ -21732,7 +24146,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 2.8
+    "popularity": 2.8,
+    "fp_last": 11.0
   },
   {
     "playerId": 213446,
@@ -21741,7 +24156,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213447,
@@ -21750,7 +24166,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.8
+    "popularity": 0.8,
+    "fp_last": 1.0
   },
   {
     "playerId": 213448,
@@ -21759,7 +24176,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 2.0
   },
   {
     "playerId": 213449,
@@ -21768,7 +24186,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.4
+    "popularity": 1.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213473,
@@ -21777,7 +24196,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.2
+    "popularity": 1.2,
+    "fp_last": 0.0
   },
   {
     "playerId": 213474,
@@ -21786,7 +24206,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.7
+    "popularity": 0.7,
+    "fp_last": 0.0
   },
   {
     "playerId": 213475,
@@ -21795,7 +24216,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213476,
@@ -21804,7 +24226,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.5
+    "popularity": 1.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213502,
@@ -21813,7 +24236,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 17.0
   },
   {
     "playerId": 213503,
@@ -21822,7 +24246,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 2.0
   },
   {
     "playerId": 213504,
@@ -21831,7 +24256,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213534,
@@ -21840,7 +24266,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 4.3
+    "popularity": 4.3,
+    "fp_last": 47.0
   },
   {
     "playerId": 213535,
@@ -21849,7 +24276,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 4.0
   },
   {
     "playerId": 213536,
@@ -21858,7 +24286,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 7.0
   },
   {
     "playerId": 213537,
@@ -21867,7 +24296,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 47.0
   },
   {
     "playerId": 213538,
@@ -21876,7 +24306,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.9
+    "popularity": 0.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213560,
@@ -21885,7 +24316,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 7.5
+    "popularity": 7.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213561,
@@ -21894,7 +24326,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.1
+    "popularity": 1.1,
+    "fp_last": 2.0
   },
   {
     "playerId": 213562,
@@ -21903,7 +24336,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.7
+    "popularity": 1.7,
+    "fp_last": 3.0
   },
   {
     "playerId": 213563,
@@ -21912,7 +24346,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.9
+    "popularity": 1.9,
+    "fp_last": 0.0
   },
   {
     "playerId": 213564,
@@ -21921,7 +24356,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 0.0
   },
   {
     "playerId": 213565,
@@ -21930,7 +24366,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.6
+    "popularity": 0.6,
+    "fp_last": 11.0
   },
   {
     "playerId": 213592,
@@ -21939,7 +24376,8 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 10.9
+    "popularity": 10.9,
+    "fp_last": 10.0
   },
   {
     "playerId": 213593,
@@ -21948,7 +24386,8 @@
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.0
+    "popularity": 1.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 213594,
@@ -21957,6 +24396,7 @@
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.6
+    "popularity": 1.6,
+    "fp_last": 1.0
   }
 ]

--- a/data/cache/top4_players.json
+++ b/data/cache/top4_players.json
@@ -1,21625 +1,21962 @@
 [
   {
-    "playerId": 108390,
-    "fullName": "Thibaut Courtois",
-    "clubName": "Real Madrid",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 404839,
-    "fullName": "Andriy Lunin",
-    "clubName": "Real Madrid",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 192279,
-    "fullName": "Kepa Arrizabalaga",
-    "clubName": "Real Madrid",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 568154,
-    "fullName": "Lucas Cañizares",
-    "clubName": "Real Madrid",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 717952,
-    "fullName": "Mario de Luis",
-    "clubName": "Real Madrid",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 926850,
-    "fullName": "Diego Piñeiro",
-    "clubName": "Real Madrid",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1055220,
-    "fullName": "Fran González",
-    "clubName": "Real Madrid",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 401530,
-    "fullName": "Éder Militão",
-    "clubName": "Real Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 86202,
-    "fullName": "Antonio Rüdiger",
-    "clubName": "Real Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 59016,
-    "fullName": "David Alaba",
-    "clubName": "Real Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 58884,
-    "fullName": "Nacho Fernández",
-    "clubName": "Real Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 652330,
-    "fullName": "Álvaro Carrillo",
-    "clubName": "Real Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 646745,
-    "fullName": "Edgar Pujol",
-    "clubName": "Real Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 948278,
-    "fullName": "Jacobo Ramón",
-    "clubName": "Real Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 291417,
-    "fullName": "Ferland Mendy",
-    "clubName": "Real Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 341264,
-    "fullName": "Fran García",
-    "clubName": "Real Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 138927,
-    "fullName": "Daniel Carvajal",
-    "clubName": "Real Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 221316,
-    "fullName": "Lucas Vázquez",
-    "clubName": "Real Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 743587,
-    "fullName": "Vinícius Tobias",
-    "clubName": "Real Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 280730,
-    "fullName": "Álvaro Odriozola",
-    "clubName": "Real Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 413112,
-    "fullName": "Aurélien Tchouaméni",
-    "clubName": "Real Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 948273,
-    "fullName": "Mario Martín",
-    "clubName": "Real Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 369081,
-    "fullName": "Federico Valverde",
-    "clubName": "Real Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 640428,
-    "fullName": "Eduardo Camavinga",
-    "clubName": "Real Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 31909,
-    "fullName": "Toni Kroos",
-    "clubName": "Real Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 27992,
-    "fullName": "Luka Modrić",
-    "clubName": "Real Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 319745,
-    "fullName": "Dani Ceballos",
-    "clubName": "Real Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 337917,
-    "fullName": "Théo Zidane",
-    "clubName": "Real Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 581678,
-    "fullName": "Jude Bellingham",
-    "clubName": "Real Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 861410,
-    "fullName": "Arda Güler",
-    "clubName": "Real Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 948294,
-    "fullName": "Nico Paz",
-    "clubName": "Real Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 371998,
-    "fullName": "Vinicius Junior",
-    "clubName": "Real Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 412363,
-    "fullName": "Rodrygo",
-    "clubName": "Real Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 314678,
-    "fullName": "Brahim Díaz",
-    "clubName": "Real Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 81999,
-    "fullName": "Joselu",
-    "clubName": "Real Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 948275,
-    "fullName": "Álvaro Rodríguez",
-    "clubName": "Real Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 935230,
-    "fullName": "Gonzalo García",
-    "clubName": "Real Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 74857,
-    "fullName": "Marc-André ter Stegen",
-    "clubName": "FC Barcelona",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 283170,
-    "fullName": "Iñaki Peña",
-    "clubName": "FC Barcelona",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 709955,
-    "fullName": "Ander Astralaga",
-    "clubName": "FC Barcelona",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 938144,
-    "fullName": "Diego Kochen",
-    "clubName": "FC Barcelona",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 938145,
-    "fullName": "Áron Yaakobishvili",
-    "clubName": "FC Barcelona",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 480267,
-    "fullName": "Ronald Araujo",
-    "clubName": "FC Barcelona",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 196948,
-    "fullName": "Andreas Christensen",
-    "clubName": "FC Barcelona",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 962110,
-    "fullName": "Pau Cubarsí",
-    "clubName": "FC Barcelona",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 466794,
-    "fullName": "Eric García",
-    "clubName": "FC Barcelona",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 666974,
-    "fullName": "Mikayil Faye",
-    "clubName": "FC Barcelona",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 158863,
-    "fullName": "Iñigo Martínez",
-    "clubName": "FC Barcelona",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 636688,
-    "fullName": "Alejandro Balde",
-    "clubName": "FC Barcelona",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 112515,
-    "fullName": "Marcos Alonso",
-    "clubName": "FC Barcelona",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 411975,
-    "fullName": "Jules Koundé",
-    "clubName": "FC Barcelona",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 182712,
-    "fullName": "João Cancelo",
-    "clubName": "FC Barcelona",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 937955,
-    "fullName": "Héctor Fort",
-    "clubName": "FC Barcelona",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 636695,
-    "fullName": "Marc Casadó",
-    "clubName": "FC Barcelona",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 66100,
-    "fullName": "Oriol Romeu",
-    "clubName": "FC Barcelona",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 937956,
-    "fullName": "Pau Prim",
-    "clubName": "FC Barcelona",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 646740,
-    "fullName": "Gavi",
-    "clubName": "FC Barcelona",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 683840,
-    "fullName": "Pedri",
-    "clubName": "FC Barcelona",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 326330,
-    "fullName": "Frenkie de Jong",
-    "clubName": "FC Barcelona",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 53622,
-    "fullName": "İlkay Gündoğan",
-    "clubName": "FC Barcelona",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 85370,
-    "fullName": "Sergi Roberto",
-    "clubName": "FC Barcelona",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 970633,
-    "fullName": "Unai Hernández",
-    "clubName": "FC Barcelona",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 709966,
-    "fullName": "Aleix Garrido",
-    "clubName": "FC Barcelona",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 636703,
-    "fullName": "Fermín López",
-    "clubName": "FC Barcelona",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 411295,
-    "fullName": "Raphinha",
-    "clubName": "FC Barcelona",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 466810,
-    "fullName": "Ansu Fati",
-    "clubName": "FC Barcelona",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 724520,
-    "fullName": "Abde Ezzalzouli",
-    "clubName": "FC Barcelona",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 646739,
-    "fullName": "Ángel Alarcón",
-    "clubName": "FC Barcelona",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 937958,
-    "fullName": "Lamine Yamal",
-    "clubName": "FC Barcelona",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 462250,
-    "fullName": "João Félix",
-    "clubName": "FC Barcelona",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 398184,
-    "fullName": "Ferran Torres",
-    "clubName": "FC Barcelona",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 943837,
-    "fullName": "Vitor Roque",
-    "clubName": "FC Barcelona",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 38253,
-    "fullName": "Robert Lewandowski",
-    "clubName": "FC Barcelona",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 938158,
-    "fullName": "Marc Guiu",
-    "clubName": "FC Barcelona",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 707572,
-    "fullName": "Pau Víctor",
-    "clubName": "FC Barcelona",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 212862,
-    "fullName": "Álex Remiro",
-    "clubName": "Real Sociedad",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 561702,
-    "fullName": "Gaizka Ayesa",
-    "clubName": "Real Sociedad",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 625657,
-    "fullName": "Unai Marrero",
-    "clubName": "Real Sociedad",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 668313,
-    "fullName": "Aitor Fraga",
-    "clubName": "Real Sociedad",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 351809,
-    "fullName": "Robin Le Normand",
-    "clubName": "Real Sociedad",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 355628,
-    "fullName": "Igor Zubeldia",
-    "clubName": "Real Sociedad",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 580560,
-    "fullName": "Jon Pacheco",
-    "clubName": "Real Sociedad",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 229804,
-    "fullName": "Aritz Elustondo",
-    "clubName": "Real Sociedad",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1018938,
-    "fullName": "Jon Martín",
-    "clubName": "Real Sociedad",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 300716,
-    "fullName": "Kieran Tierney",
-    "clubName": "Real Sociedad",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 517842,
-    "fullName": "Aihen Muñoz",
-    "clubName": "Real Sociedad",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 448628,
-    "fullName": "Javi Galán",
-    "clubName": "Real Sociedad",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 249513,
-    "fullName": "Diego Rico",
-    "clubName": "Real Sociedad",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 297070,
-    "fullName": "Hamari Traoré",
-    "clubName": "Real Sociedad",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 661145,
-    "fullName": "Jon Aramburu",
-    "clubName": "Real Sociedad",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 280730,
-    "fullName": "Álvaro Odriozola",
-    "clubName": "Real Sociedad",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1055860,
-    "fullName": "Iñaki Rupérez",
-    "clubName": "Real Sociedad",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 423440,
-    "fullName": "Martín Zubimendi",
-    "clubName": "Real Sociedad",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 625651,
-    "fullName": "Urko González de Zárate",
-    "clubName": "Real Sociedad",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 338424,
-    "fullName": "Mikel Merino",
-    "clubName": "Real Sociedad",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 634431,
-    "fullName": "Beñat Turrientes",
-    "clubName": "Real Sociedad",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 625660,
-    "fullName": "Jon Ander Olasagasti",
-    "clubName": "Real Sociedad",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 309110,
-    "fullName": "Brais Méndez",
-    "clubName": "Real Sociedad",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 555143,
-    "fullName": "Arsen Zakharyan",
-    "clubName": "Real Sociedad",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 907813,
-    "fullName": "Pablo Marín",
-    "clubName": "Real Sociedad",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 625655,
-    "fullName": "Jon Magunazelaia",
-    "clubName": "Real Sociedad",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 616369,
-    "fullName": "Ander Barrenetxea",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 188888,
-    "fullName": "Sheraldo Becker",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 289272,
-    "fullName": "Martín Merquelanz",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 581113,
-    "fullName": "Bryan Fiabema",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 405398,
-    "fullName": "Takefusa Kubo",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 670847,
-    "fullName": "Mohamed-Ali Cho",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 563137,
-    "fullName": "Robert Navarro",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 434990,
-    "fullName": "Álex Sola",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 711377,
-    "fullName": "Alberto Dadie",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 351478,
-    "fullName": "Mikel Oyarzabal",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 337715,
-    "fullName": "Umar Sadiq",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 198008,
-    "fullName": "André Silva",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 711382,
-    "fullName": "Jon Karrikaburu",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 216464,
-    "fullName": "Carlos Fernández",
-    "clubName": "Real Sociedad",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 121483,
-    "fullName": "Jan Oblak",
-    "clubName": "Atlético de Madrid",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 226073,
-    "fullName": "Ivo Grbic",
-    "clubName": "Atlético de Madrid",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 525438,
-    "fullName": "Horațiu Moldovan",
-    "clubName": "Atlético de Madrid",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 930415,
-    "fullName": "Antonio Gomis",
-    "clubName": "Atlético de Madrid",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 973314,
-    "fullName": "Sergio Mestre",
-    "clubName": "Atlético de Madrid",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 281769,
-    "fullName": "Mario Hermoso",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 250845,
-    "fullName": "José María Giménez",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 320141,
-    "fullName": "Çağlar Söyüncü",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 35047,
-    "fullName": "Axel Witsel",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 107010,
-    "fullName": "Stefan Savic",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 57500,
-    "fullName": "César Azpilicueta",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 149498,
-    "fullName": "Gabriel Paulista",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 534376,
-    "fullName": "Marco Moreno",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 614988,
-    "fullName": "Ilias Kostis",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 240692,
-    "fullName": "Reinildo Mandava",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 448628,
-    "fullName": "Javi Galán",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 282411,
-    "fullName": "Marcos Llorente",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 424042,
-    "fullName": "Nahuel Molina",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 741253,
-    "fullName": "Javier Boñar",
-    "clubName": "Atlético de Madrid",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 926694,
-    "fullName": "Arthur Vermeeren",
-    "clubName": "Atlético de Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 255901,
-    "fullName": "Rodrigo De Paul",
-    "clubName": "Atlético de Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 775605,
-    "fullName": "Pablo Barrios",
-    "clubName": "Atlético de Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 74229,
-    "fullName": "Koke",
-    "clubName": "Atlético de Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 148928,
-    "fullName": "Saúl Ñíguez",
-    "clubName": "Atlético de Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 646735,
-    "fullName": "Aitor Gismera",
-    "clubName": "Atlético de Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 606570,
-    "fullName": "Sergio Guerrero",
-    "clubName": "Atlético de Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 205562,
-    "fullName": "Thomas Lemar",
-    "clubName": "Atlético de Madrid",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 694928,
-    "fullName": "Samuel Lino",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 461617,
-    "fullName": "Rodrigo Riquelme",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 140776,
-    "fullName": "Yannick Carrasco",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 612496,
-    "fullName": "Marcos Paulo",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 935457,
-    "fullName": "Salim El Jebari",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 67082,
-    "fullName": "Vitolo",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 945500,
-    "fullName": "Rayane Belaid",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 266807,
-    "fullName": "Ángel Correa",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 633111,
-    "fullName": "Álex Calatrava",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 462250,
-    "fullName": "João Félix",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 125781,
-    "fullName": "Antoine Griezmann",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 128223,
-    "fullName": "Álvaro Morata",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 167850,
-    "fullName": "Memphis Depay",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 926849,
-    "fullName": "Adrián Niño",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 860062,
-    "fullName": "Abde Raihani",
-    "clubName": "Atlético de Madrid",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 195488,
-    "fullName": "Paulo Gazzaniga",
-    "clubName": "Girona FC",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 623526,
-    "fullName": "Toni Fuidias",
-    "clubName": "Girona FC",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 120705,
-    "fullName": "Juan Carlos",
-    "clubName": "Girona FC",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 466794,
-    "fullName": "Eric García",
-    "clubName": "Girona FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 438001,
-    "fullName": "Santiago Bueno",
-    "clubName": "Girona FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 12282,
-    "fullName": "Daley Blind",
-    "clubName": "Girona FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 129444,
-    "fullName": "David López",
-    "clubName": "Girona FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 115333,
-    "fullName": "Juanpe",
-    "clubName": "Girona FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 64598,
-    "fullName": "Bernardo Espinosa",
-    "clubName": "Girona FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 787154,
-    "fullName": "Eric Monjonell",
-    "clubName": "Girona FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 923915,
-    "fullName": "Antal Yaakobishvili",
-    "clubName": "Girona FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 525299,
-    "fullName": "Miguel Gutiérrez",
-    "clubName": "Girona FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 627228,
-    "fullName": "Yan Couto",
-    "clubName": "Girona FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 826224,
-    "fullName": "Arnau Martínez",
-    "clubName": "Girona FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 785967,
-    "fullName": "Ibrahima Kébé",
-    "clubName": "Girona FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1061660,
-    "fullName": "Selvi Clua",
-    "clubName": "Girona FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 261504,
-    "fullName": "Aleix García",
-    "clubName": "Girona FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 378293,
-    "fullName": "Yangel Herrera",
-    "clubName": "Girona FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 742521,
-    "fullName": "Jhon Solís",
-    "clubName": "Girona FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1000626,
-    "fullName": "Enric García",
-    "clubName": "Girona FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 341278,
-    "fullName": "Iván Martín",
-    "clubName": "Girona FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 720038,
-    "fullName": "Pablo Torre",
-    "clubName": "Girona FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 67808,
-    "fullName": "Borja García",
-    "clubName": "Girona FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 906025,
-    "fullName": "Ricard Artero",
-    "clubName": "Girona FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 337066,
-    "fullName": "Toni Villa",
-    "clubName": "Girona FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 946269,
-    "fullName": "Alex Almansa",
-    "clubName": "Girona FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1025582,
-    "fullName": "Juan Arango",
-    "clubName": "Girona FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1061665,
-    "fullName": "Jastin Garcia",
-    "clubName": "Girona FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 743591,
-    "fullName": "Savinho",
-    "clubName": "Girona FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 264372,
-    "fullName": "Viktor Tsygankov",
-    "clubName": "Girona FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 99353,
-    "fullName": "Portu",
-    "clubName": "Girona FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 331496,
-    "fullName": "Valery Fernández",
-    "clubName": "Girona FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1061656,
-    "fullName": "Iker Almena",
-    "clubName": "Girona FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 527350,
-    "fullName": "Manu Vallejo",
-    "clubName": "Girona FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 343537,
-    "fullName": "Artem Dovbyk",
-    "clubName": "Girona FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 59323,
-    "fullName": "Cristhian Stuani",
-    "clubName": "Girona FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 964264,
-    "fullName": "Carles Garrido",
-    "clubName": "Girona FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 262396,
-    "fullName": "Unai Simón",
-    "clubName": "Athletic Bilbao",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 625014,
-    "fullName": "Julen Agirrezabala",
-    "clubName": "Athletic Bilbao",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 834483,
-    "fullName": "Álex Padilla",
-    "clubName": "Athletic Bilbao",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 524000,
-    "fullName": "Dani Vivian",
-    "clubName": "Athletic Bilbao",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 591916,
-    "fullName": "Aitor Paredes",
-    "clubName": "Athletic Bilbao",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 255488,
-    "fullName": "Yeray Álvarez",
-    "clubName": "Athletic Bilbao",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 834485,
-    "fullName": "Unai Egiluz",
-    "clubName": "Athletic Bilbao",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 61812,
-    "fullName": "Yuri Berchiche",
-    "clubName": "Athletic Bilbao",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 626954,
-    "fullName": "Imanol García de Albéniz",
-    "clubName": "Athletic Bilbao",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 255501,
-    "fullName": "Iñigo Lekue",
-    "clubName": "Athletic Bilbao",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 96718,
-    "fullName": "Óscar de Marcos",
-    "clubName": "Athletic Bilbao",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 834487,
-    "fullName": "Hugo Rincón",
-    "clubName": "Athletic Bilbao",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 300168,
-    "fullName": "Mikel Vesga",
-    "clubName": "Athletic Bilbao",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 447052,
-    "fullName": "Peru Nolaskoain",
-    "clubName": "Athletic Bilbao",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 625047,
-    "fullName": "Beñat Prados",
-    "clubName": "Athletic Bilbao",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 126751,
-    "fullName": "Iñigo Ruiz de Galarreta",
-    "clubName": "Athletic Bilbao",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 99343,
-    "fullName": "Ander Herrera",
-    "clubName": "Athletic Bilbao",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 178425,
-    "fullName": "Dani García",
-    "clubName": "Athletic Bilbao",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 938729,
-    "fullName": "Mikel Jauregizar",
-    "clubName": "Athletic Bilbao",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 571020,
-    "fullName": "Oihan Sancet",
-    "clubName": "Athletic Bilbao",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 834752,
-    "fullName": "Unai Gómez",
-    "clubName": "Athletic Bilbao",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 54235,
-    "fullName": "Iker Muniain",
-    "clubName": "Athletic Bilbao",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 34601,
-    "fullName": "Raúl García",
-    "clubName": "Athletic Bilbao",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 709187,
-    "fullName": "Nico Williams",
-    "clubName": "Athletic Bilbao",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 338425,
-    "fullName": "Álex Berenguer",
-    "clubName": "Athletic Bilbao",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 255508,
-    "fullName": "Iñaki Williams",
-    "clubName": "Athletic Bilbao",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 895480,
-    "fullName": "Adu Ares",
-    "clubName": "Athletic Bilbao",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1056971,
-    "fullName": "Aingeru Olabarrieta",
-    "clubName": "Athletic Bilbao",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 340205,
-    "fullName": "Gorka Guruzeta",
-    "clubName": "Athletic Bilbao",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 251897,
-    "fullName": "Asier Villalibre",
-    "clubName": "Athletic Bilbao",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 711394,
-    "fullName": "Javi Martón",
-    "clubName": "Athletic Bilbao",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 585323,
-    "fullName": "Filip Jørgensen",
-    "clubName": "Villarreal CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 547248,
-    "fullName": "Iker Álvarez",
-    "clubName": "Villarreal CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 7825,
-    "fullName": "Pepe Reina",
-    "clubName": "Villarreal CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 323167,
-    "fullName": "Matteo Gabbia",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 716276,
-    "fullName": "Yerson Mosquera",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 494880,
-    "fullName": "Jorge Cuenca",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 286384,
-    "fullName": "Eric Bailly",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 797572,
-    "fullName": "Stefan Leković",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 80293,
-    "fullName": "Aïssa Mandi",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 15452,
-    "fullName": "Raúl Albiol",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 886047,
-    "fullName": "Antonio Espigares",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 635344,
-    "fullName": "Abraham del Moral",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 356197,
-    "fullName": "Alfonso Pedraza",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 207917,
-    "fullName": "Alberto Moreno",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 709372,
-    "fullName": "Carlos Romero",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 480763,
-    "fullName": "Juan Foyth",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 466807,
-    "fullName": "Adrià Altimira",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 76467,
-    "fullName": "Kiko Femenía",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 937942,
-    "fullName": "Daniel Budesca",
-    "clubName": "Villarreal CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 63494,
-    "fullName": "Étienne Capoue",
-    "clubName": "Villarreal CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 74869,
-    "fullName": "Francis Coquelin",
-    "clubName": "Villarreal CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 380598,
-    "fullName": "Santi Comesaña",
-    "clubName": "Villarreal CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 783396,
-    "fullName": "Ramón Terrats",
-    "clubName": "Villarreal CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 59561,
-    "fullName": "Dani Parejo",
-    "clubName": "Villarreal CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 188854,
-    "fullName": "Manu Trigueros",
-    "clubName": "Villarreal CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 945709,
-    "fullName": "Dani Requena",
-    "clubName": "Villarreal CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 165007,
-    "fullName": "Denis Suárez",
-    "clubName": "Villarreal CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 548111,
-    "fullName": "Álex Baena",
-    "clubName": "Villarreal CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 225122,
-    "fullName": "Gonçalo Guedes",
-    "clubName": "Villarreal CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 566965,
-    "fullName": "Diego Collado",
-    "clubName": "Villarreal CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 568157,
-    "fullName": "Yéremy Pino",
-    "clubName": "Villarreal CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 709969,
-    "fullName": "Ilias Akhomach",
-    "clubName": "Villarreal CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 131996,
-    "fullName": "Bertrand Traoré",
-    "clubName": "Villarreal CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 238407,
-    "fullName": "Alexander Sørloth",
-    "clubName": "Villarreal CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 177467,
-    "fullName": "Gerard Moreno",
-    "clubName": "Villarreal CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 426192,
-    "fullName": "Ben Brereton Díaz",
-    "clubName": "Villarreal CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 709380,
-    "fullName": "Álex Forés",
-    "clubName": "Villarreal CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 252677,
-    "fullName": "José Luis Morales",
-    "clubName": "Villarreal CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 669511,
-    "fullName": "Jorge Pascual",
-    "clubName": "Villarreal CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 502676,
-    "fullName": "Giorgi Mamardashvili",
-    "clubName": "Valencia CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 227805,
-    "fullName": "Jaume Doménech",
-    "clubName": "Valencia CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 398131,
-    "fullName": "Cristian Rivero",
-    "clubName": "Valencia CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 741251,
-    "fullName": "Vicent Abril",
-    "clubName": "Valencia CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 646750,
-    "fullName": "Cristhian Mosquera",
-    "clubName": "Valencia CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 895334,
-    "fullName": "Yarek Gasiorowski",
-    "clubName": "Valencia CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 615350,
-    "fullName": "Cenk Özkacar",
-    "clubName": "Valencia CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 346289,
-    "fullName": "Mouctar Diakhaby",
-    "clubName": "Valencia CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 149498,
-    "fullName": "Gabriel Paulista",
-    "clubName": "Valencia CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 707274,
-    "fullName": "César Tárrega",
-    "clubName": "Valencia CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 668212,
-    "fullName": "Rubén Iranzo",
-    "clubName": "Valencia CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 221322,
-    "fullName": "José Gayà",
-    "clubName": "Valencia CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 623024,
-    "fullName": "Jesús Vázquez",
-    "clubName": "Valencia CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 367466,
-    "fullName": "Thierry Correia",
-    "clubName": "Valencia CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 170472,
-    "fullName": "Dimitri Foulquier",
-    "clubName": "Valencia CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 328480,
-    "fullName": "Pepelu",
-    "clubName": "Valencia CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 495629,
-    "fullName": "Hugo Guillamón",
-    "clubName": "Valencia CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 834764,
-    "fullName": "Javi Guerra",
-    "clubName": "Valencia CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 980242,
-    "fullName": "Ali Fadal",
-    "clubName": "Valencia CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 646743,
-    "fullName": "Javi Navarro",
-    "clubName": "Valencia CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 375382,
-    "fullName": "André Almeida",
-    "clubName": "Valencia CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 377219,
-    "fullName": "Selim Amallah",
-    "clubName": "Valencia CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 622992,
-    "fullName": "Pablo Gozálbez",
-    "clubName": "Valencia CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 941883,
-    "fullName": "Martín Tejón",
-    "clubName": "Valencia CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 251845,
-    "fullName": "Sergi Canós",
-    "clubName": "Valencia CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 636119,
-    "fullName": "Marco Camus",
-    "clubName": "Valencia CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 617081,
-    "fullName": "Diego López",
-    "clubName": "Valencia CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 622988,
-    "fullName": "Fran Pérez",
-    "clubName": "Valencia CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 710004,
-    "fullName": "Peter Federico",
-    "clubName": "Valencia CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1009766,
-    "fullName": "David Otorbi",
-    "clubName": "Valencia CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 707279,
-    "fullName": "Hugo González",
-    "clubName": "Valencia CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 573775,
-    "fullName": "Hugo Duro",
-    "clubName": "Valencia CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 221958,
-    "fullName": "Roman Yaremchuk",
-    "clubName": "Valencia CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 634105,
-    "fullName": "Alberto Marí",
-    "clubName": "Valencia CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 941867,
-    "fullName": "Mario Dominguez",
-    "clubName": "Valencia CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1000135,
-    "fullName": "Joselu Pérez",
-    "clubName": "Valencia CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 207834,
-    "fullName": "Bono",
-    "clubName": "Sevilla FC",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 73517,
-    "fullName": "Ørjan Nyland",
-    "clubName": "Sevilla FC",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 94308,
-    "fullName": "Marko Dmitrovic",
-    "clubName": "Sevilla FC",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 766552,
-    "fullName": "Alberto Flores",
-    "clubName": "Sevilla FC",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 767255,
-    "fullName": "Matías Árbol",
-    "clubName": "Sevilla FC",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 833884,
-    "fullName": "Rafael Romero",
-    "clubName": "Sevilla FC",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 730581,
-    "fullName": "Loïc Badé",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 766583,
-    "fullName": "Kike Salas",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 439022,
-    "fullName": "Marcão",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 660735,
-    "fullName": "Federico Gattoni",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 538996,
-    "fullName": "Tanguy Nianzou",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 25557,
-    "fullName": "Sergio Ramos",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 569876,
-    "fullName": "Xavi Sintes",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 501418,
-    "fullName": "Adrià Pedrosa",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 60410,
-    "fullName": "Marcos Acuña",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 767229,
-    "fullName": "Diego Hormigo",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1032280,
-    "fullName": "Oso",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 676042,
-    "fullName": "Juanlu Sánchez",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 402733,
-    "fullName": "Gonzalo Montiel",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 15956,
-    "fullName": "Jesús Navas",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 711626,
-    "fullName": "Darío Benavides",
-    "clubName": "Sevilla FC",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 344605,
-    "fullName": "Boubakary Soumaré",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 569384,
-    "fullName": "Lucien Agoumé",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 74294,
-    "fullName": "Nemanja Gudelj",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 51174,
-    "fullName": "Fernando",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 212723,
-    "fullName": "Djibril Sow",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 214775,
-    "fullName": "Óliver Torres",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 263727,
-    "fullName": "Joan Jordán",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 32467,
-    "fullName": "Ivan Rakitic",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 766723,
-    "fullName": "Manu Bueno",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 718581,
-    "fullName": "Lulo Dasilva",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 935342,
-    "fullName": "Alberto Collado",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 607224,
-    "fullName": "Hannibal",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 743387,
-    "fullName": "Stanis Idumbo",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 628926,
-    "fullName": "Miguel Capitas",
-    "clubName": "Sevilla FC",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 189441,
-    "fullName": "Lucas Ocampos",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 916014,
-    "fullName": "Isra Domínguez",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 20005,
-    "fullName": "Papu Gómez",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 303259,
-    "fullName": "Dodi Lukébakio",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 111961,
-    "fullName": "Suso",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 125165,
-    "fullName": "Jesús Corona",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 111630,
-    "fullName": "Erik Lamela",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 177847,
-    "fullName": "Adnan Januzaj",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 433049,
-    "fullName": "Youssef En-Nesyri",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 687609,
-    "fullName": "Isaac Romero",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 888493,
-    "fullName": "Alejo Veliz",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 361254,
-    "fullName": "Rafa Mir",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 225020,
-    "fullName": "Mariano Díaz",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 934420,
-    "fullName": "Ibra Sow",
-    "clubName": "Sevilla FC",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 234811,
-    "fullName": "Rui Silva",
-    "clubName": "Real Betis Balompié",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 40423,
-    "fullName": "Claudio Bravo",
-    "clubName": "Real Betis Balompié",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 551182,
-    "fullName": "Fran Vieites",
-    "clubName": "Real Betis Balompié",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 567504,
-    "fullName": "Guilherme Fernandes",
-    "clubName": "Real Betis Balompié",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1061277,
-    "fullName": "Germán García",
-    "clubName": "Real Betis Balompié",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 689637,
-    "fullName": "Chadi Riad",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 457931,
-    "fullName": "Luiz Felipe",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 113133,
-    "fullName": "Germán Pezzella",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1034853,
-    "fullName": "Nobel Mendy",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 99922,
-    "fullName": "Marc Bartra",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 34322,
-    "fullName": "Sokratis Papastathopoulos",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 630989,
-    "fullName": "Ricardo Visus",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 341227,
-    "fullName": "Juan Miranda",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 646402,
-    "fullName": "Abner",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 971774,
-    "fullName": "Xavi Pleguezuelo",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 191217,
-    "fullName": "Héctor Bellerín",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 378139,
-    "fullName": "Aitor Ruibal",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 135492,
-    "fullName": "Youssouf Sabaly",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1054909,
-    "fullName": "Pablo Busto",
-    "clubName": "Real Betis Balompié",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 342385,
-    "fullName": "Guido Rodríguez",
-    "clubName": "Real Betis Balompié",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 336869,
-    "fullName": "Marc Roca",
-    "clubName": "Real Betis Balompié",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 100131,
-    "fullName": "William Carvalho",
-    "clubName": "Real Betis Balompié",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 429901,
-    "fullName": "Paul Akouokou",
-    "clubName": "Real Betis Balompié",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 689505,
-    "fullName": "Johnny Cardoso",
-    "clubName": "Real Betis Balompié",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 357885,
-    "fullName": "Pablo Fornals",
-    "clubName": "Real Betis Balompié",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 466801,
-    "fullName": "Sergi Altimira",
-    "clubName": "Real Betis Balompié",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 20506,
-    "fullName": "Andrés Guardado",
-    "clubName": "Real Betis Balompié",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 961944,
-    "fullName": "Ginés Sorroche",
-    "clubName": "Real Betis Balompié",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 668184,
-    "fullName": "Quique Fernández",
-    "clubName": "Real Betis Balompié",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 203496,
-    "fullName": "Nabil Fekir",
-    "clubName": "Real Betis Balompié",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 85288,
-    "fullName": "Isco",
-    "clubName": "Real Betis Balompié",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 895331,
-    "fullName": "Dani Pérez",
-    "clubName": "Real Betis Balompié",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1061282,
-    "fullName": "Assane Diao",
-    "clubName": "Real Betis Balompié",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 724520,
-    "fullName": "Abde Ezzalzouli",
-    "clubName": "Real Betis Balompié",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 585700,
-    "fullName": "Juan Cruz",
-    "clubName": "Real Betis Balompié",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 800175,
-    "fullName": "Luiz Henrique",
-    "clubName": "Real Betis Balompié",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 630995,
-    "fullName": "Rodri Sánchez",
-    "clubName": "Real Betis Balompié",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 246968,
-    "fullName": "Ayoze Pérez",
-    "clubName": "Real Betis Balompié",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 278359,
-    "fullName": "Borja Iglesias",
-    "clubName": "Real Betis Balompié",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 122155,
-    "fullName": "Willian José",
-    "clubName": "Real Betis Balompié",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 167721,
-    "fullName": "Chimy Ávila",
-    "clubName": "Real Betis Balompié",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 127048,
-    "fullName": "Cédric Bakambu",
-    "clubName": "Real Betis Balompié",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 297194,
-    "fullName": "Iván Villar",
-    "clubName": "Celta de Vigo",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 54534,
-    "fullName": "Agustín Marchesín",
-    "clubName": "Celta de Vigo",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 64399,
-    "fullName": "Vicente Guaita",
-    "clubName": "Celta de Vigo",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 581640,
-    "fullName": "Coke Carrillo",
-    "clubName": "Celta de Vigo",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 646741,
-    "fullName": "César Fernández",
-    "clubName": "Celta de Vigo",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 577869,
-    "fullName": "Ruly García",
-    "clubName": "Celta de Vigo",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 338285,
-    "fullName": "Unai Núñez",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 258987,
-    "fullName": "Carl Starfelt",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 358250,
-    "fullName": "Joseph Aidoo",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 636093,
-    "fullName": "Carlos Domínguez",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1076815,
-    "fullName": "Javi Rodríguez",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 939374,
-    "fullName": "Yoel Lago",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 625882,
-    "fullName": "Javi Domínguez",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 618809,
-    "fullName": "Manu Sánchez",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 271455,
-    "fullName": "Mihailo Ristic",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 586736,
-    "fullName": "Joel López",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 331505,
-    "fullName": "Óscar Mingueza",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 162029,
-    "fullName": "Javier Manquillo",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 221315,
-    "fullName": "Kevin Vázquez",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 652331,
-    "fullName": "Javi Rueda",
-    "clubName": "Celta de Vigo",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 277137,
-    "fullName": "Renato Tapia",
-    "clubName": "Celta de Vigo",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 366948,
-    "fullName": "Jailson",
-    "clubName": "Celta de Vigo",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 715628,
-    "fullName": "Damián Rodríguez",
-    "clubName": "Celta de Vigo",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 423444,
-    "fullName": "Fran Beltrán",
-    "clubName": "Celta de Vigo",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 315762,
-    "fullName": "Luca de la Torre",
-    "clubName": "Celta de Vigo",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 892221,
-    "fullName": "Hugo Sotelo",
-    "clubName": "Celta de Vigo",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 623524,
-    "fullName": "Carlos Dotor",
-    "clubName": "Celta de Vigo",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 699704,
-    "fullName": "Gabri Veiga",
-    "clubName": "Celta de Vigo",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 292818,
-    "fullName": "Jonathan Bamba",
-    "clubName": "Celta de Vigo",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 764859,
-    "fullName": "Williot Swedberg",
-    "clubName": "Celta de Vigo",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 892929,
-    "fullName": "Hugo Álvarez",
-    "clubName": "Celta de Vigo",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 341110,
-    "fullName": "Franco Cervi",
-    "clubName": "Celta de Vigo",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 872184,
-    "fullName": "Tadeo Allende",
-    "clubName": "Celta de Vigo",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 282810,
-    "fullName": "Carles Pérez",
-    "clubName": "Celta de Vigo",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 634427,
-    "fullName": "Miguel Rodríguez",
-    "clubName": "Celta de Vigo",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 429983,
-    "fullName": "Jørgen Strand Larsen",
-    "clubName": "Celta de Vigo",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 523318,
-    "fullName": "Anastasios Douvikas",
-    "clubName": "Celta de Vigo",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 72047,
-    "fullName": "Iago Aspas",
-    "clubName": "Celta de Vigo",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 181547,
-    "fullName": "Gonçalo Paciência",
-    "clubName": "Celta de Vigo",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 275218,
-    "fullName": "Augusto Batalla",
-    "clubName": "Granada CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 290346,
-    "fullName": "André Ferreira",
-    "clubName": "Granada CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 129374,
-    "fullName": "Marc Martínez",
-    "clubName": "Granada CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 412042,
-    "fullName": "Adri López",
-    "clubName": "Granada CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 54217,
-    "fullName": "Raúl Fernández",
-    "clubName": "Granada CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 605528,
-    "fullName": "Pol Tristán",
-    "clubName": "Granada CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 891312,
-    "fullName": "Fran Árbol",
-    "clubName": "Granada CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 552912,
-    "fullName": "Bruno Méndez",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 631222,
-    "fullName": "Raúl Torrente",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 345449,
-    "fullName": "Kamil Piatkowski",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 583510,
-    "fullName": "Miguel Rubio",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 70245,
-    "fullName": "Ignasi Miquel",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 251896,
-    "fullName": "Jesús Vallejo",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 707276,
-    "fullName": "Miki Bosch",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 811778,
-    "fullName": "Álvaro Carreras",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 357072,
-    "fullName": "Faitout Maouassa",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 448844,
-    "fullName": "Carlos Neva",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 713649,
-    "fullName": "Miguel Ángel Brau",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 388545,
-    "fullName": "Ricard Sánchez",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 257388,
-    "fullName": "Wilson Manafá",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 58330,
-    "fullName": "Víctor Díaz",
-    "clubName": "Granada CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 268670,
-    "fullName": "Gerard Gumbau",
-    "clubName": "Granada CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 398808,
-    "fullName": "Martin Hongla",
-    "clubName": "Granada CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 376588,
-    "fullName": "Njegos Petrovic",
-    "clubName": "Granada CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 398163,
-    "fullName": "Gonzalo Villar",
-    "clubName": "Granada CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 394694,
-    "fullName": "Sergio Ruiz",
-    "clubName": "Granada CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 944124,
-    "fullName": "Lass Sangaré",
-    "clubName": "Granada CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 448344,
-    "fullName": "Óscar Melendo",
-    "clubName": "Granada CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 833340,
-    "fullName": "Mario González",
-    "clubName": "Granada CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 713644,
-    "fullName": "Bryan Zaragoza",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 315289,
-    "fullName": "Myrto Uzuni",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 289167,
-    "fullName": "Kamil Jóźwiak",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 99559,
-    "fullName": "Alberto Perea",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1064103,
-    "fullName": "Sergio Rodelas",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 676318,
-    "fullName": "Facundo Pellistri",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 262365,
-    "fullName": "Antonio Puertas",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 568535,
-    "fullName": "Theo Corbeanu",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 61253,
-    "fullName": "José Callejón",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 487688,
-    "fullName": "Alberto Soro",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 821820,
-    "fullName": "Pablo Sáenz",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 991268,
-    "fullName": "Samu Aghehowa",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 334222,
-    "fullName": "Lucas Boyé",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 611426,
-    "fullName": "Matías Arezo",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 247652,
-    "fullName": "Shon Weissman",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 237125,
-    "fullName": "Famara Diédhiou",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1056096,
-    "fullName": "Eghosa Bello",
-    "clubName": "Granada CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 226012,
-    "fullName": "David Soria",
-    "clubName": "Getafe CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 438682,
-    "fullName": "Daniel Fuzato",
-    "clubName": "Getafe CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1135452,
-    "fullName": "Jorge Benito",
-    "clubName": "Getafe CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1130318,
-    "fullName": "Djordjije Medenica",
-    "clubName": "Getafe CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 577486,
-    "fullName": "Gastón Álvarez",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 353032,
-    "fullName": "Omar Alderete",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 221150,
-    "fullName": "Djené",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 257376,
-    "fullName": "Domingos Duarte",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 143029,
-    "fullName": "Stefan Mitrovic",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 908621,
-    "fullName": "Nabil Aberdin",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 623025,
-    "fullName": "Sergio Gimeno",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 249513,
-    "fullName": "Diego Rico",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 268506,
-    "fullName": "Fabrizio Angileri",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 537763,
-    "fullName": "Jordi Martín",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1000136,
-    "fullName": "Gorka Rivera",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1158757,
-    "fullName": "Alejandro Herranz",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 711625,
-    "fullName": "José Ángel Carmona",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 390688,
-    "fullName": "Juan Iglesias",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 76746,
-    "fullName": "Damián Suárez",
-    "clubName": "Getafe CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 273152,
-    "fullName": "Nemanja Maksimovic",
-    "clubName": "Getafe CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 290249,
-    "fullName": "Mauro Arambarri",
-    "clubName": "Getafe CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 281989,
-    "fullName": "Luis Milla",
-    "clubName": "Getafe CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 284854,
-    "fullName": "Carles Aleñá",
-    "clubName": "Getafe CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 617074,
-    "fullName": "Ilaix Moriba",
-    "clubName": "Getafe CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 941869,
-    "fullName": "Yellu Santiago",
-    "clubName": "Getafe CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 841121,
-    "fullName": "John Patrick",
-    "clubName": "Getafe CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 737138,
-    "fullName": "Facu Esnáider",
-    "clubName": "Getafe CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 284884,
-    "fullName": "Óscar Rodríguez",
-    "clubName": "Getafe CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 732096,
-    "fullName": "Santi García",
-    "clubName": "Getafe CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 891091,
-    "fullName": "Diego López",
-    "clubName": "Getafe CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1255616,
-    "fullName": "Alberto Risco",
-    "clubName": "Getafe CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1041934,
-    "fullName": "Jeremy Jorge",
-    "clubName": "Getafe CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1184137,
-    "fullName": "Yassin Tallal",
-    "clubName": "Getafe CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 532826,
-    "fullName": "Mason Greenwood",
-    "clubName": "Getafe CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 99353,
-    "fullName": "Portu",
-    "clubName": "Getafe CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 251106,
-    "fullName": "Enes Ünal",
-    "clubName": "Getafe CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 298976,
-    "fullName": "Borja Mayoral",
-    "clubName": "Getafe CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 623521,
-    "fullName": "Juanmi Latasa",
-    "clubName": "Getafe CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 131275,
-    "fullName": "Choco Lozano",
-    "clubName": "Getafe CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 227961,
-    "fullName": "Jaime Mata",
-    "clubName": "Getafe CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 298197,
-    "fullName": "Antonio Sivera",
-    "clubName": "Deportivo Alavés",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 631693,
-    "fullName": "Jesús Owono",
-    "clubName": "Deportivo Alavés",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 608382,
-    "fullName": "Adrián Rodríguez",
-    "clubName": "Deportivo Alavés",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 895316,
-    "fullName": "Gaizka García",
-    "clubName": "Deportivo Alavés",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 948253,
-    "fullName": "Rubén Montero",
-    "clubName": "Deportivo Alavés",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 559979,
-    "fullName": "Abdel Abqar",
-    "clubName": "Deportivo Alavés",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 662261,
-    "fullName": "Rafa Marín",
-    "clubName": "Deportivo Alavés",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 177046,
-    "fullName": "Rubén Duarte",
-    "clubName": "Deportivo Alavés",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 258475,
-    "fullName": "Nikola Maras",
-    "clubName": "Deportivo Alavés",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 237499,
-    "fullName": "Aleksandar Sedlar",
-    "clubName": "Deportivo Alavés",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1064403,
-    "fullName": "Álvaro García",
-    "clubName": "Deportivo Alavés",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 568158,
-    "fullName": "Javi López",
-    "clubName": "Deportivo Alavés",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 591957,
-    "fullName": "Victor Parada",
-    "clubName": "Deportivo Alavés",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 892217,
-    "fullName": "Eneko Ortiz",
-    "clubName": "Deportivo Alavés",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 289255,
-    "fullName": "Andoni Gorosabel",
-    "clubName": "Deportivo Alavés",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 533568,
-    "fullName": "Nahuel Tenaglia",
-    "clubName": "Deportivo Alavés",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1064391,
-    "fullName": "Egoitz Muñoz",
-    "clubName": "Deportivo Alavés",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 718177,
-    "fullName": "Joseda Álvarez",
-    "clubName": "Deportivo Alavés",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 495621,
-    "fullName": "Antonio Blanco",
-    "clubName": "Deportivo Alavés",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 431190,
-    "fullName": "Carlos Protesoni",
-    "clubName": "Deportivo Alavés",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 646734,
-    "fullName": "Tomás Mendes",
-    "clubName": "Deportivo Alavés",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 465967,
-    "fullName": "Ander Guevara",
-    "clubName": "Deportivo Alavés",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 289257,
-    "fullName": "Jon Guridi",
-    "clubName": "Deportivo Alavés",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1054931,
-    "fullName": "Selu Diallo",
-    "clubName": "Deportivo Alavés",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 282076,
-    "fullName": "Ianis Hagi",
-    "clubName": "Deportivo Alavés",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1064402,
-    "fullName": "Ander Sánchez",
-    "clubName": "Deportivo Alavés",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 278837,
-    "fullName": "Luis Rioja",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 718034,
-    "fullName": "Abde Rebbach",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 867611,
-    "fullName": "José de León",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 434990,
-    "fullName": "Álex Sola",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 540536,
-    "fullName": "Carlos Vicente",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 742201,
-    "fullName": "Giuliano Simeone",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 572271,
-    "fullName": "Xeber Alkain",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 718029,
-    "fullName": "Unai Ropero",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 991268,
-    "fullName": "Samu Aghehowa",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 480883,
-    "fullName": "Miguel de la Fuente",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 711382,
-    "fullName": "Jon Karrikaburu",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 166683,
-    "fullName": "Mamadou Sylla",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 93936,
-    "fullName": "Kike García",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1064871,
-    "fullName": "Joaquín Panichelli",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 550492,
-    "fullName": "Giorgi Gagua",
-    "clubName": "Deportivo Alavés",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 417913,
-    "fullName": "Álvaro Valles",
-    "clubName": "UD Las Palmas",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 284430,
-    "fullName": "Aarón Escandell",
-    "clubName": "UD Las Palmas",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 749978,
-    "fullName": "Ale Gorrin",
-    "clubName": "UD Las Palmas",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1036451,
-    "fullName": "Álvaro Killane",
-    "clubName": "UD Las Palmas",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 617060,
-    "fullName": "Mika Mármol",
-    "clubName": "UD Las Palmas",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 588426,
-    "fullName": "Saúl Coco",
-    "clubName": "UD Las Palmas",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 510396,
-    "fullName": "Álex Suárez",
-    "clubName": "UD Las Palmas",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1146029,
-    "fullName": "Juanma Herzog",
-    "clubName": "UD Las Palmas",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 390823,
-    "fullName": "Eric Curbelo",
-    "clubName": "UD Las Palmas",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 678406,
-    "fullName": "Sergi Cardona",
-    "clubName": "UD Las Palmas",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 215099,
-    "fullName": "Daley Sinkgraven",
-    "clubName": "UD Las Palmas",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1011316,
-    "fullName": "Gabriel Palmero",
-    "clubName": "UD Las Palmas",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 513970,
-    "fullName": "Julián Araujo",
-    "clubName": "UD Las Palmas",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 603940,
-    "fullName": "Marvin Park",
-    "clubName": "UD Las Palmas",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 230222,
-    "fullName": "Álvaro Lemos",
-    "clubName": "UD Las Palmas",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 668547,
-    "fullName": "Máximo Perrone",
-    "clubName": "UD Las Palmas",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 203516,
-    "fullName": "Nuke Mfulu",
-    "clubName": "UD Las Palmas",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 581781,
-    "fullName": "Enzo Loiodice",
-    "clubName": "UD Las Palmas",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 282421,
-    "fullName": "Javi Muñoz",
-    "clubName": "UD Las Palmas",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 120095,
-    "fullName": "José Campaña",
-    "clubName": "UD Las Palmas",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 531062,
-    "fullName": "Fabio González",
-    "clubName": "UD Las Palmas",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1019408,
-    "fullName": "Iñaki González",
-    "clubName": "UD Las Palmas",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1210422,
-    "fullName": "Aboubacar Bassinga",
-    "clubName": "UD Las Palmas",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 566574,
-    "fullName": "Kirian Rodríguez",
-    "clubName": "UD Las Palmas",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 153238,
-    "fullName": "Jonathan Viera",
-    "clubName": "UD Las Palmas",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 913955,
-    "fullName": "Yadam Santana",
-    "clubName": "UD Las Palmas",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 733576,
-    "fullName": "Alberto Moleiro",
-    "clubName": "UD Las Palmas",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 282672,
-    "fullName": "Benito Ramírez",
-    "clubName": "UD Las Palmas",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 223725,
-    "fullName": "Munir El Haddadi",
-    "clubName": "UD Las Palmas",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 534379,
-    "fullName": "Pejiño",
-    "clubName": "UD Las Palmas",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 199369,
-    "fullName": "Sandro Ramírez",
-    "clubName": "UD Las Palmas",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 355689,
-    "fullName": "Sory Kaba",
-    "clubName": "UD Las Palmas",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 443222,
-    "fullName": "Marc Cardona",
-    "clubName": "UD Las Palmas",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 237617,
-    "fullName": "Cristian Herrera",
-    "clubName": "UD Las Palmas",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 940462,
-    "fullName": "Pau Ferrer",
-    "clubName": "UD Las Palmas",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 248738,
-    "fullName": "Sergio Herrera",
-    "clubName": "CA Osasuna",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 118997,
-    "fullName": "Aitor Fernández",
-    "clubName": "CA Osasuna",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 634117,
-    "fullName": "Pablo Valencia",
-    "clubName": "CA Osasuna",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 890817,
-    "fullName": "Dimitrios Stamatakis",
-    "clubName": "CA Osasuna",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 298589,
-    "fullName": "David García",
-    "clubName": "CA Osasuna",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 555500,
-    "fullName": "Jorge Herrando",
-    "clubName": "CA Osasuna",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 449796,
-    "fullName": "Alejandro Catena",
-    "clubName": "CA Osasuna",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 197122,
-    "fullName": "Unai García",
-    "clubName": "CA Osasuna",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 717957,
-    "fullName": "Jorge Moreno",
-    "clubName": "CA Osasuna",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 169497,
-    "fullName": "Juan Cruz",
-    "clubName": "CA Osasuna",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 262939,
-    "fullName": "Johan Mojica",
-    "clubName": "CA Osasuna",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 488626,
-    "fullName": "Jesús Areso",
-    "clubName": "CA Osasuna",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 238868,
-    "fullName": "Rubén Peña",
-    "clubName": "CA Osasuna",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 216870,
-    "fullName": "Nacho Vidal",
-    "clubName": "CA Osasuna",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1065442,
-    "fullName": "Iñigo Arguibide",
-    "clubName": "CA Osasuna",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 710677,
-    "fullName": "Iker Muñoz",
-    "clubName": "CA Osasuna",
-    "position": "M",
-    "league": "La Liga"
+    "playerId": 213728,
+    "fullName": "Ямаль",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 10.5,
+    "popularity": 70.0
+  },
+  {
+    "playerId": 213748,
+    "fullName": "Руибаль",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 6.2
+  },
+  {
+    "playerId": 213928,
+    "fullName": "Де Фрутос",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 5.8
   },
   {
     "playerId": 213670,
-    "fullName": "Lucas Torró",
-    "clubName": "CA Osasuna",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 552425,
-    "fullName": "Jon Moncayola",
-    "clubName": "CA Osasuna",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 785353,
-    "fullName": "Pablo Ibáñez",
-    "clubName": "CA Osasuna",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 95641,
-    "fullName": "Darko Brasanac",
-    "clubName": "CA Osasuna",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 634131,
-    "fullName": "Aimar Oroz",
-    "clubName": "CA Osasuna",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 471474,
-    "fullName": "Javi Martínez",
-    "clubName": "CA Osasuna",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1038512,
-    "fullName": "Asier Osambela",
-    "clubName": "CA Osasuna",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 634125,
-    "fullName": "Xabi Huarte",
-    "clubName": "CA Osasuna",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 175449,
-    "fullName": "Moi Gómez",
-    "clubName": "CA Osasuna",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 364603,
-    "fullName": "José Manuel Arnáiz",
-    "clubName": "CA Osasuna",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 213260,
-    "fullName": "Rubén García",
-    "clubName": "CA Osasuna",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 298575,
-    "fullName": "Kike Barja",
-    "clubName": "CA Osasuna",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 46413,
-    "fullName": "Ante Budimir",
-    "clubName": "CA Osasuna",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 631002,
-    "fullName": "Raúl García",
-    "clubName": "CA Osasuna",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 167721,
-    "fullName": "Chimy Ávila",
-    "clubName": "CA Osasuna",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 705808,
-    "fullName": "Max Svensson",
-    "clubName": "CA Osasuna",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 367464,
-    "fullName": "Luís Maximiano",
-    "clubName": "UD Almería",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 81997,
-    "fullName": "Fernando Martínez",
-    "clubName": "UD Almería",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 59349,
-    "fullName": "Diego Mariño",
-    "clubName": "UD Almería",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 747197,
-    "fullName": "Bruno Iribarne",
-    "clubName": "UD Almería",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 222805,
-    "fullName": "Srdjan Babic",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 401624,
-    "fullName": "Edgar González",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 387687,
-    "fullName": "César Montes",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 743589,
-    "fullName": "Kaiky",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 333361,
-    "fullName": "Chumi",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 339501,
-    "fullName": "Aleksandar Radovanovic",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1064116,
-    "fullName": "Paco Sanz",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 355627,
-    "fullName": "Sergio Akieme",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 631472,
-    "fullName": "Bruno Langa",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 423443,
-    "fullName": "Álex Centelles",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 844637,
-    "fullName": "Marc Pubill",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 442552,
-    "fullName": "Houboulang Mendes",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 718178,
-    "fullName": "Miguel Peña",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 945760,
-    "fullName": "Carlos Ballestero",
-    "clubName": "UD Almería",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 649033,
-    "fullName": "Dion Lopy",
-    "clubName": "UD Almería",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 457221,
-    "fullName": "Lucas Robertone",
-    "clubName": "UD Almería",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 442805,
-    "fullName": "Iddrisu Baba",
-    "clubName": "UD Almería",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 536030,
-    "fullName": "Arnau Puigmal",
-    "clubName": "UD Almería",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 162056,
-    "fullName": "Gonzalo Melero",
-    "clubName": "UD Almería",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1064121,
-    "fullName": "Marcos Peña",
-    "clubName": "UD Almería",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 696506,
-    "fullName": "Gui Guedes",
-    "clubName": "UD Almería",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 630523,
-    "fullName": "Martin Svidersky",
-    "clubName": "UD Almería",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 537762,
-    "fullName": "Sergio Arribas",
-    "clubName": "UD Almería",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 153238,
-    "fullName": "Jonathan Viera",
-    "clubName": "UD Almería",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 518644,
-    "fullName": "Largie Ramazani",
-    "clubName": "UD Almería",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 574772,
-    "fullName": "Lázaro",
-    "clubName": "UD Almería",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 769063,
-    "fullName": "Luka Romero",
-    "clubName": "UD Almería",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 341272,
-    "fullName": "Álex Pozo",
-    "clubName": "UD Almería",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 288318,
-    "fullName": "Adrián Embarba",
-    "clubName": "UD Almería",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 433257,
-    "fullName": "Arvin Appiah",
-    "clubName": "UD Almería",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 424784,
-    "fullName": "Luis Suárez",
-    "clubName": "UD Almería",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 490223,
-    "fullName": "Ibrahima Koné",
-    "clubName": "UD Almería",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 221899,
-    "fullName": "Léo Baptistão",
-    "clubName": "UD Almería",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 131275,
-    "fullName": "Choco Lozano",
-    "clubName": "UD Almería",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 845568,
-    "fullName": "Marko Milovanović",
-    "clubName": "UD Almería",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1013774,
-    "fullName": "Marciano Sanca",
-    "clubName": "UD Almería",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 891310,
-    "fullName": "Rachad Fettal",
-    "clubName": "UD Almería",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 190263,
-    "fullName": "Predrag Rajković",
-    "clubName": "RCD Mallorca",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 316884,
-    "fullName": "Dominik Greif",
-    "clubName": "RCD Mallorca",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 27493,
-    "fullName": "Iván Cuéllar",
-    "clubName": "RCD Mallorca",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 632913,
-    "fullName": "Pere García",
-    "clubName": "RCD Mallorca",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 892421,
-    "fullName": "Alex Quevedo",
-    "clubName": "RCD Mallorca",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 277384,
-    "fullName": "Martin Valjent",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 520840,
-    "fullName": "José Copete",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 400131,
-    "fullName": "Siebe Van der Heyden",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 278296,
-    "fullName": "Antonio Raíllo",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 143559,
-    "fullName": "Matija Nastasić",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 947431,
-    "fullName": "David López",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 320271,
-    "fullName": "Toni Lato",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 65318,
-    "fullName": "Jaume Costa",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 947432,
-    "fullName": "Marcos Fernández",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 251876,
-    "fullName": "Pablo Maffeo",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 339699,
-    "fullName": "Giovanni González",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 216870,
-    "fullName": "Nacho Vidal",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1004518,
-    "fullName": "Carles Sogorb",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1179588,
-    "fullName": "Yuzún Ley",
-    "clubName": "RCD Mallorca",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 657430,
-    "fullName": "Samú Costa",
-    "clubName": "RCD Mallorca",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 142031,
-    "fullName": "Omar Mascarell",
-    "clubName": "RCD Mallorca",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 142021,
-    "fullName": "Sergi Darder",
-    "clubName": "RCD Mallorca",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 335225,
-    "fullName": "Manu Morlanes",
-    "clubName": "RCD Mallorca",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 513031,
-    "fullName": "Antonio Sánchez",
-    "clubName": "RCD Mallorca",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1056655,
-    "fullName": "Rubén Quintanilla",
-    "clubName": "RCD Mallorca",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 139435,
-    "fullName": "Dani Rodríguez",
-    "clubName": "RCD Mallorca",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 857830,
-    "fullName": "Daniel Luna",
-    "clubName": "RCD Mallorca",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 245078,
-    "fullName": "Nemanja Radonjić",
-    "clubName": "RCD Mallorca",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 706138,
-    "fullName": "Javi Llabrés",
-    "clubName": "RCD Mallorca",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 339820,
-    "fullName": "Amath Ndiaye",
-    "clubName": "RCD Mallorca",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 632498,
-    "fullName": "Miguelito",
-    "clubName": "RCD Mallorca",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 256267,
-    "fullName": "Vedat Muriqi",
-    "clubName": "RCD Mallorca",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 343463,
-    "fullName": "Cyle Larin",
-    "clubName": "RCD Mallorca",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 177452,
-    "fullName": "Abdón Prats",
-    "clubName": "RCD Mallorca",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 947460,
-    "fullName": "Pau Mascaró",
-    "clubName": "RCD Mallorca",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 165467,
-    "fullName": "Stole Dimitrievski",
-    "clubName": "Rayo Vallecano",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 397676,
-    "fullName": "Dani Cárdenas",
-    "clubName": "Rayo Vallecano",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 607780,
-    "fullName": "Miguel Ángel Morro",
-    "clubName": "Rayo Vallecano",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 127108,
-    "fullName": "Florian Lejeune",
-    "clubName": "Rayo Vallecano",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 451801,
-    "fullName": "Abdul Mumin",
-    "clubName": "Rayo Vallecano",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 82503,
-    "fullName": "Aridane Hernández",
-    "clubName": "Rayo Vallecano",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 717957,
-    "fullName": "Jorge Moreno",
-    "clubName": "Rayo Vallecano",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 638588,
-    "fullName": "Martín Pascual",
-    "clubName": "Rayo Vallecano",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 311044,
-    "fullName": "Alfonso Espino",
-    "clubName": "Rayo Vallecano",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 596122,
-    "fullName": "Pep Chavarría",
-    "clubName": "Rayo Vallecano",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 85295,
-    "fullName": "Iván Balliu",
-    "clubName": "Rayo Vallecano",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 527966,
-    "fullName": "Andrei Rațiu",
-    "clubName": "Rayo Vallecano",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 498529,
-    "fullName": "Miguel Crespo",
-    "clubName": "Rayo Vallecano",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 517753,
-    "fullName": "Óscar Valentín",
-    "clubName": "Rayo Vallecano",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 527698,
-    "fullName": "Kike Pérez",
-    "clubName": "Rayo Vallecano",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 192009,
-    "fullName": "Unai López",
-    "clubName": "Rayo Vallecano",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 525578,
-    "fullName": "Pathé Ciss",
-    "clubName": "Rayo Vallecano",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 932349,
-    "fullName": "Diego Méndez",
-    "clubName": "Rayo Vallecano",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 560483,
-    "fullName": "Randy Nteka",
-    "clubName": "Rayo Vallecano",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 195605,
-    "fullName": "José Pozo",
-    "clubName": "Rayo Vallecano",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 30321,
-    "fullName": "Oscar Trejo",
-    "clubName": "Rayo Vallecano",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 257062,
-    "fullName": "Álvaro García",
-    "clubName": "Rayo Vallecano",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 153427,
-    "fullName": "Bebé",
-    "clubName": "Rayo Vallecano",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1045767,
-    "fullName": "Pablo Muñoz",
-    "clubName": "Rayo Vallecano",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 455181,
-    "fullName": "Jorge de Frutos",
-    "clubName": "Rayo Vallecano",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 246204,
-    "fullName": "Salvi Sánchez",
-    "clubName": "Rayo Vallecano",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 362086,
-    "fullName": "Isi Palazón",
-    "clubName": "Rayo Vallecano",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 505674,
-    "fullName": "Sergio Camello",
-    "clubName": "Rayo Vallecano",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 162038,
-    "fullName": "Raúl de Tomás",
-    "clubName": "Rayo Vallecano",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 39152,
-    "fullName": "Radamel Falcao",
-    "clubName": "Rayo Vallecano",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 284342,
-    "fullName": "Conan Ledesma",
-    "clubName": "Cádiz CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 162027,
-    "fullName": "David Gil",
-    "clubName": "Cádiz CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 706797,
-    "fullName": "Victor Aznar",
-    "clubName": "Cádiz CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 930096,
-    "fullName": "Nando Almodóvar",
-    "clubName": "Cádiz CF",
-    "position": "GK",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 252667,
-    "fullName": "Fali",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 495625,
-    "fullName": "Víctor Chust",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 585068,
-    "fullName": "Aiham Ousou",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 286779,
-    "fullName": "Jorge Meré",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 62945,
-    "fullName": "Luis Hernández",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 490421,
-    "fullName": "Momo Mbaye",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1178748,
-    "fullName": "Álex Morata",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 834737,
-    "fullName": "Adri Miranda",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 946276,
-    "fullName": "Adrián Salguero",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 422466,
-    "fullName": "Javi Hernández",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 927768,
-    "fullName": "Lucas Pires",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1032447,
-    "fullName": "Julio Cabrera",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 254037,
-    "fullName": "Iza Carcelén",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 197135,
-    "fullName": "Joseba Zaldua",
-    "clubName": "Cádiz CF",
-    "position": "D",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 315604,
-    "fullName": "Diadié Samassékou",
-    "clubName": "Cádiz CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 225462,
-    "fullName": "José Mari",
-    "clubName": "Cádiz CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 277635,
-    "fullName": "Rominigue Kouamé",
-    "clubName": "Cádiz CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 247250,
-    "fullName": "Rubén Alcaraz",
-    "clubName": "Cádiz CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 89733,
-    "fullName": "Álex Fernández",
-    "clubName": "Cádiz CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 266795,
-    "fullName": "Gonzalo Escalante",
-    "clubName": "Cádiz CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 307519,
-    "fullName": "Fede San Emeterio",
-    "clubName": "Cádiz CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 882772,
-    "fullName": "Álvaro Bastida",
-    "clubName": "Cádiz CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 278404,
-    "fullName": "Martín Calderón",
-    "clubName": "Cádiz CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 979235,
-    "fullName": "Moussa Diakité",
-    "clubName": "Cádiz CF",
-    "position": "M",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 126737,
-    "fullName": "Juanmi",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 211251,
-    "fullName": "Darwin Machís",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 598765,
-    "fullName": "Brian Ocampo",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1027993,
-    "fullName": "José Antonio de la Rosa",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 563137,
-    "fullName": "Robert Navarro",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 281755,
-    "fullName": "Iván Alejo",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1054922,
-    "fullName": "Nico Njalla",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 538810,
-    "fullName": "Chris Ramos",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 542819,
-    "fullName": "Milutin Osmajic",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 396894,
-    "fullName": "Maxi Gómez",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 85383,
-    "fullName": "Rubén Sobrino",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 212391,
-    "fullName": "Roger Martí",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 256429,
-    "fullName": "Sergi Guardiola",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1038950,
-    "fullName": "Karl Etta Eyong",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 18644,
-    "fullName": "Álvaro Negredo",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 1230202,
-    "fullName": "Borja Vázquez",
-    "clubName": "Cádiz CF",
-    "position": "F",
-    "league": "La Liga"
-  },
-  {
-    "playerId": 238223,
-    "fullName": "Ederson",
-    "clubName": "Manchester City",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 85941,
-    "fullName": "Stefan Ortega",
-    "clubName": "Manchester City",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 221624,
-    "fullName": "Zack Steffen",
-    "clubName": "Manchester City",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 919438,
-    "fullName": "True Grant",
-    "clubName": "Manchester City",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 14555,
-    "fullName": "Scott Carson",
-    "clubName": "Manchester City",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 258004,
-    "fullName": "Rúben Dias",
-    "clubName": "Manchester City",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 284730,
-    "fullName": "Manuel Akanji",
-    "clubName": "Manchester City",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 177476,
-    "fullName": "Nathan Aké",
-    "clubName": "Manchester City",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 186590,
-    "fullName": "John Stones",
-    "clubName": "Manchester City",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 503977,
-    "fullName": "Taylor Harwood-Bellis",
-    "clubName": "Manchester City",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 176553,
-    "fullName": "Aymeric Laporte",
-    "clubName": "Manchester City",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 843595,
-    "fullName": "Max Alleyne",
-    "clubName": "Manchester City",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 475959,
-    "fullName": "Josko Gvardiol",
-    "clubName": "Manchester City",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 576121,
-    "fullName": "Josh Wilson-Esbrand",
-    "clubName": "Manchester City",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 701057,
-    "fullName": "Rico Lewis",
-    "clubName": "Manchester City",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 95424,
-    "fullName": "Kyle Walker",
-    "clubName": "Manchester City",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 649452,
-    "fullName": "Issa Kaboré",
-    "clubName": "Manchester City",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 357565,
-    "fullName": "Rodri",
-    "clubName": "Manchester City",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 351749,
-    "fullName": "Kalvin Phillips",
-    "clubName": "Manchester City",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 668547,
-    "fullName": "Máximo Perrone",
-    "clubName": "Manchester City",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 895074,
-    "fullName": "Mahamadou Susoho",
-    "clubName": "Manchester City",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 983702,
-    "fullName": "Jacob Wright",
-    "clubName": "Manchester City",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 601883,
-    "fullName": "Matheus Nunes",
-    "clubName": "Manchester City",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 51471,
-    "fullName": "Mateo Kovacic",
-    "clubName": "Manchester City",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 568177,
-    "fullName": "Cole Palmer",
-    "clubName": "Manchester City",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 241641,
-    "fullName": "Bernardo Silva",
-    "clubName": "Manchester City",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 88755,
-    "fullName": "Kevin De Bruyne",
-    "clubName": "Manchester City",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 583199,
-    "fullName": "James McAtee",
-    "clubName": "Manchester City",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 486049,
-    "fullName": "Jérémy Doku",
-    "clubName": "Manchester City",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 203460,
-    "fullName": "Jack Grealish",
-    "clubName": "Manchester City",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 366930,
-    "fullName": "Sergio Gómez",
-    "clubName": "Manchester City",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 652797,
-    "fullName": "Micah Hamilton",
-    "clubName": "Manchester City",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 406635,
-    "fullName": "Phil Foden",
-    "clubName": "Manchester City",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 661207,
-    "fullName": "Oscar Bobb",
-    "clubName": "Manchester City",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 418560,
-    "fullName": "Erling Haaland",
-    "clubName": "Manchester City",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 576024,
-    "fullName": "Julián Alvarez",
-    "clubName": "Manchester City",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 262749,
-    "fullName": "David Raya",
-    "clubName": "Arsenal FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 427568,
-    "fullName": "Aaron Ramsdale",
-    "clubName": "Arsenal FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 425306,
-    "fullName": "Matt Turner",
-    "clubName": "Arsenal FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 493513,
-    "fullName": "Karl Hein",
-    "clubName": "Arsenal FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 503769,
-    "fullName": "Arthur Okonkwo",
-    "clubName": "Arsenal FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 495666,
-    "fullName": "William Saliba",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 435338,
-    "fullName": "Gabriel Magalhães",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 425918,
-    "fullName": "Jakub Kiwior",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 253341,
-    "fullName": "Rob Holding",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1078163,
-    "fullName": "Ayden Heaven",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 203853,
-    "fullName": "Oleksandr Zinchenko",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 300716,
-    "fullName": "Kieran Tierney",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 743414,
-    "fullName": "Lino Sousa",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 890721,
-    "fullName": "Myles Lewis-Skelly",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 335721,
-    "fullName": "Ben White",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 420243,
-    "fullName": "Jurriën Timber",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 331560,
-    "fullName": "Takehiro Tomiyasu",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 878160,
-    "fullName": "Reuell Walters",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 112988,
-    "fullName": "Cédric Soares",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 583952,
-    "fullName": "James Sweet",
-    "clubName": "Arsenal FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 230784,
-    "fullName": "Thomas Partey",
-    "clubName": "Arsenal FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 102017,
-    "fullName": "Jorginho",
-    "clubName": "Arsenal FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 160438,
-    "fullName": "Mohamed Elneny",
-    "clubName": "Arsenal FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 871837,
-    "fullName": "Bradley Ibrahim",
-    "clubName": "Arsenal FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 357662,
-    "fullName": "Declan Rice",
-    "clubName": "Arsenal FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 381967,
-    "fullName": "Albert Sambi Lokonga",
-    "clubName": "Arsenal FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 745846,
-    "fullName": "Mauro Bandeira",
-    "clubName": "Arsenal FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 316264,
-    "fullName": "Martin Ødegaard",
-    "clubName": "Arsenal FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 392765,
-    "fullName": "Emile Smith Rowe",
-    "clubName": "Arsenal FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 537598,
-    "fullName": "Fábio Vieira",
-    "clubName": "Arsenal FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 890719,
-    "fullName": "Ethan Nwaneri",
-    "clubName": "Arsenal FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 655488,
-    "fullName": "Gabriel Martinelli",
-    "clubName": "Arsenal FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 144028,
-    "fullName": "Leandro Trossard",
-    "clubName": "Arsenal FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 796037,
-    "fullName": "Charles Sagoe Jr",
-    "clubName": "Arsenal FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 433177,
-    "fullName": "Bukayo Saka",
-    "clubName": "Arsenal FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 340325,
-    "fullName": "Reiss Nelson",
-    "clubName": "Arsenal FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 878150,
-    "fullName": "Amario Cozier-Duberry",
-    "clubName": "Arsenal FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 309400,
-    "fullName": "Kai Havertz",
-    "clubName": "Arsenal FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 363205,
-    "fullName": "Gabriel Jesus",
-    "clubName": "Arsenal FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 340324,
-    "fullName": "Eddie Nketiah",
-    "clubName": "Arsenal FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 403151,
-    "fullName": "Robert Sánchez",
-    "clubName": "Chelsea FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 465555,
-    "fullName": "Djordje Petrovic",
-    "clubName": "Chelsea FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 116648,
-    "fullName": "Marcus Bettinelli",
-    "clubName": "Chelsea FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 490606,
-    "fullName": "Lucas Bergström",
-    "clubName": "Chelsea FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 731466,
-    "fullName": "Teddy Sharman-Lowe",
-    "clubName": "Chelsea FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 732120,
-    "fullName": "Eddie Beach",
-    "clubName": "Chelsea FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 827435,
-    "fullName": "Max Merrick",
-    "clubName": "Chelsea FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 857792,
-    "fullName": "Ted Curd",
-    "clubName": "Chelsea FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 614258,
-    "fullName": "Levi Colwill",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 386047,
-    "fullName": "Axel Disasi",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 463603,
-    "fullName": "Benoît Badiashile",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 475411,
-    "fullName": "Wesley Fofana",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 346314,
-    "fullName": "Trevoh Chalobah",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 344596,
-    "fullName": "Malang Sarr",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 29241,
-    "fullName": "Thiago Silva",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 566832,
-    "fullName": "Josh Brooking",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 985691,
-    "fullName": "Harrison Murray-Campbell",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 796299,
-    "fullName": "Billy Gee",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 485585,
-    "fullName": "Ian Maatsen",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 316125,
-    "fullName": "Ben Chilwell",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 284857,
-    "fullName": "Marc Cucurella",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 612517,
-    "fullName": "Bashir Humphreys",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 922698,
-    "fullName": "Ishé Samuels-Smith",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 801472,
-    "fullName": "Zak Sturge",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 732117,
-    "fullName": "Dylan Williams",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 472423,
-    "fullName": "Reece James",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 620322,
-    "fullName": "Malo Gusto",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 790992,
-    "fullName": "Alfie Gilchrist",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1004708,
-    "fullName": "Josh Acheampong",
-    "clubName": "Chelsea FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 687626,
-    "fullName": "Moisés Caicedo",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 628451,
-    "fullName": "Roméo Lavia",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 711999,
-    "fullName": "Lesley Ugochukwu",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1071819,
-    "fullName": "Ollie Harrison",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 648195,
-    "fullName": "Enzo Fernández",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 488362,
-    "fullName": "Conor Gallagher",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 743600,
-    "fullName": "Andrey Santos",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 659459,
-    "fullName": "Carney Chukwuemeka",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 622380,
-    "fullName": "Cesare Casadei",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 670850,
-    "fullName": "Alex Matos",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 936842,
-    "fullName": "Michael Golding",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 681615,
-    "fullName": "Jimi Tauriainen",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 954125,
-    "fullName": "Kiano Dyer",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 655006,
-    "fullName": "Diego Moreira",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 568177,
-    "fullName": "Cole Palmer",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 796303,
-    "fullName": "Leo Castledine",
-    "clubName": "Chelsea FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 537860,
-    "fullName": "Mykhaylo Mudryk",
-    "clubName": "Chelsea FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 936874,
-    "fullName": "Tyrique George",
-    "clubName": "Chelsea FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 134425,
-    "fullName": "Raheem Sterling",
-    "clubName": "Chelsea FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 503987,
-    "fullName": "Noni Madueke",
-    "clubName": "Chelsea FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 344381,
-    "fullName": "Christopher Nkunku",
-    "clubName": "Chelsea FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 776890,
-    "fullName": "Nicolas Jackson",
-    "clubName": "Chelsea FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 571743,
-    "fullName": "Armando Broja",
-    "clubName": "Chelsea FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 787232,
-    "fullName": "David Datro Fofana",
-    "clubName": "Chelsea FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1082850,
-    "fullName": "Deivid Washington",
-    "clubName": "Chelsea FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 874080,
-    "fullName": "Mason Burstow",
-    "clubName": "Chelsea FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 825024,
-    "fullName": "Ronnie Stutter",
-    "clubName": "Chelsea FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 105470,
-    "fullName": "Alisson",
-    "clubName": "Liverpool FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 340918,
-    "fullName": "Caoimhín Kelleher",
-    "clubName": "Liverpool FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 486604,
-    "fullName": "Vitezslav Jaros",
-    "clubName": "Liverpool FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 71271,
-    "fullName": "Adrián",
-    "clubName": "Liverpool FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 662334,
-    "fullName": "Marcelo Pitaluga",
-    "clubName": "Liverpool FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 678402,
-    "fullName": "Fabian Mrozek",
-    "clubName": "Liverpool FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 357119,
-    "fullName": "Ibrahima Konaté",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 139208,
-    "fullName": "Virgil van Dijk",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 256178,
-    "fullName": "Joe Gomez",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 632349,
-    "fullName": "Jarell Quansah",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 82105,
-    "fullName": "Joel Matip",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 371814,
-    "fullName": "Nat Phillips",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 503679,
-    "fullName": "Rhys Williams",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 670861,
-    "fullName": "Luke Chambers",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1108049,
-    "fullName": "Amara Nallo",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 234803,
-    "fullName": "Andrew Robertson",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 338070,
-    "fullName": "Konstantinos Tsimikas",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 551001,
-    "fullName": "Owen Beck",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 796298,
-    "fullName": "Calum Scanlon",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 314353,
-    "fullName": "Trent Alexander-Arnold",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 624258,
-    "fullName": "Conor Bradley",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 633652,
-    "fullName": "Calvin Ramsay",
-    "clubName": "Liverpool FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 478573,
-    "fullName": "Ryan Gravenberch",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 146310,
-    "fullName": "Wataru Endo",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 864799,
-    "fullName": "Stefan Bajcetic",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 534033,
-    "fullName": "Alexis Mac Allister",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 433188,
-    "fullName": "Curtis Jones",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 60444,
-    "fullName": "Thiago Alcántara",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 712117,
-    "fullName": "Bobby Clark",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 845289,
-    "fullName": "James McConnell",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1045123,
-    "fullName": "Trey Nyoni",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 655990,
-    "fullName": "Tom Hill",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 451276,
-    "fullName": "Dominik Szoboszlai",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 565822,
-    "fullName": "Harvey Elliott",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 559263,
-    "fullName": "Fábio Carvalho",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 570469,
-    "fullName": "Mateusz Musialowski",
-    "clubName": "Liverpool FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 480692,
-    "fullName": "Luis Díaz",
-    "clubName": "Liverpool FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 434675,
-    "fullName": "Cody Gakpo",
-    "clubName": "Liverpool FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 922462,
-    "fullName": "Lewis Koumas",
-    "clubName": "Liverpool FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 148455,
-    "fullName": "Mohamed Salah",
-    "clubName": "Liverpool FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 719673,
-    "fullName": "Ben Doak",
-    "clubName": "Liverpool FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 732119,
-    "fullName": "Kaide Gordon",
-    "clubName": "Liverpool FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 546543,
-    "fullName": "Darwin Núñez",
-    "clubName": "Liverpool FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 340950,
-    "fullName": "Diogo Jota",
-    "clubName": "Liverpool FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 939290,
-    "fullName": "Jayden Danns",
-    "clubName": "Liverpool FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 286047,
-    "fullName": "Guglielmo Vicario",
-    "clubName": "Tottenham Hotspur",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 17965,
-    "fullName": "Hugo Lloris",
-    "clubName": "Tottenham Hotspur",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 52570,
-    "fullName": "Fraser Forster",
-    "clubName": "Tottenham Hotspur",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 428016,
-    "fullName": "Brandon Austin",
-    "clubName": "Tottenham Hotspur",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 282823,
-    "fullName": "Alfie Whiteman",
-    "clubName": "Tottenham Hotspur",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 355915,
-    "fullName": "Cristian Romero",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 557459,
-    "fullName": "Micky van de Ven",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 568559,
-    "fullName": "Radu Drăgușin",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 341429,
-    "fullName": "Davinson Sánchez",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 175722,
-    "fullName": "Eric Dier",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 192765,
-    "fullName": "Ben Davies",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 297212,
-    "fullName": "Joe Rodon",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 859951,
-    "fullName": "Ashley Phillips",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 346478,
-    "fullName": "Japhet Tanganga",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 796300,
-    "fullName": "Alfie Dorrington",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 556385,
-    "fullName": "Destiny Udogie",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 282429,
-    "fullName": "Sergio Reguilón",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 392775,
-    "fullName": "Ryan Sessegnon",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 553875,
-    "fullName": "Pedro Porro",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 476344,
-    "fullName": "Emerson Royal",
-    "clubName": "Tottenham Hotspur",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 410425,
-    "fullName": "Yves Bissouma",
-    "clubName": "Tottenham Hotspur",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 354362,
-    "fullName": "Rodrigo Bentancur",
-    "clubName": "Tottenham Hotspur",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 167799,
-    "fullName": "Pierre-Emile Højbjerg",
-    "clubName": "Tottenham Hotspur",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 406638,
-    "fullName": "Oliver Skipp",
-    "clubName": "Tottenham Hotspur",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 568693,
-    "fullName": "Pape Matar Sarr",
-    "clubName": "Tottenham Hotspur",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 965971,
-    "fullName": "Tyrese Hall",
-    "clubName": "Tottenham Hotspur",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 294057,
-    "fullName": "James Maddison",
-    "clubName": "Tottenham Hotspur",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 431755,
-    "fullName": "Dejan Kulusevski",
-    "clubName": "Tottenham Hotspur",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 348795,
-    "fullName": "Giovani Lo Celso",
-    "clubName": "Tottenham Hotspur",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 91845,
-    "fullName": "Heung-min Son",
-    "clubName": "Tottenham Hotspur",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 170527,
-    "fullName": "Timo Werner",
-    "clubName": "Tottenham Hotspur",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 537382,
-    "fullName": "Bryan Gil",
-    "clubName": "Tottenham Hotspur",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 396638,
-    "fullName": "Manor Solomon",
-    "clubName": "Tottenham Hotspur",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 42460,
-    "fullName": "Ivan Perišić",
-    "clubName": "Tottenham Hotspur",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 706947,
-    "fullName": "Yago Santiago",
-    "clubName": "Tottenham Hotspur",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1011147,
-    "fullName": "Mikey Moore",
-    "clubName": "Tottenham Hotspur",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 470607,
-    "fullName": "Brennan Johnson",
-    "clubName": "Tottenham Hotspur",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 796305,
-    "fullName": "Jamie Donley",
-    "clubName": "Tottenham Hotspur",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 378710,
-    "fullName": "Richarlison",
-    "clubName": "Tottenham Hotspur",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 888493,
-    "fullName": "Alejo Veliz",
-    "clubName": "Tottenham Hotspur",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 670883,
-    "fullName": "Dane Scarlett",
-    "clubName": "Tottenham Hotspur",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 234509,
-    "fullName": "André Onana",
-    "clubName": "Manchester United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 258919,
-    "fullName": "Dean Henderson",
-    "clubName": "Manchester United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 336077,
-    "fullName": "Altay Bayındır",
-    "clubName": "Manchester United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 622236,
-    "fullName": "Radek Vítek",
-    "clubName": "Manchester United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 34130,
-    "fullName": "Tom Heaton",
-    "clubName": "Manchester United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 620362,
-    "fullName": "Dermot Mee",
-    "clubName": "Manchester United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 480762,
-    "fullName": "Lisandro Martínez",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 164770,
-    "fullName": "Raphaël Varane",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 177907,
-    "fullName": "Harry Maguire",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 184573,
-    "fullName": "Victor Lindelöf",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 780630,
-    "fullName": "Willy Kambwala",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 42412,
-    "fullName": "Jonny Evans",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 794816,
-    "fullName": "Rhys Bennett",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 858191,
-    "fullName": "Louis Jackson",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 183288,
-    "fullName": "Luke Shaw",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 339340,
-    "fullName": "Tyrell Malacia",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 282429,
-    "fullName": "Sergio Reguilón",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 811778,
-    "fullName": "Álvaro Carreras",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 507700,
-    "fullName": "Brandon Williams",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1011738,
-    "fullName": "Harry Amass",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 357147,
-    "fullName": "Diogo Dalot",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 477758,
-    "fullName": "Aaron Wan-Bissaka",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 864788,
-    "fullName": "Habeeb Ogunneye",
-    "clubName": "Manchester United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 287579,
-    "fullName": "Sofyan Amrabat",
-    "clubName": "Manchester United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 16306,
-    "fullName": "Casemiro",
-    "clubName": "Manchester United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 654253,
-    "fullName": "Toby Collyer",
-    "clubName": "Manchester United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 820374,
-    "fullName": "Kobbie Mainoo",
-    "clubName": "Manchester United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 315969,
-    "fullName": "Scott McTominay",
-    "clubName": "Manchester United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 69633,
-    "fullName": "Christian Eriksen",
-    "clubName": "Manchester United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 288255,
-    "fullName": "Donny van de Beek",
-    "clubName": "Manchester United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 747153,
-    "fullName": "Daniel Gore",
-    "clubName": "Manchester United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 240306,
-    "fullName": "Bruno Fernandes",
-    "clubName": "Manchester United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 346483,
-    "fullName": "Mason Mount",
-    "clubName": "Manchester United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 607224,
-    "fullName": "Hannibal",
-    "clubName": "Manchester United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 258923,
-    "fullName": "Marcus Rashford",
-    "clubName": "Manchester United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 811779,
-    "fullName": "Alejandro Garnacho",
-    "clubName": "Manchester United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 401173,
-    "fullName": "Jadon Sancho",
-    "clubName": "Manchester United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 640026,
-    "fullName": "Shola Shoretire",
-    "clubName": "Manchester United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 602105,
-    "fullName": "Antony",
-    "clubName": "Manchester United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 536835,
-    "fullName": "Amad Diallo",
-    "clubName": "Manchester United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 676318,
-    "fullName": "Facundo Pellistri",
-    "clubName": "Manchester United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 670845,
-    "fullName": "Omari Forson",
-    "clubName": "Manchester United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 610442,
-    "fullName": "Rasmus Højlund",
-    "clubName": "Manchester United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 182877,
-    "fullName": "Anthony Martial",
-    "clubName": "Manchester United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 726859,
-    "fullName": "Joe Hugill",
-    "clubName": "Manchester United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 888639,
-    "fullName": "Ethan Wheatley",
-    "clubName": "Manchester United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 111873,
-    "fullName": "Emiliano Martínez",
-    "clubName": "Aston Villa",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 591844,
-    "fullName": "Joe Gauci",
-    "clubName": "Aston Villa",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 75458,
-    "fullName": "Robin Olsen",
-    "clubName": "Aston Villa",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 610863,
-    "fullName": "Filip Marschall",
-    "clubName": "Aston Villa",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 555074,
-    "fullName": "Oliwier Zych",
-    "clubName": "Aston Villa",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 712181,
-    "fullName": "James Wright",
-    "clubName": "Aston Villa",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1004709,
-    "fullName": "Sam Proctor",
-    "clubName": "Aston Villa",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1237073,
-    "fullName": "Lander Emery",
-    "clubName": "Aston Villa",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 399776,
-    "fullName": "Pau Torres",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 413403,
-    "fullName": "Ezri Konsa",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 329145,
-    "fullName": "Diego Carlos",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 253677,
-    "fullName": "Tyrone Mings",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 182904,
-    "fullName": "Clément Lenglet",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 215118,
-    "fullName": "Calum Chambers",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 233124,
-    "fullName": "Kortney Hause",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 875929,
-    "fullName": "Josh Feeney",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 193098,
-    "fullName": "Álex Moreno",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 126664,
-    "fullName": "Lucas Digne",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 743414,
-    "fullName": "Lino Sousa",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 667925,
-    "fullName": "Sebastian Revan",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 845723,
-    "fullName": "Finley Munroe",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 874902,
-    "fullName": "Travis Patterson",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 425334,
-    "fullName": "Matty Cash",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 626888,
-    "fullName": "Kaine Kesler-Hayden",
-    "clubName": "Aston Villa",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 394327,
-    "fullName": "Boubacar Kamara",
-    "clubName": "Aston Villa",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 168157,
-    "fullName": "Leander Dendoncker",
-    "clubName": "Aston Villa",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 447661,
-    "fullName": "Douglas Luiz",
-    "clubName": "Aston Villa",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 503749,
-    "fullName": "Jacob Ramsey",
-    "clubName": "Aston Villa",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 193116,
-    "fullName": "John McGinn",
-    "clubName": "Aston Villa",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 249565,
-    "fullName": "Youri Tielemans",
-    "clubName": "Aston Villa",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 696589,
-    "fullName": "Tim Iroegbunam",
-    "clubName": "Aston Villa",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 321247,
-    "fullName": "Emiliano Buendía",
-    "clubName": "Aston Villa",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 392085,
-    "fullName": "Nicolò Zaniolo",
-    "clubName": "Aston Villa",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 503743,
-    "fullName": "Morgan Rogers",
-    "clubName": "Aston Villa",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 80444,
-    "fullName": "Philippe Coutinho",
-    "clubName": "Aston Villa",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 926135,
-    "fullName": "Omari Kellyman",
-    "clubName": "Aston Villa",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 818237,
-    "fullName": "Tommi O'Reilly",
-    "clubName": "Aston Villa",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 665390,
-    "fullName": "Jaden Philogene",
-    "clubName": "Aston Villa",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 887433,
-    "fullName": "Kadan Young",
-    "clubName": "Aston Villa",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 395516,
-    "fullName": "Moussa Diaby",
-    "clubName": "Aston Villa",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 387626,
-    "fullName": "Leon Bailey",
-    "clubName": "Aston Villa",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 131996,
-    "fullName": "Bertrand Traoré",
-    "clubName": "Aston Villa",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 324358,
-    "fullName": "Ollie Watkins",
-    "clubName": "Aston Villa",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 649317,
-    "fullName": "Jhon Durán",
-    "clubName": "Aston Villa",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 533662,
-    "fullName": "Cameron Archer",
-    "clubName": "Aston Villa",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 192080,
-    "fullName": "Nick Pope",
-    "clubName": "Newcastle United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 74960,
-    "fullName": "Martin Dúbravka",
-    "clubName": "Newcastle United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 85864,
-    "fullName": "Loris Karius",
-    "clubName": "Newcastle United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 142389,
-    "fullName": "Mark Gillespie",
-    "clubName": "Newcastle United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1019169,
-    "fullName": "Adam Harrison",
-    "clubName": "Newcastle United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1019170,
-    "fullName": "Aidan Harris",
-    "clubName": "Newcastle United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 361093,
-    "fullName": "Sven Botman",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 135343,
-    "fullName": "Fabian Schär",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 134270,
-    "fullName": "Dan Burn",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 183318,
-    "fullName": "Jamaal Lascelles",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 484389,
-    "fullName": "Kell Watts",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 670858,
-    "fullName": "Lewis Hall",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 250478,
-    "fullName": "Matt Targett",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 346018,
-    "fullName": "Jamal Lewis",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 170321,
-    "fullName": "Paul Dummett",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 900601,
-    "fullName": "Alex Murphy",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 503981,
-    "fullName": "Tino Livramento",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 95810,
-    "fullName": "Kieran Trippier",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 184528,
-    "fullName": "Emil Krafth",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 162029,
-    "fullName": "Javier Manquillo",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 559130,
-    "fullName": "Harrison Ashby",
-    "clubName": "Newcastle United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 520624,
-    "fullName": "Bruno Guimarães",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 206225,
-    "fullName": "Isaac Hayden",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 333241,
-    "fullName": "Joelinton",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 397033,
-    "fullName": "Sandro Tonali",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 340329,
-    "fullName": "Joe Willock",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 346707,
-    "fullName": "Sean Longstaff",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 922769,
-    "fullName": "Lewis Miley",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 567576,
-    "fullName": "Elliot Anderson",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 148262,
-    "fullName": "Jeff Hendrick",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 626291,
-    "fullName": "Lucas De Bolle",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1053908,
-    "fullName": "Travis Hernes",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 712115,
-    "fullName": "James Huntley",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 92469,
-    "fullName": "Matt Ritchie",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 614811,
-    "fullName": "Joe White",
-    "clubName": "Newcastle United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 503733,
-    "fullName": "Anthony Gordon",
-    "clubName": "Newcastle United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 398065,
-    "fullName": "Harvey Barnes",
-    "clubName": "Newcastle United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 146795,
-    "fullName": "Ryan Fraser",
-    "clubName": "Newcastle United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 533086,
-    "fullName": "Amadou Diallo",
-    "clubName": "Newcastle United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 272999,
-    "fullName": "Miguel Almirón",
-    "clubName": "Newcastle United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 199527,
-    "fullName": "Jacob Murphy",
-    "clubName": "Newcastle United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 349066,
-    "fullName": "Alexander Isak",
-    "clubName": "Newcastle United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 123682,
-    "fullName": "Callum Wilson",
-    "clubName": "Newcastle United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 922764,
-    "fullName": "Ben Parkinson",
-    "clubName": "Newcastle United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 698151,
-    "fullName": "Michael Ndiweni",
-    "clubName": "Newcastle United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 565093,
-    "fullName": "Bart Verbruggen",
-    "clubName": "Brighton & Hove Albion",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 73564,
-    "fullName": "Jason Steele",
-    "clubName": "Brighton & Hove Albion",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 646353,
-    "fullName": "Carl Rushworth",
-    "clubName": "Brighton & Hove Albion",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 406556,
-    "fullName": "Tom McGill",
-    "clubName": "Brighton & Hove Albion",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 212847,
-    "fullName": "Adam Webster",
-    "clubName": "Brighton & Hove Albion",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 576314,
-    "fullName": "Jan Paul van Hecke",
-    "clubName": "Brighton & Hove Albion",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 380350,
-    "fullName": "Igor",
-    "clubName": "Brighton & Hove Albion",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 148153,
-    "fullName": "Lewis Dunk",
-    "clubName": "Brighton & Hove Albion",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 580809,
-    "fullName": "Ed Turns",
-    "clubName": "Brighton & Hove Albion",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 801474,
-    "fullName": "Ben Jackson",
-    "clubName": "Brighton & Hove Albion",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 724530,
-    "fullName": "Leigh Kavanagh",
-    "clubName": "Brighton & Hove Albion",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 913214,
-    "fullName": "Noel Atom",
-    "clubName": "Brighton & Hove Albion",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 349599,
-    "fullName": "Pervis Estupiñán",
-    "clubName": "Brighton & Hove Albion",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 565846,
-    "fullName": "Imari Samuels",
-    "clubName": "Brighton & Hove Albion",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 504148,
-    "fullName": "Tariq Lamptey",
-    "clubName": "Brighton & Hove Albion",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 111195,
-    "fullName": "Joël Veltman",
-    "clubName": "Brighton & Hove Albion",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 567597,
-    "fullName": "Odeluga Offiah",
-    "clubName": "Brighton & Hove Albion",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 973085,
-    "fullName": "Carlos Baleba",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 423744,
-    "fullName": "Billy Gilmour",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 867688,
-    "fullName": "Jack Hinshelwood",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 854689,
-    "fullName": "Jack Hinchy",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 849410,
-    "fullName": "Valentín Barco",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 384461,
-    "fullName": "Jakub Moder",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 82873,
-    "fullName": "Pascal Groß",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 191422,
-    "fullName": "Mahmoud Dahoud",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 667287,
-    "fullName": "Yasin Ayari",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 476237,
-    "fullName": "Steven Alzate",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 3333,
-    "fullName": "James Milner",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 463751,
-    "fullName": "Marc Leonard",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 520651,
-    "fullName": "Jensen Weir",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 756591,
-    "fullName": "Samy Chouchane",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 660867,
-    "fullName": "Julio Enciso",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 983989,
-    "fullName": "Facundo Buonanotte",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 724537,
-    "fullName": "Andrew Moran",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 43530,
-    "fullName": "Adam Lallana",
-    "clubName": "Brighton & Hove Albion",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 504849,
-    "fullName": "Kaoru Mitoma",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 658536,
-    "fullName": "Simon Adingra",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 466810,
-    "fullName": "Ansu Fati",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 776798,
-    "fullName": "Abdallah Sima",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 568005,
-    "fullName": "Jeremy Sarmiento",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 745689,
-    "fullName": "Luca Barrington",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 703626,
-    "fullName": "Cameron Peupion",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 209212,
-    "fullName": "Solly March",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 657817,
-    "fullName": "Benicio Baker",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 648046,
-    "fullName": "Evan Ferguson",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 626724,
-    "fullName": "João Pedro",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 67063,
-    "fullName": "Danny Welbeck",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 867700,
-    "fullName": "Joshua Duffus",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 943549,
-    "fullName": "Mark O'Mahony",
-    "clubName": "Brighton & Hove Albion",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 425306,
-    "fullName": "Matt Turner",
-    "clubName": "Nottingham Forest",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 124419,
-    "fullName": "Odysseas Vlachodimos",
-    "clubName": "Nottingham Forest",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 127202,
-    "fullName": "Matz Sels",
-    "clubName": "Nottingham Forest",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 242284,
-    "fullName": "Ethan Horvath",
-    "clubName": "Nottingham Forest",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 45494,
-    "fullName": "Wayne Hennessey",
-    "clubName": "Nottingham Forest",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1005649,
-    "fullName": "Murillo",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 291200,
-    "fullName": "Moussa Niakhaté",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 621993,
-    "fullName": "Andrew Omobamidele",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 255906,
-    "fullName": "Scott McKenna",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 415970,
-    "fullName": "Joe Worrall",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 142310,
-    "fullName": "Willy Boly",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 156501,
-    "fullName": "Felipe",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 933017,
-    "fullName": "Zach Abbott",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 535955,
-    "fullName": "Nuno Tavares",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 198516,
-    "fullName": "Harry Toffolo",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 503680,
-    "fullName": "Neco Williams",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 236490,
-    "fullName": "Ola Aina",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 402733,
-    "fullName": "Gonzalo Montiel",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 127032,
-    "fullName": "Serge Aurier",
-    "clubName": "Nottingham Forest",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 375885,
-    "fullName": "Ibrahim Sangaré",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 808509,
-    "fullName": "Danilo",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 289592,
-    "fullName": "Orel Mangala",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 66934,
-    "fullName": "Cheikhou Kouyaté",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 694901,
-    "fullName": "Jamie McDonnell",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 497291,
-    "fullName": "Nicolás Domínguez",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 743600,
-    "fullName": "Andrey Santos",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 425902,
-    "fullName": "Ryan Yates",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 148252,
-    "fullName": "Remo Freuler",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 560694,
-    "fullName": "Lewis O'Brien",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 55742,
-    "fullName": "Harry Arter",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 429014,
-    "fullName": "Morgan Gibbs-White",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 504215,
-    "fullName": "Giovanni Reyna",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 631996,
-    "fullName": "Brandon Aguilera",
-    "clubName": "Nottingham Forest",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 392768,
-    "fullName": "Callum Hudson-Odoi",
-    "clubName": "Nottingham Forest",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 503988,
-    "fullName": "Alex Mighten",
-    "clubName": "Nottingham Forest",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 470607,
-    "fullName": "Brennan Johnson",
-    "clubName": "Nottingham Forest",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 583189,
-    "fullName": "Anthony Elanga",
-    "clubName": "Nottingham Forest",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 506470,
-    "fullName": "Josh Bowler",
-    "clubName": "Nottingham Forest",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 295313,
-    "fullName": "Taiwo Awoniyi",
-    "clubName": "Nottingham Forest",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 108725,
-    "fullName": "Chris Wood",
-    "clubName": "Nottingham Forest",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 148368,
-    "fullName": "Divock Origi",
-    "clubName": "Nottingham Forest",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 448854,
-    "fullName": "Emmanuel Dennis",
-    "clubName": "Nottingham Forest",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 726701,
-    "fullName": "Rodrigo Ribeiro",
-    "clubName": "Nottingham Forest",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 260166,
-    "fullName": "Ui-jo Hwang",
-    "clubName": "Nottingham Forest",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 921513,
-    "fullName": "Joe Gardner",
-    "clubName": "Nottingham Forest",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 921532,
-    "fullName": "Detlef Esapa Osong",
-    "clubName": "Nottingham Forest",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 120629,
-    "fullName": "Alphonse Areola",
-    "clubName": "West Ham United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 29692,
-    "fullName": "Lukasz Fabianski",
-    "clubName": "West Ham United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 576099,
-    "fullName": "Joseph Anang",
-    "clubName": "West Ham United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 670878,
-    "fullName": "Jacob Knightbridge",
-    "clubName": "West Ham United",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 361914,
-    "fullName": "Nayef Aguerd",
-    "clubName": "West Ham United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 157509,
-    "fullName": "Kurt Zouma",
-    "clubName": "West Ham United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 415912,
-    "fullName": "Konstantinos Mavropanos",
-    "clubName": "West Ham United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 228948,
-    "fullName": "Thilo Kehrer",
-    "clubName": "West Ham United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 845321,
-    "fullName": "Kaelan Casey",
-    "clubName": "West Ham United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 48002,
-    "fullName": "Angelo Ogbonna",
-    "clubName": "West Ham United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 586982,
-    "fullName": "Levi Laing",
-    "clubName": "West Ham United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 181778,
-    "fullName": "Emerson",
-    "clubName": "West Ham United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 92571,
-    "fullName": "Aaron Cresswell",
-    "clubName": "West Ham United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 922563,
-    "fullName": "Oliver Scarles",
-    "clubName": "West Ham United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 468002,
-    "fullName": "Ben Johnson",
-    "clubName": "West Ham United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 157672,
-    "fullName": "Vladimír Coufal",
-    "clubName": "West Ham United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 401356,
-    "fullName": "Edson Álvarez",
-    "clubName": "West Ham United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 283628,
-    "fullName": "Tomáš Souček",
-    "clubName": "West Ham United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 351749,
-    "fullName": "Kalvin Phillips",
-    "clubName": "West Ham United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 506189,
-    "fullName": "Flynn Downes",
-    "clubName": "West Ham United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 419025,
-    "fullName": "Conor Coventry",
-    "clubName": "West Ham United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 181579,
-    "fullName": "James Ward-Prowse",
-    "clubName": "West Ham United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 357885,
-    "fullName": "Pablo Fornals",
-    "clubName": "West Ham United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 845809,
-    "fullName": "Lewis Orford",
-    "clubName": "West Ham United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 561452,
-    "fullName": "Dan Chesters",
-    "clubName": "West Ham United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 444523,
-    "fullName": "Lucas Paquetá",
-    "clubName": "West Ham United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 697280,
-    "fullName": "George Earthy",
-    "clubName": "West Ham United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 693066,
-    "fullName": "Kamarai Swyer",
-    "clubName": "West Ham United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 290532,
-    "fullName": "Saïd Benrahma",
-    "clubName": "West Ham United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 234781,
-    "fullName": "Maxwel Cornet",
-    "clubName": "West Ham United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 543499,
-    "fullName": "Mohammed Kudus",
-    "clubName": "West Ham United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 314875,
-    "fullName": "Jarrod Bowen",
-    "clubName": "West Ham United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 134294,
-    "fullName": "Danny Ings",
-    "clubName": "West Ham United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 104124,
-    "fullName": "Michail Antonio",
-    "clubName": "West Ham United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 953135,
-    "fullName": "Callum Marshall",
-    "clubName": "West Ham United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 670848,
-    "fullName": "Divin Mubama",
-    "clubName": "West Ham United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 258919,
-    "fullName": "Dean Henderson",
-    "clubName": "Crystal Palace",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 110864,
-    "fullName": "Sam Johnstone",
-    "clubName": "Crystal Palace",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 670840,
-    "fullName": "Joe Whitworth",
-    "clubName": "Crystal Palace",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 196722,
-    "fullName": "Remi Matthews",
-    "clubName": "Crystal Palace",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 392757,
-    "fullName": "Marc Guéhi",
-    "clubName": "Crystal Palace",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 260827,
-    "fullName": "Joachim Andersen",
-    "clubName": "Crystal Palace",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 578539,
-    "fullName": "Chris Richards",
-    "clubName": "Crystal Palace",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 253341,
-    "fullName": "Rob Holding",
-    "clubName": "Crystal Palace",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 507254,
-    "fullName": "Nathan Ferguson",
-    "clubName": "Crystal Palace",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 61592,
-    "fullName": "James Tomkins",
-    "clubName": "Crystal Palace",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 875235,
-    "fullName": "Seán Grehan",
-    "clubName": "Crystal Palace",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 730893,
-    "fullName": "Tyrick Mitchell",
-    "clubName": "Crystal Palace",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 724529,
-    "fullName": "Tayo Adaramola",
-    "clubName": "Crystal Palace",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 493003,
-    "fullName": "Daniel Muñoz",
-    "clubName": "Crystal Palace",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 85177,
-    "fullName": "Nathaniel Clyne",
-    "clubName": "Crystal Palace",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 92572,
-    "fullName": "Joel Ward",
-    "clubName": "Crystal Palace",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 543387,
-    "fullName": "Cheick Doucouré",
-    "clubName": "Crystal Palace",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 744149,
-    "fullName": "Adam Wharton",
-    "clubName": "Crystal Palace",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 262980,
-    "fullName": "Jefferson Lerma",
-    "clubName": "Crystal Palace",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 241481,
-    "fullName": "Jaïro Riedewald",
-    "clubName": "Crystal Palace",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 865993,
-    "fullName": "David Ozoh",
-    "clubName": "Crystal Palace",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 860078,
-    "fullName": "Kaden Rodney",
-    "clubName": "Crystal Palace",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 207014,
-    "fullName": "Will Hughes",
-    "clubName": "Crystal Palace",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 538971,
-    "fullName": "Naouirou Ahamada",
-    "clubName": "Crystal Palace",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 814811,
-    "fullName": "Jack Wells-Morrison",
-    "clubName": "Crystal Palace",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 157506,
-    "fullName": "Jeffrey Schlupp",
-    "clubName": "Crystal Palace",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 479999,
-    "fullName": "Eberechi Eze",
-    "clubName": "Crystal Palace",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 743597,
-    "fullName": "Matheus França",
-    "clubName": "Crystal Palace",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 655815,
-    "fullName": "Jadan Raymond",
-    "clubName": "Crystal Palace",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 659331,
-    "fullName": "John-Kymani Gordon",
-    "clubName": "Crystal Palace",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 566723,
-    "fullName": "Michael Olise",
-    "clubName": "Crystal Palace",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 108354,
-    "fullName": "Jordan Ayew",
-    "clubName": "Crystal Palace",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 586834,
-    "fullName": "Jesurun Rak-Sakyi",
-    "clubName": "Crystal Palace",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 512354,
-    "fullName": "Malcolm Ebiowei",
-    "clubName": "Crystal Palace",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 943560,
-    "fullName": "Franco Umeh-Chibueze",
-    "clubName": "Crystal Palace",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 706822,
-    "fullName": "Roshaun Mathurin",
-    "clubName": "Crystal Palace",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 420002,
-    "fullName": "Jean-Philippe Mateta",
-    "clubName": "Crystal Palace",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 344152,
-    "fullName": "Odsonne Édouard",
-    "clubName": "Crystal Palace",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 586986,
-    "fullName": "Luke Plange",
-    "clubName": "Crystal Palace",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 814820,
-    "fullName": "Ademola Ola-Adebomi",
-    "clubName": "Crystal Palace",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 249994,
-    "fullName": "José Sá",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 136401,
-    "fullName": "Daniel Bentley",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 215810,
-    "fullName": "Tom King",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 444641,
-    "fullName": "Louie Moulden",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 525247,
-    "fullName": "Maximilian Kilman",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 606718,
-    "fullName": "Toti",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 438001,
-    "fullName": "Santiago Bueno",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 716276,
-    "fullName": "Yerson Mosquera",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 121477,
-    "fullName": "Craig Dawson",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 678641,
-    "fullName": "Justin Hubner",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 821522,
-    "fullName": "Alfie Pond",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 813142,
-    "fullName": "Temple Ojinnaka",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 578391,
-    "fullName": "Rayan Aït-Nouri",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 698678,
-    "fullName": "Hugo Bueno",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 797679,
-    "fullName": "Aaron Keto-Diyawa",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 175446,
-    "fullName": "Jonny Otto",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 485583,
-    "fullName": "Ki-Jana Hoever",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 171679,
-    "fullName": "Matt Doherty",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1115502,
-    "fullName": "Wesley Okoduwa",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 170934,
-    "fullName": "Mario Lemina",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 649020,
-    "fullName": "Boubacar Traoré",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 503975,
-    "fullName": "Joe Hodge",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 415646,
-    "fullName": "Bruno Jordão",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 670558,
-    "fullName": "Harvey Griffiths",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 601883,
-    "fullName": "Matheus Nunes",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 735570,
-    "fullName": "João Gomes",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 450050,
-    "fullName": "Jean-Ricner Bellegarde",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 433183,
-    "fullName": "Tommy Doyle",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 908798,
-    "fullName": "Matthew Whittingham",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 231572,
-    "fullName": "Nélson Semedo",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 532541,
-    "fullName": "Luke Cundle",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 614603,
-    "fullName": "Chem Campbell",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 724783,
-    "fullName": "Tawanda Chirewa",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 816124,
-    "fullName": "Noha Lemina",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 751666,
-    "fullName": "Ty Barnett",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 550995,
-    "fullName": "Owen Hesketh",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1060740,
-    "fullName": "Enso González",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1172645,
-    "fullName": "Emilio Ballard-Matthews",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 487465,
-    "fullName": "Pedro Neto",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 74230,
-    "fullName": "Pablo Sarabia",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 517894,
-    "fullName": "Matheus Cunha",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 292246,
-    "fullName": "Hee-chan Hwang",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 505653,
-    "fullName": "Fábio Silva",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 369567,
-    "fullName": "Sasa Kalajdzic",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 863741,
-    "fullName": "Nathan Fraser",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1043634,
-    "fullName": "Leon Chiwome",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1080392,
-    "fullName": "Fletcher Holman",
-    "clubName": "Wolverhampton Wanderers",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 125714,
-    "fullName": "Mark Flekken",
-    "clubName": "Brentford FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 222209,
-    "fullName": "Thomas Strakosha",
-    "clubName": "Brentford FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 488935,
-    "fullName": "Hákon Valdimarsson",
-    "clubName": "Brentford FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 741236,
-    "fullName": "Matthew Cox",
-    "clubName": "Brentford FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 456292,
-    "fullName": "Ellery Balcombe",
-    "clubName": "Brentford FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 736251,
-    "fullName": "Vincent Angelini",
-    "clubName": "Brentford FC",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 469050,
-    "fullName": "Nathan Collins",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 328658,
-    "fullName": "Kristoffer Ajer",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 442248,
-    "fullName": "Ethan Pinnock",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 52059,
-    "fullName": "Zanka",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 74810,
-    "fullName": "Ben Mee",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 709767,
-    "fullName": "Ji-soo Kim",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 376856,
-    "fullName": "Charlie Goode",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1071138,
-    "fullName": "Benjamin Fredrick",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1144158,
-    "fullName": "Benjamin Arthur",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 339556,
-    "fullName": "Rico Henry",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 282429,
-    "fullName": "Sergio Reguilón",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 747996,
-    "fullName": "Val Adedokun",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 591949,
-    "fullName": "Aaron Hickey",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 391005,
-    "fullName": "Mads Roerslev",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 587019,
-    "fullName": "Fin Stevens",
-    "clubName": "Brentford FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 270171,
-    "fullName": "Vitaly Janelt",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 148367,
-    "fullName": "Christian Nørgaard",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1141628,
-    "fullName": "Yunus Konak",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 319859,
-    "fullName": "Mathias Jensen",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 340321,
-    "fullName": "Josh Dasilva",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 717411,
-    "fullName": "Yegor Yarmolyuk",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 421637,
-    "fullName": "Frank Onyeka",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 533916,
-    "fullName": "Shandon Baptiste",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 470596,
-    "fullName": "Paris Maghoma",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 718250,
-    "fullName": "Ethan Brierley",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 874538,
-    "fullName": "Ryan Trevitt",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 540941,
-    "fullName": "Mikkel Damsgaard",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 204294,
-    "fullName": "Saman Ghoddos",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 587002,
-    "fullName": "Myles Peart-Harris",
-    "clubName": "Brentford FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 473050,
-    "fullName": "Kevin Schade",
-    "clubName": "Brentford FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 644401,
-    "fullName": "Keane Lewis-Potter",
-    "clubName": "Brentford FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 413039,
-    "fullName": "Bryan Mbeumo",
-    "clubName": "Brentford FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 734425,
-    "fullName": "Michael Olakigbe",
-    "clubName": "Brentford FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 251664,
-    "fullName": "Ivan Toney",
-    "clubName": "Brentford FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 388165,
-    "fullName": "Yoane Wissa",
-    "clubName": "Brentford FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 217115,
-    "fullName": "Neal Maupay",
-    "clubName": "Brentford FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 357658,
-    "fullName": "Mark Travers",
-    "clubName": "AFC Bournemouth",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 303657,
-    "fullName": "Ionuț Radu",
-    "clubName": "AFC Bournemouth",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 111819,
-    "fullName": "Neto",
-    "clubName": "AFC Bournemouth",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 582078,
-    "fullName": "Will Dennis",
-    "clubName": "AFC Bournemouth",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 51321,
-    "fullName": "Darren Randolph",
-    "clubName": "AFC Bournemouth",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 655136,
-    "fullName": "Cameron Plain",
-    "clubName": "AFC Bournemouth",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 983248,
-    "fullName": "Callan McKenna",
-    "clubName": "AFC Bournemouth",
-    "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 659089,
-    "fullName": "Ilya Zabarnyi",
-    "clubName": "AFC Bournemouth",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 469781,
-    "fullName": "Marcos Senesi",
-    "clubName": "AFC Bournemouth",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 480116,
-    "fullName": "Lloyd Kelly",
-    "clubName": "AFC Bournemouth",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 480987,
-    "fullName": "Chris Mepham",
-    "clubName": "AFC Bournemouth",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 611793,
-    "fullName": "James Hill",
-    "clubName": "AFC Bournemouth",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 939615,
-    "fullName": "Max Kinsey",
-    "clubName": "AFC Bournemouth",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 730861,
-    "fullName": "Milos Kerkez",
-    "clubName": "AFC Bournemouth",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 646333,
-    "fullName": "Ben Greenwood",
-    "clubName": "AFC Bournemouth",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 471690,
-    "fullName": "Max Aarons",
-    "clubName": "AFC Bournemouth",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 140191,
-    "fullName": "Ryan Fredericks",
-    "clubName": "AFC Bournemouth",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 61841,
-    "fullName": "Adam Smith",
-    "clubName": "AFC Bournemouth",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 332705,
-    "fullName": "Tyler Adams",
-    "clubName": "AFC Bournemouth",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 320411,
-    "fullName": "Philip Billing",
-    "clubName": "AFC Bournemouth",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 855256,
-    "fullName": "Alex Scott",
-    "clubName": "AFC Bournemouth",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 249089,
-    "fullName": "Lewis Cook",
-    "clubName": "AFC Bournemouth",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 188077,
-    "fullName": "Ryan Christie",
-    "clubName": "AFC Bournemouth",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 183293,
-    "fullName": "Joe Rothwell",
-    "clubName": "AFC Bournemouth",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 469064,
-    "fullName": "Gavin Kilkenny",
-    "clubName": "AFC Bournemouth",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 555076,
-    "fullName": "Romain Faivre",
-    "clubName": "AFC Bournemouth",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 399434,
-    "fullName": "Marcus Tavernier",
-    "clubName": "AFC Bournemouth",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 391065,
-    "fullName": "Hamed Traoré",
-    "clubName": "AFC Bournemouth",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 330659,
-    "fullName": "Justin Kluivert",
-    "clubName": "AFC Bournemouth",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 232964,
-    "fullName": "Emiliano Marcondes",
-    "clubName": "AFC Bournemouth",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 823231,
-    "fullName": "Dango Ouattara",
-    "clubName": "AFC Bournemouth",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 512385,
-    "fullName": "Luis Sinisterra",
-    "clubName": "AFC Bournemouth",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 684210,
-    "fullName": "Jaidon Anthony",
-    "clubName": "AFC Bournemouth",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 583255,
-    "fullName": "Antoine Semenyo",
-    "clubName": "AFC Bournemouth",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 277033,
-    "fullName": "David Brooks",
-    "clubName": "AFC Bournemouth",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 936901,
-    "fullName": "Dominic Sadi",
-    "clubName": "AFC Bournemouth",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 854722,
-    "fullName": "Michael Dacosta",
-    "clubName": "AFC Bournemouth",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 258889,
-    "fullName": "Dominic Solanke",
-    "clubName": "AFC Bournemouth",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 251106,
-    "fullName": "Enes Ünal",
-    "clubName": "AFC Bournemouth",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 275590,
-    "fullName": "Kieffer Moore",
-    "clubName": "AFC Bournemouth",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 239949,
-    "fullName": "Jamal Lowe",
-    "clubName": "AFC Bournemouth",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 963878,
-    "fullName": "Daniel Adu-Adjei",
-    "clubName": "AFC Bournemouth",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 130164,
-    "fullName": "Jordan Pickford",
-    "clubName": "Everton FC",
+    "fullName": "Нико Уильямс",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.5,
+    "popularity": 25.3
+  },
+  {
+    "playerId": 214086,
+    "fullName": "Уче",
+    "clubName": "Хетафе",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 3.7
+  },
+  {
+    "playerId": 214076,
+    "fullName": "Лисо",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 213792,
+    "fullName": "Жуниор",
+    "clubName": "Вильярреал",
     "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 329813,
-    "fullName": "João Virgínia",
-    "clubName": "Everton FC",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 14.9
+  },
+  {
+    "playerId": 213929,
+    "fullName": "Паласон",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213800,
+    "fullName": "Гуйе",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 3.2
+  },
+  {
+    "playerId": 214062,
+    "fullName": "Бекуша",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 10.2
+  },
+  {
+    "playerId": 213826,
+    "fullName": "Хоэль Рока",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 213938,
+    "fullName": "Милитао",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 4.3
+  },
+  {
+    "playerId": 214027,
+    "fullName": "Агуме",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213780,
+    "fullName": "Диего Лопес",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 213851,
+    "fullName": "Толян",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 214038,
+    "fullName": "Лукебакио",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 5.4
+  },
+  {
+    "playerId": 214106,
+    "fullName": "Валера",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213788,
+    "fullName": "Моуриньо",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 10.6
+  },
+  {
+    "playerId": 213636,
+    "fullName": "Теналья",
+    "clubName": "Алавес",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 3.1
+  },
+  {
+    "playerId": 213729,
+    "fullName": "Рафинья",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 11.5,
+    "popularity": 38.2
+  },
+  {
+    "playerId": 213638,
+    "fullName": "Антонио Бланко",
+    "clubName": "Алавес",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213700,
+    "fullName": "Хулиан Альварес",
+    "clubName": "Атлетико",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 9.5,
+    "popularity": 34.6
+  },
+  {
+    "playerId": 213798,
+    "fullName": "Кардона",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 13.2
+  },
+  {
+    "playerId": 213796,
+    "fullName": "Этта-Эйонг",
+    "clubName": "Вильярреал",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 12.4
+  },
+  {
+    "playerId": 214009,
+    "fullName": "Кубо",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 6.7
+  },
+  {
+    "playerId": 213795,
+    "fullName": "Фойт",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 8.6
+  },
+  {
+    "playerId": 213794,
+    "fullName": "Рафа Марин",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 3.6
+  },
+  {
+    "playerId": 213709,
+    "fullName": "Кубарси",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 13.8
+  },
+  {
+    "playerId": 213708,
+    "fullName": "Араухо",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 4.9
+  },
+  {
+    "playerId": 214136,
+    "fullName": "Экспосито",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214032,
+    "fullName": "Хуанлу Санчес",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213930,
+    "fullName": "Альваро Гарсия",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214125,
+    "fullName": "Рубио",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213753,
+    "fullName": "Рикельме",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 3.3
+  },
+  {
+    "playerId": 213807,
+    "fullName": "Пино",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 7.3
+  },
+  {
+    "playerId": 213806,
+    "fullName": "Пепе",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 11.1
+  },
+  {
+    "playerId": 213637,
+    "fullName": "Аленья",
+    "clubName": "Алавес",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213640,
+    "fullName": "Тони Мартинес",
+    "clubName": "Алавес",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 213939,
+    "fullName": "Альваро Каррерас",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 213956,
+    "fullName": "Мбаппе",
+    "clubName": "Реал Мадрид",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 11.5,
+    "popularity": 69.6
+  },
+  {
+    "playerId": 213945,
+    "fullName": "Александер-Арнолд",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 30.5
+  },
+  {
+    "playerId": 213714,
+    "fullName": "Бальде",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 8.5
+  },
+  {
+    "playerId": 214132,
+    "fullName": "Пере Милья",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213716,
+    "fullName": "Жоан Гарсия",
+    "clubName": "Барселона",
     "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 14044,
-    "fullName": "Andy Lonergan",
-    "clubName": "Everton FC",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 5.9
+  },
+  {
+    "playerId": 213719,
+    "fullName": "Эрик Гарсия",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 214083,
+    "fullName": "Сория",
+    "clubName": "Хетафе",
     "position": "GK",
-    "league": "EPL"
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 4.8
   },
   {
-    "playerId": 536794,
-    "fullName": "Billy Crellin",
-    "clubName": "Everton FC",
+    "playerId": 213940,
+    "fullName": "Куртуа",
+    "clubName": "Реал Мадрид",
     "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 661053,
-    "fullName": "Jarrad Branthwaite",
-    "clubName": "Everton FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 173504,
-    "fullName": "James Tarkowski",
-    "clubName": "Everton FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 343475,
-    "fullName": "Ben Godfrey",
-    "clubName": "Everton FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 118534,
-    "fullName": "Michael Keane",
-    "clubName": "Everton FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 348623,
-    "fullName": "Mason Holgate",
-    "clubName": "Everton FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 747598,
-    "fullName": "Elijah Campbell",
-    "clubName": "Everton FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 404842,
-    "fullName": "Vitaliy Mykolenko",
-    "clubName": "Everton FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 574420,
-    "fullName": "Mackenzie Hunt",
-    "clubName": "Everton FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 424015,
-    "fullName": "Nathan Patterson",
-    "clubName": "Everton FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 14086,
-    "fullName": "Ashley Young",
-    "clubName": "Everton FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 68390,
-    "fullName": "Séamus Coleman",
-    "clubName": "Everton FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 485706,
-    "fullName": "Amadou Onana",
-    "clubName": "Everton FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 505219,
-    "fullName": "James Garner",
-    "clubName": "Everton FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 126665,
-    "fullName": "Idrissa Gueye",
-    "clubName": "Everton FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 221025,
-    "fullName": "André Gomes",
-    "clubName": "Everton FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 652979,
-    "fullName": "Lewis Warrington",
-    "clubName": "Everton FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 663225,
-    "fullName": "Tyler Onyango",
-    "clubName": "Everton FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 855890,
-    "fullName": "Jenson Metcalfe",
-    "clubName": "Everton FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 127187,
-    "fullName": "Abdoulaye Doucouré",
-    "clubName": "Everton FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 207929,
-    "fullName": "Dele Alli",
-    "clubName": "Everton FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 242631,
-    "fullName": "Alex Iwobi",
-    "clubName": "Everton FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 584769,
-    "fullName": "Dwight McNeil",
-    "clubName": "Everton FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 417346,
-    "fullName": "Jack Harrison",
-    "clubName": "Everton FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 355861,
-    "fullName": "Arnaut Danjuma",
-    "clubName": "Everton FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 627248,
-    "fullName": "Lewis Dobbin",
-    "clubName": "Everton FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 306024,
-    "fullName": "Dominic Calvert-Lewin",
-    "clubName": "Everton FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 595809,
-    "fullName": "Beto",
-    "clubName": "Everton FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 217115,
-    "fullName": "Neal Maupay",
-    "clubName": "Everton FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 670688,
-    "fullName": "Youssef Chermiti",
-    "clubName": "Everton FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 669366,
-    "fullName": "Tom Cannon",
-    "clubName": "Everton FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 72476,
-    "fullName": "Bernd Leno",
-    "clubName": "Fulham FC",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 14.6
+  },
+  {
+    "playerId": 213696,
+    "fullName": "Симеоне",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 4.6
+  },
+  {
+    "playerId": 213944,
+    "fullName": "Хейсен",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 14.1
+  },
+  {
+    "playerId": 213725,
+    "fullName": "Ферран Торрес",
+    "clubName": "Барселона",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 12.2
+  },
+  {
+    "playerId": 214033,
+    "fullName": "Адамс",
+    "clubName": "Севилья",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213657,
+    "fullName": "Роберт Наварро",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214071,
+    "fullName": "Хуан Иглесиас",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214063,
+    "fullName": "Давинчи",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 8.2
+  },
+  {
+    "playerId": 214069,
+    "fullName": "Джене",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213837,
+    "fullName": "Цыганков",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 214008,
+    "fullName": "Браис Мендес",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 214079,
+    "fullName": "Рико",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 213663,
+    "fullName": "Саннади",
+    "clubName": "Атлетик",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213723,
+    "fullName": "Педри",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 16.9
+  },
+  {
+    "playerId": 214087,
+    "fullName": "Арамбарри",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213754,
+    "fullName": "Форнальс",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213857,
+    "fullName": "Ури Рей",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213980,
+    "fullName": "Шаира",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213858,
+    "fullName": "Бруги",
+    "clubName": "Леванте",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213693,
+    "fullName": "Галлахер",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 4.3
+  },
+  {
+    "playerId": 214085,
+    "fullName": "Луис Милья",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214077,
+    "fullName": "Марио Мартин",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214096,
+    "fullName": "Аффенгрубер",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213781,
+    "fullName": "Раба",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213892,
+    "fullName": "Розье",
+    "clubName": "Осасуна",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213747,
+    "fullName": "Серджи Альтимира",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.0
+  },
+  {
+    "playerId": 213907,
+    "fullName": "Будимир",
+    "clubName": "Осасуна",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 7.9
+  },
+  {
+    "playerId": 213904,
+    "fullName": "Торро",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214124,
+    "fullName": "Карлос Ромеро",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214108,
+    "fullName": "Мартим Нету",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214110,
+    "fullName": "Фебас",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213926,
+    "fullName": "Унаи Лопес",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213756,
+    "fullName": "Ло Чельсо",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 15.9
+  },
+  {
+    "playerId": 214101,
+    "fullName": "Мендоса",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 4.0
+  },
+  {
+    "playerId": 213720,
+    "fullName": "Гави",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 213721,
+    "fullName": "де Йонг",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 2.9
+  },
+  {
+    "playerId": 213768,
+    "fullName": "Фулькье",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 214129,
+    "fullName": "Эль-Хилали",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213948,
+    "fullName": "Браим Диас",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213802,
+    "fullName": "Комесанья",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214001,
+    "fullName": "Барренечеа",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 213880,
+    "fullName": "Антонио Санчес",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214010,
+    "fullName": "Ойарсабаль",
+    "clubName": "Реал Сосьедад",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 14.2
+  },
+  {
+    "playerId": 213662,
+    "fullName": "Руис де Галаррета",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213665,
+    "fullName": "Хаурегисар",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213877,
+    "fullName": "Мохика",
+    "clubName": "Мальорка",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214000,
+    "fullName": "Пабло Марин",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213952,
+    "fullName": "Гюлер",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 13.7
+  },
+  {
+    "playerId": 213950,
+    "fullName": "Вальверде",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 13.7
+  },
+  {
+    "playerId": 213947,
+    "fullName": "Тчуамени",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 213695,
+    "fullName": "Альмада",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 214135,
+    "fullName": "Поль Лосано",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213627,
+    "fullName": "Кастро",
+    "clubName": "Алавес",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213822,
+    "fullName": "Давид Лопес",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213975,
+    "fullName": "Сибо",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213641,
+    "fullName": "Висенте",
+    "clubName": "Алавес",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 214105,
+    "fullName": "Хори",
+    "clubName": "Эльче",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.6
+  },
+  {
+    "playerId": 213745,
+    "fullName": "Рикардо Родригес",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213897,
+    "fullName": "Катена",
+    "clubName": "Осасуна",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213901,
+    "fullName": "Монкайола",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213899,
+    "fullName": "Серхио Эррера",
+    "clubName": "Осасуна",
     "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 186901,
-    "fullName": "Marek Rodák",
-    "clubName": "Fulham FC",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 214103,
+    "fullName": "Петро",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214102,
+    "fullName": "Нуньес",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213906,
+    "fullName": "Орос",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213625,
+    "fullName": "Гарсес",
+    "clubName": "Алавес",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213622,
+    "fullName": "Парада",
+    "clubName": "Алавес",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 213896,
+    "fullName": "Бойомо",
+    "clubName": "Осасуна",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 214097,
+    "fullName": "Бигас",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213823,
+    "fullName": "Крейчи",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 2.0
+  },
+  {
+    "playerId": 214099,
+    "fullName": "Дитуро",
+    "clubName": "Эльче",
     "position": "GK",
-    "league": "EPL"
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.5
   },
   {
-    "playerId": 381469,
-    "fullName": "Steven Benda",
-    "clubName": "Fulham FC",
+    "playerId": 213969,
+    "fullName": "Эскандель",
+    "clubName": "Реал Овьедо",
     "position": "GK",
-    "league": "EPL"
-  },
-  {
-    "playerId": 258878,
-    "fullName": "Tosin Adarabioyo",
-    "clubName": "Fulham FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 272622,
-    "fullName": "Issa Diop",
-    "clubName": "Fulham FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 461883,
-    "fullName": "Calvin Bassey",
-    "clubName": "Fulham FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 145466,
-    "fullName": "Tim Ream",
-    "clubName": "Fulham FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 921995,
-    "fullName": "Luc De Fougerolles",
-    "clubName": "Fulham FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 349701,
-    "fullName": "Antonee Robinson",
-    "clubName": "Fulham FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 296422,
-    "fullName": "Fodé Ballo-Touré",
-    "clubName": "Fulham FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 262226,
-    "fullName": "Timothy Castagne",
-    "clubName": "Fulham FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 206746,
-    "fullName": "Kenny Tete",
-    "clubName": "Fulham FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 183321,
-    "fullName": "Kevin Mbabu",
-    "clubName": "Fulham FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 745452,
-    "fullName": "Devan Tanton",
-    "clubName": "Fulham FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 257455,
-    "fullName": "João Palhinha",
-    "clubName": "Fulham FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 226973,
-    "fullName": "Harrison Reed",
-    "clubName": "Fulham FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 245056,
-    "fullName": "Saša Lukić",
-    "clubName": "Fulham FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 123275,
-    "fullName": "Tom Cairney",
-    "clubName": "Fulham FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 528888,
-    "fullName": "Tyrese Francois",
-    "clubName": "Fulham FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 817611,
-    "fullName": "Matt Dibley-Dias",
-    "clubName": "Fulham FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1011131,
-    "fullName": "Josh King",
-    "clubName": "Fulham FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 203394,
-    "fullName": "Andreas Pereira",
-    "clubName": "Fulham FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 817612,
-    "fullName": "Luke Harris",
-    "clubName": "Fulham FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 539810,
-    "fullName": "Kristian Sekularac",
-    "clubName": "Fulham FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 242631,
-    "fullName": "Alex Iwobi",
-    "clubName": "Fulham FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 52769,
-    "fullName": "Willian",
-    "clubName": "Fulham FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 279455,
-    "fullName": "Harry Wilson",
-    "clubName": "Fulham FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 204103,
-    "fullName": "Adama Traoré",
-    "clubName": "Fulham FC",
-    "position": "F",
-    "league": "EPL"
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 214031,
+    "fullName": "Соу",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214024,
+    "fullName": "Салас",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214058,
+    "fullName": "Аспас",
+    "clubName": "Сельта",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 14.3
+  },
+  {
+    "playerId": 213886,
+    "fullName": "Дардер",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213691,
+    "fullName": "Руджери",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 4.0
+  },
+  {
+    "playerId": 213856,
+    "fullName": "Иван Ромеро",
+    "clubName": "Леванте",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214122,
+    "fullName": "Дмитрович",
+    "clubName": "Эспаньол",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 3.4
+  },
+  {
+    "playerId": 213927,
+    "fullName": "Сисс",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214141,
+    "fullName": "Пуадо",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 213925,
+    "fullName": "Рациу",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 213924,
+    "fullName": "Лежен",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213922,
+    "fullName": "Диас",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213669,
+    "fullName": "Иньяки Уильямс",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 5.9
+  },
+  {
+    "playerId": 213737,
+    "fullName": "Бартра",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 13.6
+  },
+  {
+    "playerId": 213955,
+    "fullName": "Винисиус Жуниор",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 10.0,
+    "popularity": 12.0
+  },
+  {
+    "playerId": 213779,
+    "fullName": "Риоха",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213915,
+    "fullName": "Чаваррия",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213698,
+    "fullName": "Алекс Баэна",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.5,
+    "popularity": 10.7
+  },
+  {
+    "playerId": 213836,
+    "fullName": "Янхель Эррера",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214054,
+    "fullName": "Мориба",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213733,
+    "fullName": "Бельерин",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 213961,
+    "fullName": "Альхассан",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213827,
+    "fullName": "Солис",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213774,
+    "fullName": "Таррега",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213782,
+    "fullName": "Дуро",
+    "clubName": "Валенсия",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 214042,
+    "fullName": "Ристич",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213879,
+    "fullName": "Раильо",
+    "clubName": "Мальорка",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213867,
+    "fullName": "Вальент",
+    "clubName": "Мальорка",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213799,
+    "fullName": "Бьюкенен",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214036,
+    "fullName": "Эджуке",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213777,
+    "fullName": "Герра",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213770,
+    "fullName": "Агирресабала",
+    "clubName": "Валенсия",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 4.1
+  },
+  {
+    "playerId": 213778,
+    "fullName": "Пепелу",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213872,
+    "fullName": "Роман",
+    "clubName": "Мальорка",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 214053,
+    "fullName": "Мингеса",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 21.9
+  },
+  {
+    "playerId": 213654,
+    "fullName": "Берчиче",
+    "clubName": "Атлетик",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 7.7
+  },
+  {
+    "playerId": 214056,
+    "fullName": "Бельтран",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213766,
+    "fullName": "Копете",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213666,
+    "fullName": "Беренгер",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 4.0
+  },
+  {
+    "playerId": 213664,
+    "fullName": "Унаи Симон",
+    "clubName": "Атлетик",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 12.6
+  },
+  {
+    "playerId": 213661,
+    "fullName": "Вивиан",
+    "clubName": "Атлетик",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 9.8
+  },
+  {
+    "playerId": 213658,
+    "fullName": "Паредес",
+    "clubName": "Атлетик",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213962,
+    "fullName": "Начо Видаль",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214131,
+    "fullName": "Кабрера",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 215666,
+    "fullName": "Чалета-Цар",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213997,
+    "fullName": "Туррьентес",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214003,
+    "fullName": "Ремиро",
+    "clubName": "Реал Сосьедад",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 2.5
+  },
+  {
+    "playerId": 213639,
+    "fullName": "Гуриди",
+    "clubName": "Алавес",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213998,
+    "fullName": "Арамбуру",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.5
+  },
+  {
+    "playerId": 213634,
+    "fullName": "Ибаньес",
+    "clubName": "Алавес",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214061,
+    "fullName": "Жуджла",
+    "clubName": "Сельта",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 3.8
+  },
+  {
+    "playerId": 214139,
+    "fullName": "Роберто Фернандес",
+    "clubName": "Эспаньол",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213690,
+    "fullName": "Облак",
+    "clubName": "Атлетико",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 23.7
   },
   {
-    "playerId": 186186,
-    "fullName": "Bobby De Cordova-Reid",
-    "clubName": "Fulham FC",
-    "position": "F",
-    "league": "EPL"
+    "playerId": 213630,
+    "fullName": "Сивера",
+    "clubName": "Алавес",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 7.8
+  },
+  {
+    "playerId": 214111,
+    "fullName": "Альваро Родригес",
+    "clubName": "Эльче",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214095,
+    "fullName": "Марк Агуадо",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 16.0
+  },
+  {
+    "playerId": 214100,
+    "fullName": "Искьердо",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213757,
+    "fullName": "Кучо Эрнандес",
+    "clubName": "Бетис",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 5.5
+  },
+  {
+    "playerId": 213905,
+    "fullName": "Рубен Гарсия",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213743,
+    "fullName": "Натан",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 3.6
+  },
+  {
+    "playerId": 213740,
+    "fullName": "Пау Лопес",
+    "clubName": "Бетис",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 3.1
+  },
+  {
+    "playerId": 213994,
+    "fullName": "Айен Муньос",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 214019,
+    "fullName": "Гудель",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213995,
+    "fullName": "Субельдия",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 2.2
+  },
+  {
+    "playerId": 213921,
+    "fullName": "Баталья",
+    "clubName": "Райо Вальекано",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 214050,
+    "fullName": "Сотело",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213859,
+    "fullName": "Пабло Мартинес",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214021,
+    "fullName": "Кармона",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 214020,
+    "fullName": "Идумбо-Музамбо",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213978,
+    "fullName": "Илич",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214051,
+    "fullName": "Хави Родригес",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 3.3
+  },
+  {
+    "playerId": 214057,
+    "fullName": "Дуран",
+    "clubName": "Сельта",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213850,
+    "fullName": "Ману Санчес",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213866,
+    "fullName": "Тони Лато",
+    "clubName": "Мальорка",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213852,
+    "fullName": "Эльхесабаль",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214052,
+    "fullName": "Алонсо",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 9.6
+  },
+  {
+    "playerId": 213860,
+    "fullName": "Моралес",
+    "clubName": "Леванте",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213861,
+    "fullName": "Карлос Альварес",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213990,
+    "fullName": "Элустондо",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214026,
+    "fullName": "Янузай",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214047,
+    "fullName": "Раду",
+    "clubName": "Сельта",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 6.7
+  },
+  {
+    "playerId": 213936,
+    "fullName": "Карвахаль",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 213979,
+    "fullName": "Рондон",
+    "clubName": "Реал Овьедо",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213977,
+    "fullName": "Хассан",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213972,
+    "fullName": "Касорла",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 213970,
+    "fullName": "Виньяс",
+    "clubName": "Реал Овьедо",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213968,
+    "fullName": "Борха Санчес",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213967,
+    "fullName": "Луэнго",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214005,
+    "fullName": "Серхио Гомес",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 4.0
+  },
+  {
+    "playerId": 213964,
+    "fullName": "Кальво",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214007,
+    "fullName": "Оускарссон",
+    "clubName": "Реал Сосьедад",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214012,
+    "fullName": "Маркао Тейшейра",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213951,
+    "fullName": "Гонсало Гарсия",
+    "clubName": "Реал Мадрид",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 3.1
+  },
+  {
+    "playerId": 213942,
+    "fullName": "Себальос",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214022,
+    "fullName": "Нюланд",
+    "clubName": "Севилья",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213874,
+    "fullName": "Маскарель",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214023,
+    "fullName": "Рафа Мир",
+    "clubName": "Эльче",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213919,
+    "fullName": "Оскар Валентин",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213918,
+    "fullName": "Нтека",
+    "clubName": "Райо Вальекано",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213917,
+    "fullName": "Гумбау",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213916,
+    "fullName": "Эспино",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213848,
+    "fullName": "Морено",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213910,
+    "fullName": "Пелайо Фернандес",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213903,
+    "fullName": "Рауль Гарсия",
+    "clubName": "Осасуна",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213902,
+    "fullName": "Виктор Муньос",
+    "clubName": "Осасуна",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213900,
+    "fullName": "Мойсес Гомес",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214035,
+    "fullName": "Исаак Ромеро",
+    "clubName": "Севилья",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213883,
+    "fullName": "Дани Родригес",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213881,
+    "fullName": "Асано",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213849,
+    "fullName": "Пампин",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213805,
+    "fullName": "Молейро",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 214059,
+    "fullName": "Сарагоса",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 213718,
+    "fullName": "Кунде",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 17.4
+  },
+  {
+    "playerId": 214134,
+    "fullName": "Каррерас",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213687,
+    "fullName": "Ганцко",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 5.4
+  },
+  {
+    "playerId": 213688,
+    "fullName": "Коке",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213692,
+    "fullName": "Барриос",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213697,
+    "fullName": "Гризманн",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 7.5
+  },
+  {
+    "playerId": 213699,
+    "fullName": "Серлот",
+    "clubName": "Атлетико",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 8.5,
+    "popularity": 4.9
+  },
+  {
+    "playerId": 214123,
+    "fullName": "Калеро",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213722,
+    "fullName": "Фермин Лопес",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 214138,
+    "fullName": "Терратс",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213846,
+    "fullName": "Серхио Лосано",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213726,
+    "fullName": "Ольмо",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 9.0,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 214109,
+    "fullName": "Мурад",
+    "clubName": "Эльче",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213750,
+    "fullName": "Чими Авила",
+    "clubName": "Бетис",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213751,
+    "fullName": "Бакамбу",
+    "clubName": "Бетис",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213752,
+    "fullName": "Борха Иглесиас",
+    "clubName": "Сельта",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 3.0
+  },
+  {
+    "playerId": 213769,
+    "fullName": "Хесус Васкес",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213771,
+    "fullName": "Гайя",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 5.9
+  },
+  {
+    "playerId": 214137,
+    "fullName": "Долан",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214140,
+    "fullName": "Кике Гарсия",
+    "clubName": "Эспаньол",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213776,
+    "fullName": "Андре Алмейда",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213647,
+    "fullName": "Рего Мора",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213624,
+    "fullName": "Энрикес",
+    "clubName": "Алавес",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216529,
+    "fullName": "Фернандес",
+    "clubName": "Мальорка",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213629,
+    "fullName": "Реббаш",
+    "clubName": "Алавес",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 216527,
+    "fullName": "Гарсия",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213633,
+    "fullName": "Гевара",
+    "clubName": "Алавес",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213635,
+    "fullName": "Калебе",
+    "clubName": "Алавес",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 216525,
+    "fullName": "Торрентс",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 216524,
+    "fullName": "Распадори",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213649,
+    "fullName": "Горосабель",
+    "clubName": "Атлетик",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 215655,
+    "fullName": "Мариано Диас",
+    "clubName": "Алавес",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 215667,
+    "fullName": "Гедеш",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 215665,
+    "fullName": "Рейс",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213653,
+    "fullName": "Аресо",
+    "clubName": "Атлетик",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 213655,
+    "fullName": "Весга",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 215663,
+    "fullName": "Парти",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 215662,
+    "fullName": "Угринич",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213667,
+    "fullName": "Гурусета",
+    "clubName": "Атлетик",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 215661,
+    "fullName": "Сантамария",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214091,
+    "fullName": "Дональд",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213724,
+    "fullName": "Рэшфорд",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213991,
+    "fullName": "Урко Гонсалес",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213841,
+    "fullName": "Адри",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213804,
+    "fullName": "Парехо",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 213803,
+    "fullName": "Данджума",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 213831,
+    "fullName": "Порту",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213832,
+    "fullName": "Асприлья",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 2.0
+  },
+  {
+    "playerId": 213825,
+    "fullName": "Миовски",
+    "clubName": "Жирона",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 214080,
+    "fullName": "Сола",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213833,
+    "fullName": "Лемар",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213820,
+    "fullName": "Блинд",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 5.3
+  },
+  {
+    "playerId": 213838,
+    "fullName": "Кабельо",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 7.4
+  },
+  {
+    "playerId": 213801,
+    "fullName": "Жерар Морено",
+    "clubName": "Вильярреал",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 11.7
+  },
+  {
+    "playerId": 213842,
+    "fullName": "Виктор Гарсия",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213810,
+    "fullName": "Крапивцов",
+    "clubName": "Жирона",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 213817,
+    "fullName": "Ринкон",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213790,
+    "fullName": "Педраса",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213845,
+    "fullName": "Куньят",
+    "clubName": "Леванте",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 215664,
+    "fullName": "Кебе",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214068,
+    "fullName": "Альдерете",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 215656,
+    "fullName": "Сантос Линарес",
+    "clubName": "Атлетик",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214014,
+    "fullName": "Ньянзу",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214055,
+    "fullName": "Уго Альварес",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 215658,
+    "fullName": "Кочен",
+    "clubName": "Барселона",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215657,
+    "fullName": "Хисмера",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 215660,
+    "fullName": "Деосса",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214070,
+    "fullName": "Дуарте",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214011,
+    "fullName": "Альберто Флорес",
+    "clubName": "Севилья",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 215659,
+    "fullName": "Форт",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214072,
+    "fullName": "Петер Федерико",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214067,
+    "fullName": "Абкар",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214013,
+    "fullName": "Рамон Мартинес",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214037,
+    "fullName": "Варгас",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 215668,
+    "fullName": "Виктор Чуст",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214066,
+    "fullName": "Эрранс",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 214060,
+    "fullName": "Сведберг",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213992,
+    "fullName": "Захарян",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 213993,
+    "fullName": "Каррикабуру",
+    "clubName": "Реал Сосьедад",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 216532,
+    "fullName": "Яньес",
+    "clubName": "Реал Мадрид",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 216531,
+    "fullName": "Мартин",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 213996,
+    "fullName": "Траоре",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 216530,
+    "fullName": "Диего Агуадо",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213999,
+    "fullName": "Горрочатеги",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 216528,
+    "fullName": "Витцель",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214006,
+    "fullName": "Сучич",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214064,
+    "fullName": "Летачек",
+    "clubName": "Хетафе",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 216526,
+    "fullName": "Дро Фернандес",
+    "clubName": "Барселона",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214002,
+    "fullName": "Беккер",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214065,
+    "fullName": "Трилья",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214004,
+    "fullName": "Садик",
+    "clubName": "Реал Сосьедад",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216523,
+    "fullName": "Марио де Луис",
+    "clubName": "Атлетико",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 216522,
+    "fullName": "Хон де Луис",
+    "clubName": "Атлетик",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214073,
+    "fullName": "Риско",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214015,
+    "fullName": "Альваро Фернандес",
+    "clubName": "Севилья",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214048,
+    "fullName": "Дамиан Родригес",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214074,
+    "fullName": "Фемения",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214098,
+    "fullName": "Боаяр",
+    "clubName": "Эльче",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 9.3
+  },
+  {
+    "playerId": 214112,
+    "fullName": "Хосан",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214028,
+    "fullName": "Жордан",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214029,
+    "fullName": "Ихеаначо",
+    "clubName": "Севилья",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214043,
+    "fullName": "Руэда",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214030,
+    "fullName": "Пеке",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214107,
+    "fullName": "де Сантьяго",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214104,
+    "fullName": "Рафаэль Нуньес",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214081,
+    "fullName": "Хуанми",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214041,
+    "fullName": "Карлос Домингес",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214094,
+    "fullName": "Хесус Лопес",
+    "clubName": "Эльче",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214114,
+    "fullName": "Рамон",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214093,
+    "fullName": "Кастильо",
+    "clubName": "Эльче",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214082,
+    "fullName": "Санкрис",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214040,
+    "fullName": "Марк Видаль",
+    "clubName": "Сельта",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.3
   },
   {
-    "playerId": 51152,
-    "fullName": "Aleksandar Mitrović",
-    "clubName": "Fulham FC",
-    "position": "F",
-    "league": "EPL"
+    "playerId": 214092,
+    "fullName": "Итурбе",
+    "clubName": "Эльче",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 2.0
+  },
+  {
+    "playerId": 214039,
+    "fullName": "Айду",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 6.6
+  },
+  {
+    "playerId": 214090,
+    "fullName": "Диаби",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214034,
+    "fullName": "Альфон Гонсалес",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214089,
+    "fullName": "Барзич",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 12.5
+  },
+  {
+    "playerId": 214088,
+    "fullName": "Майораль",
+    "clubName": "Хетафе",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214113,
+    "fullName": "Инохо",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214115,
+    "fullName": "Рубен Санчес",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 214016,
+    "fullName": "Баде",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214045,
+    "fullName": "Каррейра",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 214049,
+    "fullName": "Серви",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214017,
+    "fullName": "Буэно",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 214084,
+    "fullName": "Хави Муньос",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214133,
+    "fullName": "Антониу Рока",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214075,
+    "fullName": "да Коста",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214018,
+    "fullName": "Педроса",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214078,
+    "fullName": "Неу",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214130,
+    "fullName": "Хави Эрнандес",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214046,
+    "fullName": "Старфельт",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.2
+  },
+  {
+    "playerId": 214128,
+    "fullName": "Маркос Фернандес",
+    "clubName": "Эспаньол",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 214116,
+    "fullName": "Тристан",
+    "clubName": "Эспаньол",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214127,
+    "fullName": "Салинас",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214126,
+    "fullName": "Саласар",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214121,
+    "fullName": "Гастон Вальес",
+    "clubName": "Эспаньол",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 3.1
+  },
+  {
+    "playerId": 214120,
+    "fullName": "Бауса",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.5
+  },
+  {
+    "playerId": 214119,
+    "fullName": "Фортуньо",
+    "clubName": "Эспаньол",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214118,
+    "fullName": "Форнс",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214117,
+    "fullName": "Уго Перес",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214044,
+    "fullName": "Вильяр",
+    "clubName": "Сельта",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214025,
+    "fullName": "Суасо",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213619,
+    "fullName": "Адриан Родригес",
+    "clubName": "Алавес",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 7.8
+  },
+  {
+    "playerId": 213893,
+    "fullName": "Хуан Крус",
+    "clubName": "Осасуна",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213989,
+    "fullName": "Хави Лопес",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213732,
+    "fullName": "Нобель Менди",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213744,
+    "fullName": "Петит",
+    "clubName": "Бетис",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213742,
+    "fullName": "Диего Льоренте",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213741,
+    "fullName": "Лосада",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213739,
+    "fullName": "Гомес",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213738,
+    "fullName": "Альваро Вальес",
+    "clubName": "Бетис",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213736,
+    "fullName": "Сенхаджи",
+    "clubName": "Бетис",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213735,
+    "fullName": "Перро",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213734,
+    "fullName": "Ортис",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213731,
+    "fullName": "Вьейтес",
+    "clubName": "Бетис",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213749,
+    "fullName": "Фирпо",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 4.7
+  },
+  {
+    "playerId": 213730,
+    "fullName": "Адриан",
+    "clubName": "Бетис",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 18.1
+  },
+  {
+    "playerId": 213727,
+    "fullName": "Левандовски",
+    "clubName": "Барселона",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 10.0,
+    "popularity": 5.7
+  },
+  {
+    "playerId": 213717,
+    "fullName": "Касадо",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213715,
+    "fullName": "Бардагжи",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213713,
+    "fullName": "Шченсны",
+    "clubName": "Барселона",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.9
   },
   {
-    "playerId": 571743,
-    "fullName": "Armando Broja",
-    "clubName": "Fulham FC",
-    "position": "F",
-    "league": "EPL"
+    "playerId": 213712,
+    "fullName": "тер Стеген",
+    "clubName": "Барселона",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213711,
+    "fullName": "Иньиго Мартинес",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213710,
+    "fullName": "Жерар Мартин",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213746,
+    "fullName": "Марк Рока",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 213755,
+    "fullName": "Эззальзули",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213706,
+    "fullName": "Кристенсен",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213773,
+    "fullName": "Мари",
+    "clubName": "Валенсия",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213791,
+    "fullName": "Денис Суарес",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213789,
+    "fullName": "Пау Наварро",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213787,
+    "fullName": "Конде",
+    "clubName": "Вильярреал",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213786,
+    "fullName": "Камбвала",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213785,
+    "fullName": "Кабанес",
+    "clubName": "Вильярреал",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213784,
+    "fullName": "Адриа Альтимира",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213783,
+    "fullName": "Рубен Гомес",
+    "clubName": "Вильярреал",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213775,
+    "fullName": "Франсиско Перес",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213772,
+    "fullName": "Канос",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 213758,
+    "fullName": "Иско",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 4.4
+  },
+  {
+    "playerId": 213767,
+    "fullName": "Тьерри Коррейя",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213765,
+    "fullName": "Димитриевски",
+    "clubName": "Валенсия",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213764,
+    "fullName": "Диакаби",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213763,
+    "fullName": "Гильямон",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213762,
+    "fullName": "Риверо",
+    "clubName": "Валенсия",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213761,
+    "fullName": "Озкаджар",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213760,
+    "fullName": "Ирансо",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213759,
+    "fullName": "Джемерт",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213707,
+    "fullName": "Ромеу",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213705,
+    "fullName": "Берналь",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213797,
+    "fullName": "Ахомаш",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213645,
+    "fullName": "Венседор",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213660,
+    "fullName": "Унаи Гомес",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213659,
+    "fullName": "Прадос",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213656,
+    "fullName": "Исета",
+    "clubName": "Атлетик",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213652,
+    "fullName": "Нико Серрано",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213651,
+    "fullName": "Падилья",
+    "clubName": "Атлетик",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213650,
+    "fullName": "Йерай Альварес",
+    "clubName": "Атлетик",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213648,
+    "fullName": "Бойро",
+    "clubName": "Атлетик",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213646,
+    "fullName": "Каналес",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213644,
+    "fullName": "Арес",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.0
+  },
+  {
+    "playerId": 213671,
+    "fullName": "Боньяр",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213643,
+    "fullName": "Эхилус",
+    "clubName": "Атлетик",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213642,
+    "fullName": "Лекуэ",
+    "clubName": "Атлетик",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213632,
+    "fullName": "Вильялибре",
+    "clubName": "Алавес",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213631,
+    "fullName": "Бенавидес",
+    "clubName": "Алавес",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213628,
+    "fullName": "Новоа",
+    "clubName": "Алавес",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213626,
+    "fullName": "Диарра",
+    "clubName": "Алавес",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213623,
+    "fullName": "Рауль Фернандес",
+    "clubName": "Алавес",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213621,
+    "fullName": "Мараш",
+    "clubName": "Алавес",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213668,
+    "fullName": "Сансет",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 213672,
+    "fullName": "Костис",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213704,
+    "fullName": "Тони Фернандес",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213683,
+    "fullName": "Молина",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213703,
+    "fullName": "Гилье Фернандес",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 213702,
+    "fullName": "Дани Родригес",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213701,
+    "fullName": "Пенья",
+    "clubName": "Барселона",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213694,
+    "fullName": "Кардозо",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213689,
+    "fullName": "Маркос Льоренте",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 14.8
+  },
+  {
+    "playerId": 213686,
+    "fullName": "Хименес",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213685,
+    "fullName": "Пубиль",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213684,
+    "fullName": "Муссо",
+    "clubName": "Атлетико",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213682,
+    "fullName": "Ле Норман",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 16.8
+  },
+  {
+    "playerId": 213673,
+    "fullName": "Эскивель",
+    "clubName": "Атлетико",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213681,
+    "fullName": "Лангле",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213680,
+    "fullName": "Галан",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213679,
+    "fullName": "Карлос Мартин",
+    "clubName": "Атлетико",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213678,
+    "fullName": "Хавьер Серрано",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213677,
+    "fullName": "Сейду",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213676,
+    "fullName": "Монсеррате",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213675,
+    "fullName": "Джанне",
+    "clubName": "Атлетико",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213674,
+    "fullName": "Белаид",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213793,
+    "fullName": "Коста",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213808,
+    "fullName": "Айосе Перес",
+    "clubName": "Вильярреал",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 8.5,
+    "popularity": 4.0
+  },
+  {
+    "playerId": 213988,
+    "fullName": "Карлос Фернандес",
+    "clubName": "Реал Сосьедад",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213920,
+    "fullName": "Трехо",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213941,
+    "fullName": "Рюдигер",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 3.3
+  },
+  {
+    "playerId": 213937,
+    "fullName": "Лунин",
+    "clubName": "Реал Мадрид",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213935,
+    "fullName": "Асенсио",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213934,
+    "fullName": "Рейньер",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213933,
+    "fullName": "Ферлан Менди",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 213932,
+    "fullName": "Алаба",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213931,
+    "fullName": "Фран Гонсалес",
+    "clubName": "Реал Мадрид",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213923,
+    "fullName": "Камельо",
+    "clubName": "Райо Вальекано",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213914,
+    "fullName": "Мумин",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 213946,
+    "fullName": "Камавинга",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213913,
+    "fullName": "Диего Мендес",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213912,
+    "fullName": "Луис Фелипе",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213911,
+    "fullName": "Балиу",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213909,
+    "fullName": "Карденас",
+    "clubName": "Райо Вальекано",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213908,
+    "fullName": "де лас Сиас",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 213898,
+    "fullName": "Икер Муньос",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213895,
+    "fullName": "Барха",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213894,
+    "fullName": "Эррандо",
+    "clubName": "Осасуна",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213943,
+    "fullName": "Фран Гарсия",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213949,
+    "fullName": "Эндрик",
+    "clubName": "Реал Мадрид",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213809,
+    "fullName": "Жордана",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213973,
+    "fullName": "Коломбатто",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213987,
+    "fullName": "Пачеко",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213986,
+    "fullName": "Марьескуррена",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213985,
+    "fullName": "Хон Мартин",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213984,
+    "fullName": "Марреро",
+    "clubName": "Реал Сосьедад",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213983,
+    "fullName": "Дадье",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213982,
+    "fullName": "Фрага",
+    "clubName": "Реал Сосьедад",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213981,
+    "fullName": "Одриосола",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 2.5
+  },
+  {
+    "playerId": 213976,
+    "fullName": "Форес",
+    "clubName": "Реал Овьедо",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213971,
+    "fullName": "Брандон Домингес",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213953,
+    "fullName": "Родриго",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.5,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213966,
+    "fullName": "Костас",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213965,
+    "fullName": "Кардеро",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213963,
+    "fullName": "Яйо Гонсалес",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213960,
+    "fullName": "Нарваэс",
+    "clubName": "Реал Овьедо",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.7
   },
   {
-    "playerId": 735571,
-    "fullName": "Rodrigo Muniz",
-    "clubName": "Fulham FC",
-    "position": "F",
-    "league": "EPL"
+    "playerId": 213959,
+    "fullName": "Молдован",
+    "clubName": "Реал Овьедо",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 5.7
+  },
+  {
+    "playerId": 213958,
+    "fullName": "Лукас Аихадо",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213957,
+    "fullName": "Лемос",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213954,
+    "fullName": "Беллингем",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 9.5,
+    "popularity": 4.4
+  },
+  {
+    "playerId": 213620,
+    "fullName": "Хоседа Альварес",
+    "clubName": "Алавес",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 10.5
+  },
+  {
+    "playerId": 213891,
+    "fullName": "Бретонес",
+    "clubName": "Осасуна",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213890,
+    "fullName": "Бенито",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213828,
+    "fullName": "Абель Руис",
+    "clubName": "Жирона",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213843,
+    "fullName": "Виктор Фернандес",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213840,
+    "fullName": "Примо",
+    "clubName": "Леванте",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.8
   },
   {
-    "playerId": 206040,
-    "fullName": "Raúl Jiménez",
-    "clubName": "Fulham FC",
-    "position": "F",
-    "league": "EPL"
+    "playerId": 213839,
+    "fullName": "Пастор",
+    "clubName": "Леванте",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213835,
+    "fullName": "Стуани",
+    "clubName": "Жирона",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 2.5
+  },
+  {
+    "playerId": 213834,
+    "fullName": "Иван Мартин",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213830,
+    "fullName": "Мигель Гутьеррес",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213829,
+    "fullName": "ван де Бек",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213824,
+    "fullName": "Арнау Мартинес",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213889,
+    "fullName": "Айтор Фернандес",
+    "clubName": "Осасуна",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213819,
+    "fullName": "Франсес",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213818,
+    "fullName": "Валери Фернандес",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213816,
+    "fullName": "Курума",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213815,
+    "fullName": "Камара",
+    "clubName": "Жирона",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 213814,
+    "fullName": "Джастин Гарсия",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213813,
+    "fullName": "Ба",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 5.2
+  },
+  {
+    "playerId": 213812,
+    "fullName": "Якобишвили",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 213811,
+    "fullName": "Хуан Карлос",
+    "clubName": "Жирона",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213844,
+    "fullName": "Клементе",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213847,
+    "fullName": "Маттурро",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213853,
+    "fullName": "Эспи",
+    "clubName": "Леванте",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 213854,
+    "fullName": "Арриага",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213888,
+    "fullName": "Валенсия",
+    "clubName": "Осасуна",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 213885,
+    "fullName": "Торре",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213884,
+    "fullName": "Ларин",
+    "clubName": "Мальорка",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213882,
+    "fullName": "Саму Кошта",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213878,
+    "fullName": "Пратс",
+    "clubName": "Мальорка",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213875,
+    "fullName": "Маффео",
+    "clubName": "Мальорка",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213873,
+    "fullName": "Грейф",
+    "clubName": "Мальорка",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213870,
+    "fullName": "Льябрес",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213869,
+    "fullName": "Луна",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213868,
+    "fullName": "Доменек",
+    "clubName": "Мальорка",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.0
+  },
+  {
+    "playerId": 213865,
+    "fullName": "Давид Лопес",
+    "clubName": "Мальорка",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213864,
+    "fullName": "Куэльяр",
+    "clubName": "Мальорка",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.3
   },
   {
-    "playerId": 525287,
-    "fullName": "Carlos Vinícius",
-    "clubName": "Fulham FC",
-    "position": "F",
-    "league": "EPL"
+    "playerId": 213863,
+    "fullName": "Бергстрем",
+    "clubName": "Мальорка",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 4.5
+  },
+  {
+    "playerId": 213862,
+    "fullName": "Койялипу",
+    "clubName": "Леванте",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213855,
+    "fullName": "Оласагасти",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 216533,
+    "fullName": "Влаходимос",
+    "clubName": "Севилья",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213871,
+    "fullName": "Морей",
+    "clubName": "Мальорка",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213974,
+    "fullName": "Рейна",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213876,
+    "fullName": "Морланес",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 213887,
+    "fullName": "Мурики",
+    "clubName": "Мальорка",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213821,
+    "fullName": "Гассанига",
+    "clubName": "Жирона",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 5.0
+  },
+  {
+    "playerId": 214535,
+    "fullName": "Семеньо",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 7.9
+  },
+  {
+    "playerId": 214915,
+    "fullName": "Бэллард",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 6.5
+  },
+  {
+    "playerId": 214416,
+    "fullName": "Калафьори",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 7.1
+  },
+  {
+    "playerId": 214795,
+    "fullName": "Рейндерс",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 20.2
+  },
+  {
+    "playerId": 214735,
+    "fullName": "Салах",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 12.5,
+    "popularity": 27.7
+  },
+  {
+    "playerId": 214974,
+    "fullName": "Ришарлисон",
+    "clubName": "Тоттенхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 13.1
+  },
+  {
+    "playerId": 214865,
+    "fullName": "Вуд",
+    "clubName": "Ноттингем Форест",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 10.3
+  },
+  {
+    "playerId": 214977,
+    "fullName": "Кудус",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 15.9
+  },
+  {
+    "playerId": 214802,
+    "fullName": "Холанд",
+    "clubName": "Манчестер Сити",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 12.0,
+    "popularity": 36.5
+  },
+  {
+    "playerId": 214732,
+    "fullName": "Гакпо",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.5,
+    "popularity": 8.8
+  },
+  {
+    "playerId": 214733,
+    "fullName": "Экитике",
+    "clubName": "Ливерпуль",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 8.5,
+    "popularity": 28.9
+  },
+  {
+    "playerId": 214782,
+    "fullName": "Льюис",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 3.0
+  },
+  {
+    "playerId": 214785,
+    "fullName": "Бобб",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214861,
+    "fullName": "Эллиот Андерсон",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 214862,
+    "fullName": "Ндойе",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 214968,
+    "fullName": "Пап Матар Сарр",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 8.5
+  },
+  {
+    "playerId": 214976,
+    "fullName": "Бреннан Джонсон",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 2.6
+  },
+  {
+    "playerId": 214748,
+    "fullName": "Гудмундссон",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 214560,
+    "fullName": "Мэттью О`Райли",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 214760,
+    "fullName": "Штах",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 215024,
+    "fullName": "Чалоба",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 214922,
+    "fullName": "Руфс",
+    "clubName": "Сандерленд",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 4.1
+  },
+  {
+    "playerId": 215030,
+    "fullName": "Кукурелья",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 18.0
+  },
+  {
+    "playerId": 215029,
+    "fullName": "Санчес",
+    "clubName": "Челси",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 7.3
+  },
+  {
+    "playerId": 214888,
+    "fullName": "Шер",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 214886,
+    "fullName": "Триппьер",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 3.8
+  },
+  {
+    "playerId": 214885,
+    "fullName": "Поуп",
+    "clubName": "Ньюкасл",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 4.0
+  },
+  {
+    "playerId": 214456,
+    "fullName": "Динь",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 3.1
+  },
+  {
+    "playerId": 214599,
+    "fullName": "Игор Тиаго",
+    "clubName": "Брентфорд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 214791,
+    "fullName": "Рубен Диаш",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 6.6
+  },
+  {
+    "playerId": 214925,
+    "fullName": "Хьюм",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 215026,
+    "fullName": "Рис Джеймс",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 6.6
+  },
+  {
+    "playerId": 214744,
+    "fullName": "Богл",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214964,
+    "fullName": "ван де Вен",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 13.5
+  },
+  {
+    "playerId": 214883,
+    "fullName": "Берн",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 2.0
+  },
+  {
+    "playerId": 214965,
+    "fullName": "Викарио",
+    "clubName": "Тоттенхэм",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 10.7
+  },
+  {
+    "playerId": 214967,
+    "fullName": "Ромеро",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 6.1
+  },
+  {
+    "playerId": 214973,
+    "fullName": "Порро",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 15.1
+  },
+  {
+    "playerId": 214777,
+    "fullName": "Стоунз",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 214684,
+    "fullName": "Митчелл",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 214784,
+    "fullName": "Аит-Нури",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 11.4
+  },
+  {
+    "playerId": 214778,
+    "fullName": "Траффорд",
+    "clubName": "Манчестер Сити",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 4.4
+  },
+  {
+    "playerId": 214999,
+    "fullName": "Харри Уилсон",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 214906,
+    "fullName": "Рейнилду",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 11.4
+  },
+  {
+    "playerId": 214889,
+    "fullName": "Ливраменто",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 2.9
+  },
+  {
+    "playerId": 214421,
+    "fullName": "Райя",
+    "clubName": "Арсенал",
+    "position": "GK",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 13.5
+  },
+  {
+    "playerId": 214424,
+    "fullName": "Бен Уайт",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 215006,
+    "fullName": "Ачимпонг",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 3.9
+  },
+  {
+    "playerId": 214430,
+    "fullName": "Райс",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 10.7
+  },
+  {
+    "playerId": 214422,
+    "fullName": "Салиба",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 16.4
+  },
+  {
+    "playerId": 214753,
+    "fullName": "Стрейк",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 214443,
+    "fullName": "Бизот",
+    "clubName": "Астон Вилла",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 4.0
   },
   {
-    "playerId": 696346,
-    "fullName": "Jay Stansfield",
-    "clubName": "Fulham FC",
-    "position": "F",
-    "league": "EPL"
+    "playerId": 214692,
+    "fullName": "Дин Хендерсон",
+    "clubName": "Кристал Пэлас",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 7.4
+  },
+  {
+    "playerId": 214752,
+    "fullName": "Родон",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214683,
+    "fullName": "Лакруа",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 214751,
+    "fullName": "Лукас Перри",
+    "clubName": "Лидс",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 3.7
+  },
+  {
+    "playerId": 214447,
+    "fullName": "Мингз",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 214723,
+    "fullName": "Керкез",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 5.7
+  },
+  {
+    "playerId": 214936,
+    "fullName": "Аденгра",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 214935,
+    "fullName": "Тальби",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214725,
+    "fullName": "Кьеза",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214961,
+    "fullName": "Спенс",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 3.0
+  },
+  {
+    "playerId": 214726,
+    "fullName": "Фримпонг",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 32.7
+  },
+  {
+    "playerId": 214681,
+    "fullName": "Гехи",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 8.2
+  },
+  {
+    "playerId": 214435,
+    "fullName": "Эдегор",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 8.2
+  },
+  {
+    "playerId": 214420,
+    "fullName": "Габриэл",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 11.3
+  },
+  {
+    "playerId": 214799,
+    "fullName": "Шерки",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 9.6
+  },
+  {
+    "playerId": 214594,
+    "fullName": "Ярмолюк",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214568,
+    "fullName": "Рюттер",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 4.6
+  },
+  {
+    "playerId": 214676,
+    "fullName": "Крис Ричардс",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 2.5
+  },
+  {
+    "playerId": 214460,
+    "fullName": "Амаду Онана",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 214453,
+    "fullName": "Кэш",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 214531,
+    "fullName": "Тавернье",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214933,
+    "fullName": "Майенда",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 2.5
+  },
+  {
+    "playerId": 214892,
+    "fullName": "Тонали",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 2.9
+  },
+  {
+    "playerId": 214524,
+    "fullName": "Брукс",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214564,
+    "fullName": "Балеба",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 3.0
+  },
+  {
+    "playerId": 214763,
+    "fullName": "Нмеча",
+    "clubName": "Лидс",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 214864,
+    "fullName": "Гиббс-Уайт",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 4.1
+  },
+  {
+    "playerId": 214556,
+    "fullName": "Айяри",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214790,
+    "fullName": "Нико Гонсалес",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214937,
+    "fullName": "Изидор",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 214457,
+    "fullName": "Камара",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214891,
+    "fullName": "Бруно Гимараэс",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 4.6
+  },
+  {
+    "playerId": 214463,
+    "fullName": "Макгинн",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 215063,
+    "fullName": "Ндиай",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 214691,
+    "fullName": "Уортон",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 214466,
+    "fullName": "Роджерс",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 2.5
+  },
+  {
+    "playerId": 214694,
+    "fullName": "Муньос",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 214931,
+    "fullName": "Диарра",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214428,
+    "fullName": "Субименди",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 214697,
+    "fullName": "Исмаила Сарр",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 214730,
+    "fullName": "Мак Аллистер",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 4.8
+  },
+  {
+    "playerId": 214897,
+    "fullName": "Гордон",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.5,
+    "popularity": 2.2
+  },
+  {
+    "playerId": 214635,
+    "fullName": "Боуэн",
+    "clubName": "Вест Хэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 8.5,
+    "popularity": 5.9
+  },
+  {
+    "playerId": 214837,
+    "fullName": "Бруну Фернандеш",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 10.0,
+    "popularity": 11.0
+  },
+  {
+    "playerId": 215038,
+    "fullName": "Нету",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 5.4
+  },
+  {
+    "playerId": 215041,
+    "fullName": "Палмер",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 11.0,
+    "popularity": 34.7
+  },
+  {
+    "playerId": 214719,
+    "fullName": "Эндо",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214985,
+    "fullName": "Джошуа Кинг",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 214582,
+    "fullName": "Оньека",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214836,
+    "fullName": "Мбемо",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.5,
+    "popularity": 5.9
+  },
+  {
+    "playerId": 214437,
+    "fullName": "Сака",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 10.5,
+    "popularity": 10.5
+  },
+  {
+    "playerId": 214525,
+    "fullName": "Хамед Траоре",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214433,
+    "fullName": "Мартинелли",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 214731,
+    "fullName": "Собослаи",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 3.4
+  },
+  {
+    "playerId": 214896,
+    "fullName": "Эланга",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 3.0
+  },
+  {
+    "playerId": 214558,
+    "fullName": "Виффер",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214567,
+    "fullName": "Минте",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 215060,
+    "fullName": "Гуйе",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 215000,
+    "fullName": "Родриго Муниз",
+    "clubName": "Фулхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214698,
+    "fullName": "Эзе",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.5,
+    "popularity": 4.9
+  },
+  {
+    "playerId": 214734,
+    "fullName": "Виртц",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 9.0,
+    "popularity": 30.4
+  },
+  {
+    "playerId": 214634,
+    "fullName": "Лукас Пакета",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 3.7
+  },
+  {
+    "playerId": 214893,
+    "fullName": "Харви Барнс",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214958,
+    "fullName": "Арчи Грэй",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214853,
+    "fullName": "Айна",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 4.6
+  },
+  {
+    "playerId": 214758,
+    "fullName": "Танака",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214923,
+    "fullName": "Садики",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 214658,
+    "fullName": "Мунеци",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214494,
+    "fullName": "Каллен",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214467,
+    "fullName": "Уоткинс",
+    "clubName": "Астон Вилла",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 9.5,
+    "popularity": 10.2
+  },
+  {
+    "playerId": 214465,
+    "fullName": "Тилеманс",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 215035,
+    "fullName": "Кайседо",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 4.9
+  },
+  {
+    "playerId": 214857,
+    "fullName": "Мурилло",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 6.3
+  },
+  {
+    "playerId": 214793,
+    "fullName": "Бернарду Силва",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 3.0
+  },
+  {
+    "playerId": 214598,
+    "fullName": "Карвалью",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214927,
+    "fullName": "Джака",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 10.7
+  },
+  {
+    "playerId": 214517,
+    "fullName": "Адамс",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214655,
+    "fullName": "Андре",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214626,
+    "fullName": "Родригес",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214628,
+    "fullName": "Уан-Биссака",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 5.4
+  },
+  {
+    "playerId": 214894,
+    "fullName": "Жоэлинтон",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 214992,
+    "fullName": "Лено",
+    "clubName": "Фулхэм",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.2
+  },
+  {
+    "playerId": 214552,
+    "fullName": "Данк",
+    "clubName": "Брайтон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 214633,
+    "fullName": "Фюллькруг",
+    "clubName": "Вест Хэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 214559,
+    "fullName": "де Кейпер",
+    "clubName": "Брайтон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 5.5
+  },
+  {
+    "playerId": 214765,
+    "fullName": "Дэниэл Джеймс",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214696,
+    "fullName": "Матета",
+    "clubName": "Кристал Пэлас",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 8.9
+  },
+  {
+    "playerId": 214661,
+    "fullName": "Жоао Гомес",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214693,
+    "fullName": "Хьюз",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214766,
+    "fullName": "Ньонто",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214981,
+    "fullName": "Куэнка",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 214742,
+    "fullName": "Ампаду",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 8.5
+  },
+  {
+    "playerId": 214767,
+    "fullName": "Пиру",
+    "clubName": "Лидс",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 214963,
+    "fullName": "Бергвалль",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214835,
+    "fullName": "Матеус Кунья",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 6.5
+  },
+  {
+    "playerId": 215048,
+    "fullName": "О'Брайен",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 3.2
+  },
+  {
+    "playerId": 214816,
+    "fullName": "де Лигт",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 214549,
+    "fullName": "ван Хекке",
+    "clubName": "Брайтон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 215047,
+    "fullName": "Кин",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 215052,
+    "fullName": "Ироэгбунам",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214798,
+    "fullName": "Доку",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 214452,
+    "fullName": "Конса",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 3.0
+  },
+  {
+    "playerId": 215055,
+    "fullName": "Гарнер",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 215059,
+    "fullName": "Бету",
+    "clubName": "Эвертон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 2.0
+  },
+  {
+    "playerId": 215061,
+    "fullName": "Дьюзбери-Холл",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 214496,
+    "fullName": "Лоран",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214818,
+    "fullName": "Йоро",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 3.3
+  },
+  {
+    "playerId": 214822,
+    "fullName": "Шоу",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214863,
+    "fullName": "Хадсон-Одои",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214995,
+    "fullName": "Лукич",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214994,
+    "fullName": "Тете",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214504,
+    "fullName": "Энтони",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 215039,
+    "fullName": "Энцо Фернандес",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 5.4
+  },
+  {
+    "playerId": 214497,
+    "fullName": "Межбри",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 215040,
+    "fullName": "Жоао Педро",
+    "clubName": "Челси",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 32.2
+  },
+  {
+    "playerId": 214855,
+    "fullName": "Зельс",
+    "clubName": "Ноттингем Форест",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 11.0
   },
   {
-    "playerId": 566799,
-    "fullName": "James Trafford",
-    "clubName": "Burnley FC",
+    "playerId": 214873,
+    "fullName": "Дубравка",
+    "clubName": "Бернли",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 3.1
+  },
+  {
+    "playerId": 214501,
+    "fullName": "Фостер",
+    "clubName": "Бернли",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214608,
+    "fullName": "Агерд",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214623,
+    "fullName": "Диуф",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 3.8
+  },
+  {
+    "playerId": 214630,
+    "fullName": "Уорд-Проуз",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 214551,
+    "fullName": "Вербрюгген",
+    "clubName": "Брайтон",
     "position": "GK",
-    "league": "EPL"
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 6.6
   },
   {
-    "playerId": 371021,
-    "fullName": "Arijanet Murić",
-    "clubName": "Burnley FC",
+    "playerId": 214803,
+    "fullName": "Байындыр",
+    "clubName": "Манчестер Юнайтед",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 14.8
+  },
+  {
+    "playerId": 214852,
+    "fullName": "Сангаре",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214657,
+    "fullName": "Белльгард",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214851,
+    "fullName": "Йейтс",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214663,
+    "fullName": "Ларсен",
+    "clubName": "Вулверхэмптон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 214601,
+    "fullName": "Шаде",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 215054,
+    "fullName": "Алькарас",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 215056,
+    "fullName": "Пикфорд",
+    "clubName": "Эвертон",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 9.0
+  },
+  {
+    "playerId": 214436,
+    "fullName": "Дьокереш",
+    "clubName": "Арсенал",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 9.5,
+    "popularity": 24.3
+  },
+  {
+    "playerId": 214907,
+    "fullName": "Селт",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 214724,
+    "fullName": "Конате",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 214721,
+    "fullName": "ван Дейк",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 16.8
+  },
+  {
+    "playerId": 214828,
+    "fullName": "Каземиро",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 214830,
+    "fullName": "Маунт",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214856,
+    "fullName": "Миленкович",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 9.4
+  },
+  {
+    "playerId": 214486,
+    "fullName": "Уокер",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 3.0
+  },
+  {
+    "playerId": 215002,
+    "fullName": "Ивоби",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 214570,
+    "fullName": "Митома",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 4.5
+  },
+  {
+    "playerId": 215004,
+    "fullName": "Хименес",
+    "clubName": "Фулхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 214988,
+    "fullName": "Басси",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214593,
+    "fullName": "Джордан Хендерсон",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214987,
+    "fullName": "Андерсен",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214534,
+    "fullName": "Эванилсон",
+    "clubName": "Борнмут",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 214522,
+    "fullName": "Скотт",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214589,
+    "fullName": "Йенсен",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214520,
+    "fullName": "Петрович",
+    "clubName": "Борнмут",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 3.4
+  },
+  {
+    "playerId": 214577,
+    "fullName": "ван ден Берг",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214662,
+    "fullName": "Хван Хи Чхан",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214859,
+    "fullName": "Игор Жезус",
+    "clubName": "Ноттингем Форест",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 214660,
+    "fullName": "Арьяс",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214980,
+    "fullName": "Соланке",
+    "clubName": "Тоттенхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 214595,
+    "fullName": "Льюис-Поттер",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 214596,
+    "fullName": "Миламбо",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214579,
+    "fullName": "Кайоде",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 214654,
+    "fullName": "Фер Лопес",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214652,
+    "fullName": "Хувер",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214722,
+    "fullName": "Кертис Джонс",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214523,
+    "fullName": "Трюффер",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 214649,
+    "fullName": "Меллер Вольф",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214881,
+    "fullName": "Осула",
+    "clubName": "Ньюкасл",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214647,
+    "fullName": "Доэрти",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214880,
+    "fullName": "Майли",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214475,
+    "fullName": "Сонне",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 215003,
+    "fullName": "Смит-Роу",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214932,
+    "fullName": "Ле Фе",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 215058,
+    "fullName": "Барри",
+    "clubName": "Эвертон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 214690,
+    "fullName": "Лерма",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214565,
+    "fullName": "Груда",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214431,
+    "fullName": "Мадуэке",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 215652,
+    "fullName": "Шешко",
+    "clubName": "Манчестер Юнайтед",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 8.3
+  },
+  {
+    "playerId": 214429,
+    "fullName": "Мерино",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 214817,
+    "fullName": "Диогу Далот",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 214682,
+    "fullName": "Девенни",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 216508,
+    "fullName": "Уинтерберн",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214823,
+    "fullName": "Доргу",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 214860,
+    "fullName": "Силва",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214819,
+    "fullName": "Магуайр",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 214569,
+    "fullName": "Уэлбек",
+    "clubName": "Брайтон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 214787,
+    "fullName": "Грилиш",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 4.8
+  },
+  {
+    "playerId": 216510,
+    "fullName": "Хермансен",
+    "clubName": "Вест Хэм",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214773,
+    "fullName": "Хусанов",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 214464,
+    "fullName": "Мален",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 214930,
+    "fullName": "Ригг",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 215001,
+    "fullName": "Адама Траоре",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214643,
+    "fullName": "Родригу Гомеш",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214644,
+    "fullName": "Тоте Гомеш",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214591,
+    "fullName": "Коллинз",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 214617,
+    "fullName": "Тодибо",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214762,
+    "fullName": "Лонгстафф",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214972,
+    "fullName": "Одобер",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214764,
+    "fullName": "Харрисон",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214500,
+    "fullName": "Тшауна",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214590,
+    "fullName": "Келлехер",
+    "clubName": "Брентфорд",
     "position": "GK",
-    "league": "EPL"
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 4.7
+  },
+  {
+    "playerId": 214962,
+    "fullName": "Бентанкур",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 214609,
+    "fullName": "Ирвинг",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214502,
+    "fullName": "Эдвардс",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214761,
+    "fullName": "Ааронсон",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214503,
+    "fullName": "Флемминг",
+    "clubName": "Бернли",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214554,
+    "fullName": "Милнер",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214966,
+    "fullName": "Пальинья",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215022,
+    "fullName": "Угочукву",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214858,
+    "fullName": "Неко Уильямс",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 215021,
+    "fullName": "Сантос",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214512,
+    "fullName": "Хилл",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 2.2
+  },
+  {
+    "playerId": 215018,
+    "fullName": "Гюсто",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.5
+  },
+  {
+    "playerId": 214514,
+    "fullName": "Крупи",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214479,
+    "fullName": "Экдаль",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 3.7
+  },
+  {
+    "playerId": 214834,
+    "fullName": "Диалло",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 2.2
+  },
+  {
+    "playerId": 214587,
+    "fullName": "Хенри",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214789,
+    "fullName": "Матеуш Нунеш",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 214720,
+    "fullName": "Алиссон",
+    "clubName": "Ливерпуль",
+    "position": "GK",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 11.3
+  },
+  {
+    "playerId": 214825,
+    "fullName": "Угарте",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 215037,
+    "fullName": "Гиттенс",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 215034,
+    "fullName": "Делап",
+    "clubName": "Челси",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 3.7
+  },
+  {
+    "playerId": 214637,
+    "fullName": "Уго Буэно",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 214712,
+    "fullName": "Джо Гомес",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214487,
+    "fullName": "Хартман",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214800,
+    "fullName": "Мармуш",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 9.0,
+    "popularity": 6.5
+  },
+  {
+    "playerId": 214632,
+    "fullName": "Соучек",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214629,
+    "fullName": "Каллум Уилсон",
+    "clubName": "Вест Хэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 214516,
+    "fullName": "Смит",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214489,
+    "fullName": "Эстев",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214990,
+    "fullName": "Кастань",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214493,
+    "fullName": "Бруун Ларсен",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214756,
+    "fullName": "Груев",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214895,
+    "fullName": "Джейкоб Мерфи",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214975,
+    "fullName": "Тель",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214434,
+    "fullName": "Хавертц",
+    "clubName": "Арсенал",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 2.0
+  },
+  {
+    "playerId": 214838,
+    "fullName": "Карлос Мигел",
+    "clubName": "Ноттингем Форест",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214839,
+    "fullName": "Карму",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214890,
+    "fullName": "Уиллок",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214841,
+    "fullName": "Боли",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214840,
+    "fullName": "Тернер",
+    "clubName": "Ноттингем Форест",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214870,
+    "fullName": "Алекс Мерфи",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214842,
+    "fullName": "Боулер",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214869,
+    "fullName": "Ласселс",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214872,
+    "fullName": "Эшби",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 214874,
+    "fullName": "Кордеро",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214875,
+    "fullName": "Нив",
+    "clubName": "Ньюкасл",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214876,
+    "fullName": "Таргетт",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214854,
+    "fullName": "Домингес",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214877,
+    "fullName": "Джо Уайт",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214878,
+    "fullName": "Хернес",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214879,
+    "fullName": "Хэйден",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214871,
+    "fullName": "Радди",
+    "clubName": "Ньюкасл",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214850,
+    "fullName": "Эммануэль Деннис",
+    "clubName": "Ноттингем Форест",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214868,
+    "fullName": "Крафт",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214843,
+    "fullName": "Жаир Кунья",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214882,
+    "fullName": "Рэмсдейл",
+    "clubName": "Ньюкасл",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 214849,
+    "fullName": "да Силва Морейра",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214848,
+    "fullName": "Авонийи",
+    "clubName": "Ноттингем Форест",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 214847,
+    "fullName": "Стаменич",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214884,
+    "fullName": "Ботман",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 214846,
+    "fullName": "Омар Ричардс",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214887,
+    "fullName": "Льюис Холл",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214845,
+    "fullName": "О`Брайен",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214867,
+    "fullName": "Гиллеспи",
+    "clubName": "Ньюкасл",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214844,
+    "fullName": "Морато",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214866,
+    "fullName": "Влаходимос",
+    "clubName": "Ньюкасл",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 214405,
+    "fullName": "Кацурри",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214898,
+    "fullName": "Исак",
+    "clubName": "Ньюкасл",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 10.5,
+    "popularity": 3.1
+  },
+  {
+    "playerId": 215015,
+    "fullName": "Адарабиойо",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 215033,
+    "fullName": "Стерлинг",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 215032,
+    "fullName": "Джексон",
+    "clubName": "Челси",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 215031,
+    "fullName": "Эстевао",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215028,
+    "fullName": "Лавия",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 215027,
+    "fullName": "Колуилл",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 215025,
+    "fullName": "Чуквуэмека",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 215023,
+    "fullName": "Фофана",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 215020,
+    "fullName": "Йоргенсен",
+    "clubName": "Челси",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 215019,
+    "fullName": "Джордж",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 215017,
+    "fullName": "Гиу",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 3.4
+  },
+  {
+    "playerId": 215016,
+    "fullName": "Броя",
+    "clubName": "Бернли",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 215014,
+    "fullName": "Эссугу",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 215042,
+    "fullName": "Азну",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 12.2
+  },
+  {
+    "playerId": 215013,
+    "fullName": "Чилуэлл",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 215012,
+    "fullName": "Келлимен",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215011,
+    "fullName": "Дисаси",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 215010,
+    "fullName": "Бадьяшиль",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 215009,
+    "fullName": "Слонина",
+    "clubName": "Челси",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 215008,
+    "fullName": "Мамаду Сарр",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 215007,
+    "fullName": "Гилкрист",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 215005,
+    "fullName": "Ансельмино",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 214998,
+    "fullName": "Сессеньон",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214997,
+    "fullName": "Перейра",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214996,
+    "fullName": "Робинсон",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 215036,
+    "fullName": "Нкунку",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 215043,
+    "fullName": "Коулмэн",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214991,
+    "fullName": "Кэрни",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 216509,
+    "fullName": "Артур",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 216521,
+    "fullName": "Хит",
+    "clubName": "Эвертон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 216520,
+    "fullName": "Оньянго",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 216519,
+    "fullName": "Уолш",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216518,
+    "fullName": "Сэмюэл Рак-Сакьи",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216517,
+    "fullName": "Антви",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 216516,
+    "fullName": "Масуаку",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 216515,
+    "fullName": "Куол",
+    "clubName": "Ньюкасл",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 216514,
+    "fullName": "Шахар",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 216513,
+    "fullName": "Ганн",
+    "clubName": "Ноттингем Форест",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.8
   },
   {
-    "playerId": 243591,
-    "fullName": "Lawrence Vigouroux",
-    "clubName": "Burnley FC",
+    "playerId": 216512,
+    "fullName": "Мердок",
+    "clubName": "Манчестер Юнайтед",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216511,
+    "fullName": "Амасс",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 216507,
+    "fullName": "Рис-Доттин",
+    "clubName": "Борнмут",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 215044,
+    "fullName": "Тайрер",
+    "clubName": "Эвертон",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 216506,
+    "fullName": "Аду-Аджей",
+    "clubName": "Борнмут",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 216505,
+    "fullName": "Биван",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 215653,
+    "fullName": "Хато",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215651,
+    "fullName": "Гессан",
+    "clubName": "Астон Вилла",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 215062,
+    "fullName": "Макнил",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 215057,
+    "fullName": "Тарковски",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 215053,
+    "fullName": "Миколенко",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 215051,
+    "fullName": "Брэнтуэйт",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 215050,
+    "fullName": "Шермити",
+    "clubName": "Эвертон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 215049,
+    "fullName": "Натан Паттерсон",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 215046,
+    "fullName": "Армстронг",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 215045,
+    "fullName": "Трэверс",
+    "clubName": "Эвертон",
     "position": "GK",
-    "league": "EPL"
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214993,
+    "fullName": "Рид",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214989,
+    "fullName": "Берге",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214899,
+    "fullName": "Алесе",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214914,
+    "fullName": "Браун",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214934,
+    "fullName": "Патрик Робертс",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214929,
+    "fullName": "Нил",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214928,
+    "fullName": "Мандл",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214926,
+    "fullName": "Эква",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214924,
+    "fullName": "Серкин",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214921,
+    "fullName": "Русин",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214920,
+    "fullName": "Поведа",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214919,
+    "fullName": "О`Нин",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214918,
+    "fullName": "Матете",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214917,
+    "fullName": "Луиш Семеду",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 214916,
+    "fullName": "Харрисон Джонс",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214913,
+    "fullName": "Ба",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 214939,
+    "fullName": "Кассанова",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214912,
+    "fullName": "Алексич",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 214911,
+    "fullName": "Абдуллахи",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 6.8
+  },
+  {
+    "playerId": 214910,
+    "fullName": "Хьельде",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214909,
+    "fullName": "Хаггинс",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214908,
+    "fullName": "Триантис",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214905,
+    "fullName": "Пэттерсон",
+    "clubName": "Сандерленд",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214904,
+    "fullName": "Пембеле",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214903,
+    "fullName": "Нуке",
+    "clubName": "Сандерленд",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
   },
   {
-    "playerId": 606576,
-    "fullName": "Denis Franchi",
-    "clubName": "Burnley FC",
+    "playerId": 214902,
+    "fullName": "Саймон Мур",
+    "clubName": "Сандерленд",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214901,
+    "fullName": "Зак Джонсон",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214900,
+    "fullName": "Джозеф Андерсон",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 4.1
+  },
+  {
+    "playerId": 214938,
+    "fullName": "Вушкович",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214940,
+    "fullName": "Остин",
+    "clubName": "Тоттенхэм",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214986,
+    "fullName": "Харрис",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214956,
+    "fullName": "Эшкрофт",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214984,
+    "fullName": "Диоп",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214983,
+    "fullName": "Годо",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214982,
+    "fullName": "Лекомт",
+    "clubName": "Фулхэм",
     "position": "GK",
-    "league": "EPL"
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214979,
+    "fullName": "Мэддисон",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214978,
+    "fullName": "Кулусевски",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214971,
+    "fullName": "Хиль",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214970,
+    "fullName": "Удоджи",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214969,
+    "fullName": "Соломон",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214960,
+    "fullName": "Мин Хек",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214959,
+    "fullName": "Данзо",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214957,
+    "fullName": "Биссума",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214954,
+    "fullName": "Уильямс-Барнетт",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214941,
+    "fullName": "Такаи",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214953,
+    "fullName": "Скарлетт",
+    "clubName": "Тоттенхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214952,
+    "fullName": "Рассел-Дэнни",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214951,
+    "fullName": "Олусеси",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214950,
+    "fullName": "Майки Мур",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214949,
+    "fullName": "Лэнкшир",
+    "clubName": "Тоттенхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214948,
+    "fullName": "Кьерематен",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214947,
+    "fullName": "Кински",
+    "clubName": "Тоттенхэм",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214946,
+    "fullName": "Дэвис",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214945,
+    "fullName": "Дрэгушин",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214944,
+    "fullName": "Донли",
+    "clubName": "Тоттенхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214943,
+    "fullName": "Дивайн",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214942,
+    "fullName": "Эбботт",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214955,
+    "fullName": "Тайрис Холл",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214745,
+    "fullName": "Гелхардт",
+    "clubName": "Лидс",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 2.0
+  },
+  {
+    "playerId": 214833,
+    "fullName": "Хейлунд",
+    "clubName": "Манчестер Юнайтед",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214536,
+    "fullName": "Игор Жулио",
+    "clubName": "Брайтон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214548,
+    "fullName": "Ялькуйе",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214547,
+    "fullName": "Уэбстер",
+    "clubName": "Брайтон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214546,
+    "fullName": "Уотсон",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214545,
+    "fullName": "Сармиенто",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214544,
+    "fullName": "Моран",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214543,
+    "fullName": "Лэмпти",
+    "clubName": "Брайтон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214542,
+    "fullName": "Коппола",
+    "clubName": "Брайтон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214541,
+    "fullName": "Кадыоглу",
+    "clubName": "Брайтон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214540,
+    "fullName": "Диего Гомес",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214539,
+    "fullName": "Боскальи",
+    "clubName": "Брайтон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214538,
+    "fullName": "Стил",
+    "clubName": "Брайтон",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.6
   },
   {
-    "playerId": 403898,
-    "fullName": "Jordan Beyer",
-    "clubName": "Burnley FC",
-    "position": "D",
-    "league": "EPL"
+    "playerId": 214537,
+    "fullName": "Макгилл",
+    "clubName": "Брайтон",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214533,
+    "fullName": "Клюйверт",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214553,
+    "fullName": "Костулас",
+    "clubName": "Брайтон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214532,
+    "fullName": "Уаттара",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214530,
+    "fullName": "Синистерра",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214529,
+    "fullName": "Кук",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214528,
+    "fullName": "Кристи",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214527,
+    "fullName": "Февр",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214526,
+    "fullName": "Унал",
+    "clubName": "Борнмут",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214521,
+    "fullName": "Сенеси",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214519,
+    "fullName": "Забарный",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 214518,
+    "fullName": "Биллинг",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214515,
+    "fullName": "Силкотт-Дьюберри",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214513,
+    "fullName": "Араухо",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 214511,
+    "fullName": "Солер",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214510,
+    "fullName": "Полсен",
+    "clubName": "Борнмут",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214550,
+    "fullName": "Велтман",
+    "clubName": "Брайтон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214555,
+    "fullName": "Сима",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214508,
+    "fullName": "Мифем",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214584,
+    "fullName": "Пирт-Харрис",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214610,
+    "fullName": "Каммингс",
+    "clubName": "Вест Хэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214607,
+    "fullName": "Хедьи",
+    "clubName": "Вест Хэм",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.5
   },
   {
-    "playerId": 620598,
-    "fullName": "Ameen Al-Dakhil",
-    "clubName": "Burnley FC",
-    "position": "D",
-    "league": "EPL"
+    "playerId": 214606,
+    "fullName": "Фодерингэм",
+    "clubName": "Вест Хэм",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214605,
+    "fullName": "Скарлз",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214604,
+    "fullName": "Клейтон",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214603,
+    "fullName": "Кейси",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214602,
+    "fullName": "Висса",
+    "clubName": "Брентфорд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 214600,
+    "fullName": "Дамсгор",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214597,
+    "fullName": "Янельт",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214592,
+    "fullName": "Нунес",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214588,
+    "fullName": "Хики",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214586,
+    "fullName": "Тревитт",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214585,
+    "fullName": "Роэрслев",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214583,
+    "fullName": "Пиннок",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214557,
+    "fullName": "Буонанотте",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214581,
+    "fullName": "Магома",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214580,
+    "fullName": "Конак",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214578,
+    "fullName": "Донован",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214576,
+    "fullName": "Айер",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214575,
+    "fullName": "Мегома",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214574,
+    "fullName": "Кокс",
+    "clubName": "Брентфорд",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214573,
+    "fullName": "Ким Чжи Су",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214572,
+    "fullName": "Вальдимарссон",
+    "clubName": "Брентфорд",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.3
   },
   {
-    "playerId": 401320,
-    "fullName": "Dara O'Shea",
-    "clubName": "Burnley FC",
-    "position": "D",
-    "league": "EPL"
+    "playerId": 214571,
+    "fullName": "Балкомб",
+    "clubName": "Брентфорд",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 3.2
+  },
+  {
+    "playerId": 214566,
+    "fullName": "Марч",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214563,
+    "fullName": "Энсисо",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214562,
+    "fullName": "Цимас",
+    "clubName": "Брайтон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214561,
+    "fullName": "Хиншелвуд",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214509,
+    "fullName": "Нето",
+    "clubName": "Борнмут",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.4
   },
   {
-    "playerId": 392179,
-    "fullName": "Hjalmar Ekdal",
-    "clubName": "Burnley FC",
-    "position": "D",
-    "league": "EPL"
+    "playerId": 214507,
+    "fullName": "Маккенна",
+    "clubName": "Борнмут",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214612,
+    "fullName": "Келли",
+    "clubName": "Вест Хэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214426,
+    "fullName": "Нванери",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214449,
+    "fullName": "Баркли",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214448,
+    "fullName": "Морено",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214446,
+    "fullName": "Доббин",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214445,
+    "fullName": "Джимо-Алоба",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214444,
+    "fullName": "Богарде",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214442,
+    "fullName": "Райт",
+    "clubName": "Астон Вилла",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214441,
+    "fullName": "Трэвис Паттерсон",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214440,
+    "fullName": "Филип Маршалл",
+    "clubName": "Астон Вилла",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
   },
   {
-    "playerId": 842341,
-    "fullName": "Maxime Estève",
-    "clubName": "Burnley FC",
-    "position": "D",
-    "league": "EPL"
+    "playerId": 214439,
+    "fullName": "Госи",
+    "clubName": "Астон Вилла",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214438,
+    "fullName": "Гарсия",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214432,
+    "fullName": "Троссард",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214427,
+    "fullName": "Нергор",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214425,
+    "fullName": "Габриэл Жезус",
+    "clubName": "Арсенал",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214451,
+    "fullName": "Илинг-Джуниор",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214423,
+    "fullName": "Тимбер",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214419,
+    "fullName": "Фабиу Виейра",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214418,
+    "fullName": "Льюис-Скелли",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 214417,
+    "fullName": "Кивер",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214415,
+    "fullName": "Аррисабалага",
+    "clubName": "Арсенал",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214414,
+    "fullName": "Нелсон",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214413,
+    "fullName": "Кристиан Москера",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214412,
+    "fullName": "Зинченко",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214411,
+    "fullName": "Локонга",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214410,
+    "fullName": "Кабиа",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214409,
+    "fullName": "Хейн",
+    "clubName": "Арсенал",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
   },
   {
-    "playerId": 338635,
-    "fullName": "Hannes Delcroix",
-    "clubName": "Burnley FC",
-    "position": "D",
-    "league": "EPL"
+    "playerId": 214408,
+    "fullName": "Сетфорд",
+    "clubName": "Арсенал",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
   },
   {
-    "playerId": 535927,
-    "fullName": "Luke McNally",
-    "clubName": "Burnley FC",
-    "position": "D",
-    "league": "EPL"
+    "playerId": 214407,
+    "fullName": "Рохас Федорущенко",
+    "clubName": "Арсенал",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214450,
+    "fullName": "Дендонкер",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214454,
+    "fullName": "Матсен",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 214506,
+    "fullName": "Уилл Деннис",
+    "clubName": "Борнмут",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214480,
+    "fullName": "Адевуми",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 214505,
+    "fullName": "Акинмбони",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 4.8
+  },
+  {
+    "playerId": 214499,
+    "fullName": "Обафеми",
+    "clubName": "Бернли",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214498,
+    "fullName": "Ндайишимийе",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214495,
+    "fullName": "Колиошо",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214492,
+    "fullName": "Бенсон",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214491,
+    "fullName": "Эшли Барнс",
+    "clubName": "Бернли",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214490,
+    "fullName": "Амдуни",
+    "clubName": "Бернли",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214488,
+    "fullName": "Чурлинов",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214485,
+    "fullName": "Аарон Рэмзи",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214484,
+    "fullName": "Коннор Робертс",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214483,
+    "fullName": "Вайсс",
+    "clubName": "Бернли",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 214482,
+    "fullName": "Банел",
+    "clubName": "Бернли",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214481,
+    "fullName": "Аджей",
+    "clubName": "Бернли",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 214478,
+    "fullName": "Хамфрис",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214455,
+    "fullName": "Пау Торрес",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 214477,
+    "fullName": "Уоррелл",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214476,
+    "fullName": "Туанзебе",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 214474,
+    "fullName": "Самбо",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214473,
+    "fullName": "Пирес",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214472,
+    "fullName": "Доджсон",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214471,
+    "fullName": "Делькруа",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214470,
+    "fullName": "Грин",
+    "clubName": "Бернли",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.7
   },
   {
-    "playerId": 581669,
-    "fullName": "CJ Egan-Riley",
-    "clubName": "Burnley FC",
-    "position": "D",
-    "league": "EPL"
+    "playerId": 214469,
+    "fullName": "Гладки",
+    "clubName": "Бернли",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 214468,
+    "fullName": "Байер",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 214462,
+    "fullName": "Бэйли",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214461,
+    "fullName": "Джейкоб Рэмзи",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214459,
+    "fullName": "Буэндиа",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214458,
+    "fullName": "Эмилиано Мартинес",
+    "clubName": "Астон Вилла",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 214611,
+    "fullName": "Канте",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214613,
+    "fullName": "Мавропанос",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214832,
+    "fullName": "Гарначо",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214747,
+    "fullName": "Харри Грэй",
+    "clubName": "Лидс",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 214774,
+    "fullName": "Аке",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.0
+  },
+  {
+    "playerId": 214772,
+    "fullName": "Рейс",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214771,
+    "fullName": "Нюпан",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214770,
+    "fullName": "Уилсон-Эсбранд",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214769,
+    "fullName": "Каборе",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214768,
+    "fullName": "Беттинелли",
+    "clubName": "Манчестер Сити",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214759,
+    "fullName": "Матео Фернандес",
+    "clubName": "Лидс",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214757,
+    "fullName": "Рамазани",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214755,
+    "fullName": "Бэмфорд",
+    "clubName": "Лидс",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 214754,
+    "fullName": "Чамберс",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214750,
+    "fullName": "Крю",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214749,
+    "fullName": "Джаби",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214746,
+    "fullName": "Гринвуд",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214776,
+    "fullName": "Ортега",
+    "clubName": "Манчестер Сити",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214406,
+    "fullName": "Николс",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214743,
+    "fullName": "Бийол",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 214741,
+    "fullName": "Шмидт",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 214740,
+    "fullName": "Мелье",
+    "clubName": "Лидс",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 2.0
   },
   {
-    "playerId": 195633,
-    "fullName": "Charlie Taylor",
-    "clubName": "Burnley FC",
-    "position": "D",
-    "league": "EPL"
+    "playerId": 214739,
+    "fullName": "Кэрнс",
+    "clubName": "Лидс",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
   },
   {
-    "playerId": 711969,
-    "fullName": "Lorenz Assignon",
-    "clubName": "Burnley FC",
-    "position": "D",
-    "league": "EPL"
+    "playerId": 214738,
+    "fullName": "Дарлоу",
+    "clubName": "Лидс",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 5.4
+  },
+  {
+    "playerId": 214737,
+    "fullName": "Борнаув",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 214736,
+    "fullName": "Байрэм",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 214729,
+    "fullName": "Нуньес",
+    "clubName": "Ливерпуль",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 214728,
+    "fullName": "Гравенберх",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214727,
+    "fullName": "Эллиот",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214718,
+    "fullName": "Робертсон",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214717,
+    "fullName": "Мамардашвили",
+    "clubName": "Ливерпуль",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214775,
+    "fullName": "Нико О`Райли",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214779,
+    "fullName": "Филлипс",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214715,
+    "fullName": "Цимикас",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214809,
+    "fullName": "Хитон",
+    "clubName": "Манчестер Юнайтед",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214831,
+    "fullName": "Санчо",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214829,
+    "fullName": "Майну",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 214827,
+    "fullName": "Зиркзе",
+    "clubName": "Манчестер Юнайтед",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 214826,
+    "fullName": "Антони",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214824,
+    "fullName": "Андре Онана",
+    "clubName": "Манчестер Юнайтед",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 214821,
+    "fullName": "Лисандро Мартинес",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214820,
+    "fullName": "Мазрауи",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214815,
+    "fullName": "Флетчер",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214814,
+    "fullName": "Уитли",
+    "clubName": "Манчестер Юнайтед",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214813,
+    "fullName": "Оби-Мартин",
+    "clubName": "Манчестер Юнайтед",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214812,
+    "fullName": "Мантато",
+    "clubName": "Манчестер Юнайтед",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214811,
+    "fullName": "Коне",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214810,
+    "fullName": "Коллиер",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214808,
+    "fullName": "Хевен",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214780,
+    "fullName": "Эчеверри",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214807,
+    "fullName": "Фредриксон",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214806,
+    "fullName": "Ми",
+    "clubName": "Манчестер Юнайтед",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214805,
+    "fullName": "Маласиа",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214804,
+    "fullName": "Леон",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214801,
+    "fullName": "Фоден",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 9.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 214797,
+    "fullName": "Савио",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214796,
+    "fullName": "Родри Эрнандес",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214794,
+    "fullName": "Гюндоган",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214792,
+    "fullName": "Эдерсон",
+    "clubName": "Манчестер Сити",
+    "position": "GK",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 2.5
+  },
+  {
+    "playerId": 214788,
+    "fullName": "Ковачич",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214786,
+    "fullName": "Гвардиол",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 11.3
+  },
+  {
+    "playerId": 214783,
+    "fullName": "Макати",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214781,
+    "fullName": "Аканджи",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 214716,
+    "fullName": "Брэдли",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214714,
+    "fullName": "Нгумоа",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214614,
+    "fullName": "Каллум Маршалл",
+    "clubName": "Вест Хэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 214640,
+    "fullName": "Ерсон Москера",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
   },
   {
     "playerId": 214666,
-    "fullName": "Connor Roberts",
-    "clubName": "Burnley FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 468249,
-    "fullName": "Vitinho",
-    "clubName": "Burnley FC",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 333014,
-    "fullName": "Sander Berge",
-    "clubName": "Burnley FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 242606,
-    "fullName": "Josh Cullen",
-    "clubName": "Burnley FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 40613,
-    "fullName": "Jack Cork",
-    "clubName": "Burnley FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 293569,
-    "fullName": "Josh Brownhill",
-    "clubName": "Burnley FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 536508,
-    "fullName": "Han-Noah Massengo",
-    "clubName": "Burnley FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 646658,
-    "fullName": "Aaron Ramsey",
-    "clubName": "Burnley FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 433818,
-    "fullName": "Scott Twine",
-    "clubName": "Burnley FC",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 381963,
-    "fullName": "Mike Tresor",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 491296,
-    "fullName": "Anass Zaroury",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 293281,
-    "fullName": "Jacob Bruun Larsen",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 386786,
-    "fullName": "Darko Churlinov",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 614700,
-    "fullName": "Dara Costelloe",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 743498,
-    "fullName": "Wilson Odobert",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 745461,
-    "fullName": "Luca Koleosho",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 322702,
-    "fullName": "Benson Manuel",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 129078,
-    "fullName": "Nathan Redmond",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 89231,
-    "fullName": "Jóhann Berg Gudmundsson",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 724041,
-    "fullName": "Enock Agyei",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 467623,
-    "fullName": "Lyle Foster",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 787232,
-    "fullName": "David Datro Fofana",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 548729,
-    "fullName": "Zeki Amdouni",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 444208,
-    "fullName": "Michael Obafemi",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 53360,
-    "fullName": "Jay Rodríguez",
-    "clubName": "Burnley FC",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 226073,
-    "fullName": "Ivo Grbic",
-    "clubName": "Sheffield United",
+    "fullName": "Мэттьюз",
+    "clubName": "Кристал Пэлас",
     "position": "GK",
-    "league": "EPL"
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3
   },
   {
-    "playerId": 61697,
-    "fullName": "Wes Foderingham",
-    "clubName": "Sheffield United",
+    "playerId": 214665,
+    "fullName": "Кпорха",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214664,
+    "fullName": "Клайн",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 214659,
+    "fullName": "Фабиу Силва",
+    "clubName": "Вулверхэмптон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214656,
+    "fullName": "Калайджич",
+    "clubName": "Вулверхэмптон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214653,
+    "fullName": "Чирева",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214651,
+    "fullName": "Холмен",
+    "clubName": "Вулверхэмптон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214650,
+    "fullName": "Бубакар Траоре",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214648,
+    "fullName": "Жозе Са",
+    "clubName": "Вулверхэмптон",
     "position": "GK",
-    "league": "EPL"
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 2.2
   },
   {
-    "playerId": 121254,
-    "fullName": "Adam Davies",
-    "clubName": "Sheffield United",
+    "playerId": 214646,
+    "fullName": "Джонстон",
+    "clubName": "Вулверхэмптон",
     "position": "GK",
-    "league": "EPL"
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
   },
   {
-    "playerId": 385412,
-    "fullName": "Jordan Amissah",
-    "clubName": "Sheffield United",
+    "playerId": 214645,
+    "fullName": "Гонсалес",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214642,
+    "fullName": "Сантьяго Буэно",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214641,
+    "fullName": "Агбаду",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 214639,
+    "fullName": "Лима",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 214668,
+    "fullName": "Агбиноне",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 214638,
+    "fullName": "Том Кинг",
+    "clubName": "Эвертон",
     "position": "GK",
-    "league": "EPL"
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4
   },
   {
-    "playerId": 377468,
-    "fullName": "Anel Ahmedhodzic",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 389253,
-    "fullName": "Auston Trusty",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 348623,
-    "fullName": "Mason Holgate",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 121324,
-    "fullName": "John Egan",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 128909,
-    "fullName": "Jack Robinson",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 52495,
-    "fullName": "Chris Basham",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 743553,
-    "fullName": "Evan Easton",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1108667,
-    "fullName": "Dovydas Sasnauskas",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 505194,
-    "fullName": "Luke Thomas",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 554251,
-    "fullName": "Yasser Larouci",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 258885,
-    "fullName": "Max Lowe",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 543164,
-    "fullName": "Rhys Norrington-Davies",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1072898,
-    "fullName": "Jili Buyabu",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 465717,
-    "fullName": "Jayden Bogle",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 146690,
-    "fullName": "George Baldock",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 638649,
-    "fullName": "Femi Seriki",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 741267,
-    "fullName": "Sam Curtis",
-    "clubName": "Sheffield United",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 663581,
-    "fullName": "Vini Souza",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 314210,
-    "fullName": "Tom Davies",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 746739,
-    "fullName": "Andre Brooks",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 546712,
-    "fullName": "Anis Slimane",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 73547,
-    "fullName": "Oliver Norwood",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 490224,
-    "fullName": "Ismaila Coulibaly",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 218087,
-    "fullName": "Ben Osborn",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 54383,
-    "fullName": "John Fleck",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 874066,
-    "fullName": "Oliver Arblaster",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 745851,
-    "fullName": "Sydie Peck",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 967318,
-    "fullName": "Billy Blacker",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 967340,
-    "fullName": "Owen Hampson",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 322985,
-    "fullName": "Gustavo Hamer",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 583199,
-    "fullName": "James McAtee",
-    "clubName": "Sheffield United",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 852024,
-    "fullName": "Bénie Traoré",
-    "clubName": "Sheffield United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 874043,
-    "fullName": "Louie Marsh",
-    "clubName": "Sheffield United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 533662,
-    "fullName": "Cameron Archer",
-    "clubName": "Sheffield United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 426192,
-    "fullName": "Ben Brereton Díaz",
-    "clubName": "Sheffield United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 298477,
-    "fullName": "Oli McBurnie",
-    "clubName": "Sheffield United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 406560,
-    "fullName": "Rhian Brewster",
-    "clubName": "Sheffield United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 609556,
-    "fullName": "William Osula",
-    "clubName": "Sheffield United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 746740,
-    "fullName": "Daniel Jebbison",
-    "clubName": "Sheffield United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 670859,
-    "fullName": "Antwoine Hackford",
-    "clubName": "Sheffield United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1031293,
-    "fullName": "Ryan Oné",
-    "clubName": "Sheffield United",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 77757,
-    "fullName": "Thomas Kaminski",
-    "clubName": "Luton Town",
+    "playerId": 214636,
+    "fullName": "Бентли",
+    "clubName": "Вулверхэмптон",
     "position": "GK",
-    "league": "EPL"
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 3.1
   },
   {
-    "playerId": 33027,
-    "fullName": "Tim Krul",
-    "clubName": "Luton Town",
+    "playerId": 214631,
+    "fullName": "Саммервилл",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214627,
+    "fullName": "Альварес",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214625,
+    "fullName": "Корне",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214624,
+    "fullName": "Килмен",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 214622,
+    "fullName": "Гильерме",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214621,
+    "fullName": "Ареоля",
+    "clubName": "Вест Хэм",
     "position": "GK",
-    "league": "EPL"
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.1
   },
   {
-    "playerId": 368629,
-    "fullName": "Jack Walton",
-    "clubName": "Luton Town",
+    "playerId": 214620,
+    "fullName": "Эрти",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214619,
+    "fullName": "Эмерсон",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214618,
+    "fullName": "Уокер-Питерс",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214616,
+    "fullName": "Поттс",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 214615,
+    "fullName": "Орфорд",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214667,
+    "fullName": "Холдинг",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 214669,
+    "fullName": "Ахамада",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 214713,
+    "fullName": "Доук",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214695,
+    "fullName": "Нкетиа",
+    "clubName": "Кристал Пэлас",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 214711,
+    "fullName": "Байчетич",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214710,
+    "fullName": "Стивенсон",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214709,
+    "fullName": "Пиллинг",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 214708,
+    "fullName": "Ньони",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214707,
+    "fullName": "Моррисон",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214706,
+    "fullName": "Кумас",
+    "clubName": "Ливерпуль",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214705,
+    "fullName": "Дэннс",
+    "clubName": "Ливерпуль",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214704,
+    "fullName": "Рис Уильямс",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214703,
+    "fullName": "Кэлвин Рэмзи",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 214702,
+    "fullName": "Печи",
+    "clubName": "Ливерпуль",
     "position": "GK",
-    "league": "EPL"
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
   },
   {
-    "playerId": 91340,
-    "fullName": "James Shea",
-    "clubName": "Luton Town",
+    "playerId": 214701,
+    "fullName": "Налло",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214700,
+    "fullName": "Мабайя",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 214699,
+    "fullName": "Вудмен",
+    "clubName": "Ливерпуль",
     "position": "GK",
-    "league": "EPL"
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2
   },
   {
-    "playerId": 548470,
-    "fullName": "Teden Mengi",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
+    "playerId": 214689,
+    "fullName": "Камада",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1
   },
   {
-    "playerId": 424900,
-    "fullName": "Tom Holmes",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 364409,
-    "fullName": "Gabriel Osho",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 407021,
-    "fullName": "Mads Andersen",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 207742,
-    "fullName": "Tom Lockyer",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 278166,
-    "fullName": "Amari'i Bell",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 264220,
-    "fullName": "Reece Burke",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 207037,
-    "fullName": "Dan Potts",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1225825,
-    "fullName": "Christian Chigozie",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 504581,
-    "fullName": "Ryan Giles",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1088818,
-    "fullName": "Joe Johnson",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 649452,
-    "fullName": "Issa Kaboré",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 387191,
-    "fullName": "Daiki Hashioka",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 802230,
-    "fullName": "Aidan Francis-Clarke",
-    "clubName": "Luton Town",
-    "position": "D",
-    "league": "EPL"
-  },
-  {
-    "playerId": 324882,
-    "fullName": "Marvelous Nakamba",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 244338,
-    "fullName": "Pelly Ruddock Mpanzu",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1203143,
-    "fullName": "Dominic Dos Santos Martins",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 381967,
-    "fullName": "Albert Sambi Lokonga",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 131978,
-    "fullName": "Ross Barkley",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 347619,
-    "fullName": "Allan Campbell",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 184129,
-    "fullName": "Jordan Clark",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 125685,
-    "fullName": "Luke Berry",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 505548,
-    "fullName": "Louie Watson",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 907219,
-    "fullName": "Axel Piesold",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 965954,
-    "fullName": "Jake Burger",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 1088817,
-    "fullName": "Jayden Luker",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 305274,
-    "fullName": "Fred Onyedinma",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 608175,
-    "fullName": "Alfie Doughty",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 344830,
-    "fullName": "Tahith Chong",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 496661,
-    "fullName": "Elliot Thorpe",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 965940,
-    "fullName": "Zack Nelson",
-    "clubName": "Luton Town",
-    "position": "M",
-    "league": "EPL"
-  },
-  {
-    "playerId": 499604,
-    "fullName": "Dion Pereira",
-    "clubName": "Luton Town",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 392591,
-    "fullName": "Chiedozie Ogbene",
-    "clubName": "Luton Town",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 61842,
-    "fullName": "Andros Townsend",
-    "clubName": "Luton Town",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 504855,
-    "fullName": "John McAtee",
-    "clubName": "Luton Town",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 246963,
-    "fullName": "Carlton Morris",
-    "clubName": "Luton Town",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 319900,
-    "fullName": "Elijah Adebayo",
-    "clubName": "Luton Town",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 469958,
-    "fullName": "Jacob Brown",
-    "clubName": "Luton Town",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 169801,
-    "fullName": "Cauley Woodrow",
-    "clubName": "Luton Town",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 944551,
-    "fullName": "Joe Taylor",
-    "clubName": "Luton Town",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 314378,
-    "fullName": "Admiral Muskwe",
-    "clubName": "Luton Town",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 985717,
-    "fullName": "Taylan Harris",
-    "clubName": "Luton Town",
-    "position": "F",
-    "league": "EPL"
-  },
-  {
-    "playerId": 42205,
-    "fullName": "Yann Sommer",
-    "clubName": "Inter Milan",
+    "playerId": 214670,
+    "fullName": "Бенитес",
+    "clubName": "Кристал Пэлас",
     "position": "GK",
-    "league": "Serie A"
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
   },
   {
-    "playerId": 256339,
-    "fullName": "Emil Audero",
-    "clubName": "Inter Milan",
-    "position": "GK",
-    "league": "Serie A"
+    "playerId": 214688,
+    "fullName": "Дукуре",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.0
   },
   {
-    "playerId": 70580,
-    "fullName": "Raffaele Di Gennaro",
-    "clubName": "Inter Milan",
-    "position": "GK",
-    "league": "Serie A"
+    "playerId": 214687,
+    "fullName": "Эсс",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
   },
   {
-    "playerId": 746711,
-    "fullName": "Alessandro Calligaris",
-    "clubName": "Inter Milan",
-    "position": "GK",
-    "league": "Serie A"
+    "playerId": 214686,
+    "fullName": "Эдуар",
+    "clubName": "Кристал Пэлас",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.4
   },
   {
-    "playerId": 315853,
-    "fullName": "Alessandro Bastoni",
-    "clubName": "Inter Milan",
-    "position": "D",
-    "league": "Serie A"
+    "playerId": 214685,
+    "fullName": "Джесуран Рак-Сакьи",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1
   },
   {
-    "playerId": 353366,
-    "fullName": "Benjamin Pavard",
-    "clubName": "Inter Milan",
-    "position": "D",
-    "league": "Serie A"
+    "playerId": 214680,
+    "fullName": "Эбиовей",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
   },
   {
-    "playerId": 441986,
-    "fullName": "Yann Bisseck",
-    "clubName": "Inter Milan",
-    "position": "D",
-    "league": "Serie A"
+    "playerId": 214679,
+    "fullName": "Уме",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
   },
   {
-    "playerId": 111196,
-    "fullName": "Stefan de Vrij",
-    "clubName": "Inter Milan",
-    "position": "D",
-    "league": "Serie A"
+    "playerId": 214678,
+    "fullName": "Соса",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
   },
   {
-    "playerId": 131075,
-    "fullName": "Francesco Acerbi",
-    "clubName": "Inter Milan",
-    "position": "D",
-    "league": "Serie A"
+    "playerId": 214677,
+    "fullName": "Родни",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
   },
   {
-    "playerId": 936503,
-    "fullName": "Giacomo Stabile",
-    "clubName": "Inter Milan",
-    "position": "D",
-    "league": "Serie A"
+    "playerId": 214675,
+    "fullName": "Риад",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.0
   },
   {
-    "playerId": 198116,
-    "fullName": "Federico Dimarco",
-    "clubName": "Inter Milan",
-    "position": "D",
-    "league": "Serie A"
+    "playerId": 214674,
+    "fullName": "Пьеррик",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
   },
   {
-    "playerId": 585982,
-    "fullName": "Carlos Augusto",
-    "clubName": "Inter Milan",
-    "position": "D",
-    "league": "Serie A"
+    "playerId": 214673,
+    "fullName": "Озо",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2
   },
   {
-    "playerId": 937342,
-    "fullName": "Matteo Motta",
-    "clubName": "Inter Milan",
-    "position": "D",
-    "league": "Serie A"
+    "playerId": 214672,
+    "fullName": "Матеус Франса",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1
   },
   {
-    "playerId": 321528,
-    "fullName": "Denzel Dumfries",
-    "clubName": "Inter Milan",
-    "position": "D",
-    "league": "Serie A"
+    "playerId": 214671,
+    "fullName": "Марш",
+    "clubName": "Кристал Пэлас",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3
   },
   {
-    "playerId": 54906,
-    "fullName": "Matteo Darmian",
-    "clubName": "Inter Milan",
-    "position": "D",
-    "league": "Serie A"
+    "playerId": 216536,
+    "fullName": "Тиав",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.0
   },
   {
-    "playerId": 717900,
-    "fullName": "Tommaso Guercio",
-    "clubName": "Inter Milan",
-    "position": "D",
-    "league": "Serie A"
+    "playerId": 216211,
+    "fullName": "Лукаку",
+    "clubName": "Наполи",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 11.0,
+    "popularity": 10.5
   },
   {
-    "playerId": 126414,
-    "fullName": "Hakan Çalhanoğlu",
-    "clubName": "Inter Milan",
-    "position": "M",
-    "league": "Serie A"
+    "playerId": 216212,
+    "fullName": "Мактоминей",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 11.0,
+    "popularity": 9.1
   },
   {
-    "playerId": 543771,
-    "fullName": "Kristjan Asllani",
-    "clubName": "Inter Milan",
-    "position": "M",
-    "league": "Serie A"
+    "playerId": 215982,
+    "fullName": "Мартинес",
+    "clubName": "Интер",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 10.5,
+    "popularity": 10.5
   },
   {
-    "playerId": 569384,
-    "fullName": "Lucien Agoumé",
-    "clubName": "Inter Milan",
-    "position": "M",
-    "league": "Serie A"
+    "playerId": 216183,
+    "fullName": "Пулишич",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 10.5,
+    "popularity": 10.5
   },
   {
-    "playerId": 780136,
-    "fullName": "Aleksandar Stanković",
-    "clubName": "Inter Milan",
-    "position": "M",
-    "league": "Serie A"
+    "playerId": 215852,
+    "fullName": "Лукман",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 10.0,
+    "popularity": 4.9
   },
   {
-    "playerId": 255942,
-    "fullName": "Nicolò Barella",
-    "clubName": "Inter Milan",
-    "position": "M",
-    "league": "Serie A"
+    "playerId": 216469,
+    "fullName": "Кин",
+    "clubName": "Фиорентина",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 10.0,
+    "popularity": 3.5
   },
   {
-    "playerId": 394300,
-    "fullName": "Davide Frattesi",
-    "clubName": "Inter Milan",
-    "position": "M",
-    "league": "Serie A"
+    "playerId": 215981,
+    "fullName": "Маркус Тюрам",
+    "clubName": "Интер",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 9.5,
+    "popularity": 9.8
   },
   {
-    "playerId": 55735,
-    "fullName": "Henrikh Mkhitaryan",
-    "clubName": "Inter Milan",
-    "position": "M",
-    "league": "Serie A"
+    "playerId": 216210,
+    "fullName": "де Брюйне",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 9.5,
+    "popularity": 13.3
   },
   {
-    "playerId": 182932,
-    "fullName": "Davy Klaassen",
-    "clubName": "Inter Milan",
-    "position": "M",
-    "league": "Serie A"
+    "playerId": 216504,
+    "fullName": "Дэвид",
+    "clubName": "Ювентус",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 9.0,
+    "popularity": 8.4
+  },
+  {
+    "playerId": 216182,
+    "fullName": "Рафаэл Леау",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 9.0,
+    "popularity": 6.3
+  },
+  {
+    "playerId": 215882,
+    "fullName": "Орсолини",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 9.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216331,
+    "fullName": "Дибала",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 9.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216502,
+    "fullName": "Влахович",
+    "clubName": "Ювентус",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 8.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216126,
+    "fullName": "Дзакканьи",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215850,
+    "fullName": "де Кетеларе",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.5,
+    "popularity": 7.7
+  },
+  {
+    "playerId": 215851,
+    "fullName": "Скамакка",
+    "clubName": "Аталанта",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 8.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216503,
+    "fullName": "Йылдыз",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.5,
+    "popularity": 11.2
+  },
+  {
+    "playerId": 216127,
+    "fullName": "Кастельянос",
+    "clubName": "Лацио",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 8.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215980,
+    "fullName": "Чалханоглу",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216208,
+    "fullName": "Ланг",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215979,
+    "fullName": "Барелла",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216052,
+    "fullName": "Нико Пас",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 5.6
+  },
+  {
+    "playerId": 216181,
+    "fullName": "Сантьяго Хименес",
+    "clubName": "Милан",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 4.9
+  },
+  {
+    "playerId": 215881,
+    "fullName": "Иммобиле",
+    "clubName": "Болонья",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 4.9
+  },
+  {
+    "playerId": 216209,
+    "fullName": "Политано",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216329,
+    "fullName": "Довбик",
+    "clubName": "Рома",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216330,
+    "fullName": "Соуле",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216401,
+    "fullName": "Сапата",
+    "clubName": "Торино",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215978,
+    "fullName": "Мхитарян",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216125,
+    "fullName": "Педро",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216159,
+    "fullName": "Крстович",
+    "clubName": "Лечче",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 4.9
+  },
+  {
+    "playerId": 216206,
+    "fullName": "Замбо-Ангисса",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216124,
+    "fullName": "Диа",
+    "clubName": "Лацио",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216364,
+    "fullName": "Берарди",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216400,
+    "fullName": "Влашич",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215848,
+    "fullName": "де Рон",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215849,
+    "fullName": "Эдерсон",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216365,
+    "fullName": "Лорьянте",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216180,
+    "fullName": "Салемакерс",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216500,
+    "fullName": "Копмейнерс",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216123,
+    "fullName": "Гендузи",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216207,
+    "fullName": "Лукка",
+    "clubName": "Наполи",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216399,
+    "fullName": "Адамс",
+    "clubName": "Торино",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216051,
+    "fullName": "Мората",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216050,
+    "fullName": "Ассане Диао",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216501,
+    "fullName": "Франсишку Консейсау",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 216122,
+    "fullName": "Нослин",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216010,
+    "fullName": "Пикколи",
+    "clubName": "Кальяри",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215947,
+    "fullName": "Френдруп",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215977,
+    "fullName": "Фраттези",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216328,
+    "fullName": "Эль-Шаарави",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215846,
+    "fullName": "Мальдини",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215847,
+    "fullName": "Пашалич",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216204,
+    "fullName": "Лоботка",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215976,
+    "fullName": "Тареми",
+    "clubName": "Интер",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215975,
+    "fullName": "Луис Энрике",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216363,
+    "fullName": "Пинамонти",
+    "clubName": "Сассуоло",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216468,
+    "fullName": "Джеко",
+    "clubName": "Фиорентина",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216497,
+    "fullName": "Николас Гонсалес",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216498,
+    "fullName": "Локателли",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216499,
+    "fullName": "Кефрен Тюрам",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215880,
+    "fullName": "Кастро",
+    "clubName": "Болонья",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216205,
+    "fullName": "Нерес",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216327,
+    "fullName": "Кристанте",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216177,
+    "fullName": "Модрич",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216178,
+    "fullName": "Окафор",
+    "clubName": "Милан",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216467,
+    "fullName": "Гудмундссон",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 4.9
   },
   {
     "playerId": 216179,
-    "fullName": "Stefano Sensi",
-    "clubName": "Inter Milan",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 969192,
-    "fullName": "Ebenezer Akinsanmiro",
-    "clubName": "Inter Milan",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 885623,
-    "fullName": "Issiaka Kamate",
-    "clubName": "Inter Milan",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 91970,
-    "fullName": "Juan Cuadrado",
-    "clubName": "Inter Milan",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 638793,
-    "fullName": "Tajon Buchanan",
-    "clubName": "Inter Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 227081,
-    "fullName": "Joaquín Correa",
-    "clubName": "Inter Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 406625,
-    "fullName": "Lautaro Martínez",
-    "clubName": "Inter Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 318528,
-    "fullName": "Marcus Thuram",
-    "clubName": "Inter Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 41384,
-    "fullName": "Marko Arnautovic",
-    "clubName": "Inter Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 40433,
-    "fullName": "Alexis Sánchez",
-    "clubName": "Inter Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 723771,
-    "fullName": "Amadou Sarr",
-    "clubName": "Inter Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 182906,
-    "fullName": "Mike Maignan",
-    "clubName": "AC Milan",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 199976,
-    "fullName": "Marco Sportiello",
-    "clubName": "AC Milan",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 986180,
-    "fullName": "Noah Raveyre",
-    "clubName": "AC Milan",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 815563,
-    "fullName": "Lapo Nava",
-    "clubName": "AC Milan",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 22141,
-    "fullName": "Antonio Mirante",
-    "clubName": "AC Milan",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 815550,
-    "fullName": "Andrea Bartoccioni",
-    "clubName": "AC Milan",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 939745,
-    "fullName": "Lorenzo Torriani",
-    "clubName": "AC Milan",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 303254,
-    "fullName": "Fikayo Tomori",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 521964,
-    "fullName": "Malick Thiaw",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 585949,
-    "fullName": "Pierre Kalulu",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 323167,
-    "fullName": "Matteo Gabbia",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 800948,
-    "fullName": "Jan-Carlo Simić",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 776303,
-    "fullName": "Marco Pellegrino",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 48859,
-    "fullName": "Simon Kjaer",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 197470,
-    "fullName": "Mattia Caldara",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 910175,
-    "fullName": "Clinton Nsiala",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 339808,
-    "fullName": "Theo Hernández",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 887638,
-    "fullName": "Davide Bartesaghi",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 262523,
-    "fullName": "Davide Calabria",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 631007,
-    "fullName": "Filippo Terracciano",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 741257,
-    "fullName": "Álex Jiménez",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 130365,
-    "fullName": "Alessandro Florenzi",
-    "clubName": "AC Milan",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 351816,
-    "fullName": "Ismaël Bennacer",
-    "clubName": "AC Milan",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 395236,
-    "fullName": "Yacine Adli",
-    "clubName": "AC Milan",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 259953,
-    "fullName": "Rade Krunic",
-    "clubName": "AC Milan",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 935508,
-    "fullName": "Victor Eletu",
-    "clubName": "AC Milan",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 460939,
-    "fullName": "Tijjani Reijnders",
-    "clubName": "AC Milan",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 202886,
-    "fullName": "Ruben Loftus-Cheek",
-    "clubName": "AC Milan",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 503991,
-    "fullName": "Yunus Musah",
-    "clubName": "AC Milan",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 392538,
-    "fullName": "Tommaso Pobega",
-    "clubName": "AC Milan",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 883349,
-    "fullName": "Kevin Zeroli",
-    "clubName": "AC Milan",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 357164,
-    "fullName": "Rafael Leão",
-    "clubName": "AC Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 346890,
-    "fullName": "Noah Okafor",
-    "clubName": "AC Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 700998,
-    "fullName": "Chaka Traorè",
-    "clubName": "AC Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 999402,
-    "fullName": "Diego Sia",
-    "clubName": "AC Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 315779,
-    "fullName": "Christian Pulisic",
-    "clubName": "AC Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 401922,
-    "fullName": "Samuel Chukwueze",
-    "clubName": "AC Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 769063,
-    "fullName": "Luka Romero",
-    "clubName": "AC Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1058368,
-    "fullName": "Francesco Camarda",
-    "clubName": "AC Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 257462,
-    "fullName": "Luka Jović",
-    "clubName": "AC Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 487843,
-    "fullName": "Lorenzo Colombo",
-    "clubName": "AC Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 82442,
-    "fullName": "Olivier Giroud",
-    "clubName": "AC Milan",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 240414,
-    "fullName": "Alex Meret",
-    "clubName": "SSC Napoli",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 244192,
-    "fullName": "Pierluigi Gollini",
-    "clubName": "SSC Napoli",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 250683,
-    "fullName": "Nikita Contini",
-    "clubName": "SSC Napoli",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 555557,
-    "fullName": "Hubert Idasiak",
-    "clubName": "SSC Napoli",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 257732,
-    "fullName": "Amir Rrahmani",
-    "clubName": "SSC Napoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 735568,
-    "fullName": "Natan",
-    "clubName": "SSC Napoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 367284,
-    "fullName": "Leo Ostigard",
-    "clubName": "SSC Napoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 121985,
-    "fullName": "Juan Jesus",
-    "clubName": "SSC Napoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 885235,
-    "fullName": "Luigi D'Avino",
-    "clubName": "SSC Napoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 376514,
-    "fullName": "Mathías Olivera",
-    "clubName": "SSC Napoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 87884,
-    "fullName": "Mário Rui",
-    "clubName": "SSC Napoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 169880,
-    "fullName": "Giovanni Di Lorenzo",
-    "clubName": "SSC Napoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 397225,
-    "fullName": "Alessandro Zanoli",
-    "clubName": "SSC Napoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 250153,
-    "fullName": "Pasquale Mazzocchi",
-    "clubName": "SSC Napoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 192735,
-    "fullName": "Stanislav Lobotka",
-    "clubName": "SSC Napoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 468066,
-    "fullName": "Jens Cajuste",
-    "clubName": "SSC Napoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 168157,
-    "fullName": "Leander Dendoncker",
-    "clubName": "SSC Napoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 82070,
-    "fullName": "Diego Demme",
-    "clubName": "SSC Napoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 815546,
-    "fullName": "Francesco Gioielli",
-    "clubName": "SSC Napoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 885236,
-    "fullName": "Lorenzo Russo",
-    "clubName": "SSC Napoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 354361,
-    "fullName": "Frank Anguissa",
-    "clubName": "SSC Napoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 181136,
-    "fullName": "Piotr Zieliński",
-    "clubName": "SSC Napoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 612065,
-    "fullName": "Karim Zedadka",
-    "clubName": "SSC Napoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 391065,
-    "fullName": "Hamed Traoré",
-    "clubName": "SSC Napoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 358008,
-    "fullName": "Gianluca Gaetano",
-    "clubName": "SSC Napoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 502670,
-    "fullName": "Khvicha Kvaratskhelia",
-    "clubName": "SSC Napoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 400489,
-    "fullName": "Eljif Elmas",
-    "clubName": "SSC Napoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 316889,
-    "fullName": "Hirving Lozano",
-    "clubName": "SSC Napoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 433584,
-    "fullName": "Alessio Zerbin",
-    "clubName": "SSC Napoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 513245,
-    "fullName": "Jesper Lindstrøm",
-    "clubName": "SSC Napoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 165895,
-    "fullName": "Matteo Politano",
-    "clubName": "SSC Napoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 358032,
-    "fullName": "Cyril Ngonge",
-    "clubName": "SSC Napoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 405885,
-    "fullName": "Giacomo Raspadori",
-    "clubName": "SSC Napoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 401923,
-    "fullName": "Victor Osimhen",
-    "clubName": "SSC Napoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 282388,
-    "fullName": "Giovanni Simeone",
-    "clubName": "SSC Napoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 44058,
-    "fullName": "Wojciech Szczesny",
-    "clubName": "Juventus FC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 110923,
-    "fullName": "Mattia Perin",
-    "clubName": "Juventus FC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 814473,
-    "fullName": "Giovanni Daffara",
-    "clubName": "Juventus FC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 75411,
-    "fullName": "Carlo Pinsoglio",
-    "clubName": "Juventus FC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 564792,
-    "fullName": "Giovanni Garofani",
-    "clubName": "Juventus FC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 504825,
-    "fullName": "Gian Marco Crespi",
-    "clubName": "Juventus FC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 650989,
-    "fullName": "Simone Scaglia",
-    "clubName": "Juventus FC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 516716,
-    "fullName": "Bremer",
-    "clubName": "Juventus FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 509022,
-    "fullName": "Federico Gatti",
-    "clubName": "Juventus FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 420465,
-    "fullName": "Tiago Djaló",
-    "clubName": "Juventus FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 145707,
-    "fullName": "Danilo",
-    "clubName": "Juventus FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 890290,
-    "fullName": "Dean Huijsen",
-    "clubName": "Juventus FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 162959,
-    "fullName": "Daniele Rugani",
-    "clubName": "Juventus FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 679423,
-    "fullName": "Tarik Muharemović",
-    "clubName": "Juventus FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 459658,
-    "fullName": "Andrea Cambiaso",
-    "clubName": "Juventus FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 79960,
-    "fullName": "Alex Sandro",
-    "clubName": "Juventus FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 88682,
-    "fullName": "Mattia De Sciglio",
-    "clubName": "Juventus FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 265088,
-    "fullName": "Manuel Locatelli",
-    "clubName": "Juventus FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 182913,
-    "fullName": "Adrien Rabiot",
-    "clubName": "Juventus FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 332697,
-    "fullName": "Weston McKennie",
-    "clubName": "Juventus FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 571607,
-    "fullName": "Fabio Miretti",
-    "clubName": "Juventus FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 432090,
-    "fullName": "Nicolò Fagioli",
-    "clubName": "Juventus FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 748319,
-    "fullName": "Carlos Alcaraz",
-    "clubName": "Juventus FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 430280,
-    "fullName": "Hans Nicolussi Caviglia",
-    "clubName": "Juventus FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 748807,
-    "fullName": "Joseph Nonge",
-    "clubName": "Juventus FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 724178,
-    "fullName": "Luis Hasa",
-    "clubName": "Juventus FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 122153,
-    "fullName": "Paul Pogba",
-    "clubName": "Juventus FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 161011,
-    "fullName": "Filip Kostić",
-    "clubName": "Juventus FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 542336,
-    "fullName": "Nikola Sekulov",
-    "clubName": "Juventus FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 845654,
-    "fullName": "Kenan Yıldız",
-    "clubName": "Juventus FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 581672,
-    "fullName": "Samuel Iling-Junior",
-    "clubName": "Juventus FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 341092,
-    "fullName": "Federico Chiesa",
-    "clubName": "Juventus FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 668951,
-    "fullName": "Matías Soulé",
-    "clubName": "Juventus FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 370846,
-    "fullName": "Timothy Weah",
-    "clubName": "Juventus FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 357498,
-    "fullName": "Dušan Vlahović",
-    "clubName": "Juventus FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 364135,
-    "fullName": "Moise Kean",
-    "clubName": "Juventus FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 191891,
-    "fullName": "Arkadiusz Milik",
-    "clubName": "Juventus FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 672830,
-    "fullName": "Leonardo Cerri",
-    "clubName": "Juventus FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 659416,
-    "fullName": "Tommaso Mancini",
-    "clubName": "Juventus FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 459763,
-    "fullName": "Marco Carnesecchi",
-    "clubName": "Atalanta BC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 242359,
-    "fullName": "Juan Musso",
-    "clubName": "Atalanta BC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 650256,
-    "fullName": "Paolo Vismara",
-    "clubName": "Atalanta BC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 126634,
-    "fullName": "Francesco Rossi",
-    "clubName": "Atalanta BC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 571604,
-    "fullName": "Giorgio Scalvini",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 503075,
-    "fullName": "Isak Hien",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 165513,
-    "fullName": "Berat Djimsiti",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 94005,
-    "fullName": "Sead Kolasinac",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 461833,
-    "fullName": "Caleb Okoli",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 72441,
-    "fullName": "Rafael Tolói",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 663900,
-    "fullName": "Giovanni Bonfanti",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 125020,
-    "fullName": "José Luis Palomino",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 567475,
-    "fullName": "Andrea Ceresoli",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 820620,
-    "fullName": "Tommaso Del Lungo",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 936753,
-    "fullName": "Pietro Comi",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 616631,
-    "fullName": "Matteo Ruggeri",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 361065,
-    "fullName": "Mitchel Bakker",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 496745,
-    "fullName": "Emil Holm",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 275303,
-    "fullName": "Hans Hateboer",
-    "clubName": "Atalanta BC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 133179,
-    "fullName": "Marten de Roon",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 938678,
-    "fullName": "Leonardo Mendicino",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 814015,
-    "fullName": "Matteo Colombo",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 607854,
-    "fullName": "Éderson",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 205938,
-    "fullName": "Mario Pasalić",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 564305,
-    "fullName": "Michel Adopo",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 936755,
-    "fullName": "Alberto Manzoni",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 173859,
-    "fullName": "Davide Zappacosta",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 392966,
-    "fullName": "Nadir Zortea",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 895937,
-    "fullName": "Marco Palestra",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 360518,
-    "fullName": "Teun Koopmeiners",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 435772,
-    "fullName": "Charles De Ketelaere",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 255450,
-    "fullName": "Aleksey Miranchuk",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 421768,
-    "fullName": "Alessandro Cortinovis",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1048145,
-    "fullName": "Andrea Bonanomi",
-    "clubName": "Atalanta BC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 406040,
-    "fullName": "Ademola Lookman",
-    "clubName": "Atalanta BC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 622031,
-    "fullName": "Tommaso De Nipoti",
-    "clubName": "Atalanta BC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 315867,
-    "fullName": "Gianluca Scamacca",
-    "clubName": "Atalanta BC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 649016,
-    "fullName": "El Bilal Touré",
-    "clubName": "Atalanta BC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 73794,
-    "fullName": "Duván Zapata",
-    "clubName": "Atalanta BC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 119228,
-    "fullName": "Luis Muriel",
-    "clubName": "Atalanta BC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 984708,
-    "fullName": "Siren Diao",
-    "clubName": "Atalanta BC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 988862,
-    "fullName": "Moustapha Cissé",
-    "clubName": "Atalanta BC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 80894,
-    "fullName": "Lukasz Skorupski",
-    "clubName": "Bologna FC 1909",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 390304,
-    "fullName": "Federico Ravaglia",
-    "clubName": "Bologna FC 1909",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 818892,
-    "fullName": "Nicola Bagnolini",
-    "clubName": "Bologna FC 1909",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 882995,
-    "fullName": "Tito Gasperini",
-    "clubName": "Bologna FC 1909",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 433984,
-    "fullName": "Sam Beukema",
-    "clubName": "Bologna FC 1909",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 413565,
-    "fullName": "Jhon Lucumí",
-    "clubName": "Bologna FC 1909",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 223974,
-    "fullName": "Stefan Posch",
-    "clubName": "Bologna FC 1909",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 845566,
-    "fullName": "Mihajlo Ilić",
-    "clubName": "Bologna FC 1909",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 126673,
-    "fullName": "Adama Soumaoro",
-    "clubName": "Bologna FC 1909",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 247377,
-    "fullName": "Kevin Bonifazi",
-    "clubName": "Bologna FC 1909",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 657742,
-    "fullName": "Joaquín Sosa",
-    "clubName": "Bologna FC 1909",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 818882,
-    "fullName": "Riccardo Stivanello",
-    "clubName": "Bologna FC 1909",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 502821,
-    "fullName": "Riccardo Calafiori",
-    "clubName": "Bologna FC 1909",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 564529,
-    "fullName": "Victor Kristiansen",
-    "clubName": "Bologna FC 1909",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 818880,
-    "fullName": "Tommaso Corazza",
-    "clubName": "Bologna FC 1909",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 136514,
-    "fullName": "Charalampos Lykogiannis",
-    "clubName": "Bologna FC 1909",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 33571,
-    "fullName": "Lorenzo De Silvestri",
-    "clubName": "Bologna FC 1909",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 347900,
-    "fullName": "Jerdy Schouten",
-    "clubName": "Bologna FC 1909",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 316934,
-    "fullName": "Nikola Moro",
-    "clubName": "Bologna FC 1909",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 531065,
-    "fullName": "Oussama El Azzouzi",
-    "clubName": "Bologna FC 1909",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 428563,
-    "fullName": "Lewis Ferguson",
-    "clubName": "Bologna FC 1909",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 497291,
-    "fullName": "Nicolás Domínguez",
-    "clubName": "Bologna FC 1909",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 237658,
-    "fullName": "Michel Aebischer",
-    "clubName": "Bologna FC 1909",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 699442,
-    "fullName": "Kacper Urbanski",
-    "clubName": "Bologna FC 1909",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 148252,
-    "fullName": "Remo Freuler",
-    "clubName": "Bologna FC 1909",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 679754,
-    "fullName": "Niklas Pyyhtiä",
-    "clubName": "Bologna FC 1909",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 633668,
-    "fullName": "Giovanni Fabbian",
-    "clubName": "Bologna FC 1909",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 345590,
-    "fullName": "Jens Odgaard",
-    "clubName": "Bologna FC 1909",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 367992,
-    "fullName": "Jesper Karlsson",
-    "clubName": "Bologna FC 1909",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 997909,
-    "fullName": "Tommaso Ravaglioli",
-    "clubName": "Bologna FC 1909",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 368482,
-    "fullName": "Riccardo Orsolini",
-    "clubName": "Bologna FC 1909",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 365108,
-    "fullName": "Dan Ndoye",
-    "clubName": "Bologna FC 1909",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 381950,
-    "fullName": "Alexis Saelemaekers",
-    "clubName": "Bologna FC 1909",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 435648,
-    "fullName": "Joshua Zirkzee",
-    "clubName": "Bologna FC 1909",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 849520,
-    "fullName": "Santiago Castro",
-    "clubName": "Bologna FC 1909",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 41384,
-    "fullName": "Marko Arnautovic",
-    "clubName": "Bologna FC 1909",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 439292,
-    "fullName": "Sydney van Hooijdonk",
-    "clubName": "Bologna FC 1909",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 338670,
-    "fullName": "Mile Svilar",
-    "clubName": "AS Roma",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 45026,
-    "fullName": "Rui Patrício",
-    "clubName": "AS Roma",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1041614,
-    "fullName": "Renato Marin",
-    "clubName": "AS Roma",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 581604,
-    "fullName": "Pietro Boer",
-    "clubName": "AS Roma",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 371149,
-    "fullName": "Evan Ndicka",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 256448,
-    "fullName": "Gianluca Mancini",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 890290,
-    "fullName": "Dean Huijsen",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 246291,
-    "fullName": "Diego Llorente",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 371371,
-    "fullName": "Marash Kumbulla",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 103427,
-    "fullName": "Chris Smalling",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 929871,
-    "fullName": "Matteo Plaia",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 991751,
-    "fullName": "Lovro Golic",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 277179,
-    "fullName": "Angeliño",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 118689,
-    "fullName": "Leonardo Spinazzola",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 709970,
-    "fullName": "Jan Oliveras",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 369684,
-    "fullName": "Rasmus Kristensen",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 251075,
-    "fullName": "Zeki Çelik",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 205006,
-    "fullName": "Rick Karsdorp",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 803005,
-    "fullName": "Mattia Mannini",
-    "clubName": "AS Roma",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 199248,
-    "fullName": "Bryan Cristante",
-    "clubName": "AS Roma",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 166237,
-    "fullName": "Leandro Paredes",
-    "clubName": "AS Roma",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 488297,
-    "fullName": "Martin Vetkal",
-    "clubName": "AS Roma",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 562049,
-    "fullName": "Edoardo Bove",
-    "clubName": "AS Roma",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 258027,
-    "fullName": "Renato Sanches",
-    "clubName": "AS Roma",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 813137,
-    "fullName": "Niccolò Pisilli",
-    "clubName": "AS Roma",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 659415,
-    "fullName": "Riccardo Pagano",
-    "clubName": "AS Roma",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 723614,
-    "fullName": "Francesco D'Alessio",
-    "clubName": "AS Roma",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 550108,
-    "fullName": "Nicola Zalewski",
-    "clubName": "AS Roma",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 286297,
-    "fullName": "Lorenzo Pellegrini",
-    "clubName": "AS Roma",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 641537,
-    "fullName": "Tommaso Baldanzi",
-    "clubName": "AS Roma",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 395693,
-    "fullName": "Houssem Aouar",
-    "clubName": "AS Roma",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 94529,
-    "fullName": "Stephan El Shaarawy",
-    "clubName": "AS Roma",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 721227,
-    "fullName": "Luigi Cherubini",
-    "clubName": "AS Roma",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 431811,
-    "fullName": "Ola Solbakken",
-    "clubName": "AS Roma",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 936536,
-    "fullName": "João Costa",
-    "clubName": "AS Roma",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 206050,
-    "fullName": "Paulo Dybala",
-    "clubName": "AS Roma",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 331726,
-    "fullName": "Tammy Abraham",
-    "clubName": "AS Roma",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 96341,
-    "fullName": "Romelu Lukaku",
-    "clubName": "AS Roma",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 180337,
-    "fullName": "Sardar Azmoun",
-    "clubName": "AS Roma",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 167727,
-    "fullName": "Andrea Belotti",
-    "clubName": "AS Roma",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 830243,
-    "fullName": "Filippo Alessio",
-    "clubName": "AS Roma",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 471936,
-    "fullName": "Oliver Christensen",
-    "clubName": "ACF Fiorentina",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 96254,
-    "fullName": "Pietro Terracciano",
-    "clubName": "ACF Fiorentina",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 934159,
-    "fullName": "Tommaso Martinelli",
-    "clubName": "ACF Fiorentina",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 988977,
-    "fullName": "Tommaso Vannucchi",
-    "clubName": "ACF Fiorentina",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 413507,
-    "fullName": "Nikola Milenković",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 373373,
-    "fullName": "Lucas Martínez Quarta",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 346561,
-    "fullName": "Luca Ranieri",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 289446,
-    "fullName": "Yerry Mina",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 487829,
-    "fullName": "Christian Dalle Mura",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 746712,
-    "fullName": "Pietro Comuzzo",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 650990,
-    "fullName": "Christian Biagetti",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 547985,
-    "fullName": "Fabiano Parisi",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 124555,
-    "fullName": "Cristiano Biraghi",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 984964,
-    "fullName": "Niccolò Fortini",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 823486,
-    "fullName": "Michael Kayode",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 401529,
-    "fullName": "Dodô",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 534084,
-    "fullName": "Niccolò Pierozzi",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 73926,
-    "fullName": "Davide Faraoni",
-    "clubName": "ACF Fiorentina",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 287579,
-    "fullName": "Sofyan Amrabat",
-    "clubName": "ACF Fiorentina",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 362842,
-    "fullName": "Arthur Melo",
-    "clubName": "ACF Fiorentina",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 308279,
-    "fullName": "Rolando Mandragora",
-    "clubName": "ACF Fiorentina",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 290862,
-    "fullName": "Maxime Lopez",
-    "clubName": "ACF Fiorentina",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 707450,
-    "fullName": "Lorenzo Amatucci",
-    "clubName": "ACF Fiorentina",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 303116,
-    "fullName": "Gaetano Castrovilli",
-    "clubName": "ACF Fiorentina",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 184894,
-    "fullName": "Alfred Duncan",
-    "clubName": "ACF Fiorentina",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 831162,
-    "fullName": "Gino Infantino",
-    "clubName": "ACF Fiorentina",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 628366,
-    "fullName": "Lucas Beltrán",
-    "clubName": "ACF Fiorentina",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 272261,
-    "fullName": "Antonín Barák",
-    "clubName": "ACF Fiorentina",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 57280,
-    "fullName": "Giacomo Bonaventura",
-    "clubName": "ACF Fiorentina",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 340394,
-    "fullName": "Abdelhamid Sabiri",
-    "clubName": "ACF Fiorentina",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 386455,
-    "fullName": "Riccardo Sottil",
-    "clubName": "ACF Fiorentina",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 293169,
-    "fullName": "Josip Brekalo",
-    "clubName": "ACF Fiorentina",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 996453,
-    "fullName": "Maat Daniel Caprini",
-    "clubName": "ACF Fiorentina",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 486031,
-    "fullName": "Nico González",
-    "clubName": "ACF Fiorentina",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 324690,
-    "fullName": "Jonathan Ikoné",
-    "clubName": "ACF Fiorentina",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 89086,
-    "fullName": "Aleksandr Kokorin",
-    "clubName": "ACF Fiorentina",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 337725,
-    "fullName": "Christian Kouamé",
-    "clubName": "ACF Fiorentina",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 257462,
-    "fullName": "Luka Jović",
-    "clubName": "ACF Fiorentina",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 354814,
-    "fullName": "M'Bala Nzola",
-    "clubName": "ACF Fiorentina",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 167727,
-    "fullName": "Andrea Belotti",
-    "clubName": "ACF Fiorentina",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 707456,
-    "fullName": "Fallou Sene",
-    "clubName": "ACF Fiorentina",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 257474,
-    "fullName": "Vanja Milinković-Savić",
-    "clubName": "Torino FC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 623412,
-    "fullName": "Mihai Popa",
-    "clubName": "Torino FC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 463792,
-    "fullName": "Luca Gemello",
-    "clubName": "Torino FC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 617164,
-    "fullName": "Pietro Passador",
-    "clubName": "Torino FC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 914880,
-    "fullName": "Matteo Brezzo",
-    "clubName": "Torino FC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 386446,
-    "fullName": "Alessandro Buongiorno",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 648779,
-    "fullName": "Wilfried Singo",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 418543,
-    "fullName": "Perr Schuurs",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 459655,
-    "fullName": "Matteo Lovato",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 544149,
-    "fullName": "David Zima",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 655456,
-    "fullName": "Saba Sazonov",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 183031,
-    "fullName": "Koffi Djidji",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 286949,
-    "fullName": "Adam Masina",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 704825,
-    "fullName": "Alessandro Dellavalle",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 804799,
-    "fullName": "Ange N'Guessan",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 86784,
-    "fullName": "Ricardo Rodríguez",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 810086,
-    "fullName": "Vimoj Muntu Wa Mungu",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 815483,
-    "fullName": "Jacopo Antolini",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 336125,
-    "fullName": "Mërgim Vojvoda",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1059298,
-    "fullName": "Côme Bianay Balcot",
-    "clubName": "Torino FC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 467992,
-    "fullName": "Samuele Ricci",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 157507,
-    "fullName": "Adrien Tamèze",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 470794,
-    "fullName": "Ivan Ilić",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 225873,
-    "fullName": "Karol Linetty",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 743091,
-    "fullName": "Emirhan İlkhan",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 798929,
-    "fullName": "Gvidas Gineitis",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 724108,
-    "fullName": "Aaron Ciammaglichella",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 357992,
-    "fullName": "Raoul Bellanova",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 186368,
-    "fullName": "Valentino Lazaro",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 546880,
-    "fullName": "Brandon Soppy",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 715470,
-    "fullName": "Brian Bayeye",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1004344,
-    "fullName": "Ali Dembélé",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 293200,
-    "fullName": "Nikola Vlašić",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 130360,
-    "fullName": "Simone Verdi",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1074917,
-    "fullName": "Jonathan Silva",
-    "clubName": "Torino FC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 245078,
-    "fullName": "Nemanja Radonjić",
-    "clubName": "Torino FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 324804,
-    "fullName": "Yann Karamoh",
-    "clubName": "Torino FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 934527,
-    "fullName": "Alieu Njie",
-    "clubName": "Torino FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 551752,
-    "fullName": "Demba Seck",
-    "clubName": "Torino FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 928900,
-    "fullName": "Zanos Savva",
-    "clubName": "Torino FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 710968,
-    "fullName": "Uros Kabic",
-    "clubName": "Torino FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 73794,
-    "fullName": "Duván Zapata",
-    "clubName": "Torino FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 234523,
-    "fullName": "Antonio Sanabria",
-    "clubName": "Torino FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 364133,
-    "fullName": "Pietro Pellegri",
-    "clubName": "Torino FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 413605,
-    "fullName": "David Okereke",
-    "clubName": "Torino FC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 197929,
-    "fullName": "Ivan Provedel",
-    "clubName": "SS Lazio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 481675,
-    "fullName": "Christos Mandas",
-    "clubName": "SS Lazio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 99254,
-    "fullName": "Luigi Sepe",
-    "clubName": "SS Lazio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 818898,
-    "fullName": "Federico Magro",
-    "clubName": "SS Lazio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 300137,
-    "fullName": "Marius Adamonis",
-    "clubName": "SS Lazio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 538079,
-    "fullName": "Alessio Furlanetto",
-    "clubName": "SS Lazio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 918957,
-    "fullName": "Davide Renzetti",
-    "clubName": "SS Lazio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 197747,
-    "fullName": "Alessio Romagnoli",
-    "clubName": "SS Lazio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 389837,
-    "fullName": "Nicolò Casale",
-    "clubName": "SS Lazio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 618341,
-    "fullName": "Mario Gila",
-    "clubName": "SS Lazio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 126729,
-    "fullName": "Patric",
-    "clubName": "SS Lazio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 748720,
-    "fullName": "Fabio Andrea Ruggeri",
-    "clubName": "SS Lazio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 883055,
-    "fullName": "Matteo Duțu",
-    "clubName": "SS Lazio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 346567,
-    "fullName": "Luca Pellegrini",
-    "clubName": "SS Lazio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 465565,
-    "fullName": "Dimitrije Kamenovic",
-    "clubName": "SS Lazio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 239802,
-    "fullName": "Adam Marusic",
-    "clubName": "SS Lazio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 200056,
-    "fullName": "Elseid Hysaj",
-    "clubName": "SS Lazio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 525704,
-    "fullName": "Nicolò Rovella",
-    "clubName": "SS Lazio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 199733,
-    "fullName": "Danilo Cataldi",
-    "clubName": "SS Lazio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 465830,
-    "fullName": "Mattéo Guendouzi",
-    "clubName": "SS Lazio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 334835,
-    "fullName": "Toma Bašić",
-    "clubName": "SS Lazio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 143812,
-    "fullName": "Matías Vecino",
-    "clubName": "SS Lazio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 867545,
-    "fullName": "Larsson Coulibaly",
-    "clubName": "SS Lazio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 331401,
-    "fullName": "Manuel Lazzari",
-    "clubName": "SS Lazio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 356141,
-    "fullName": "Daichi Kamada",
-    "clubName": "SS Lazio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 128220,
-    "fullName": "Luis Alberto",
-    "clubName": "SS Lazio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 601577,
-    "fullName": "André Anderson",
-    "clubName": "SS Lazio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 745446,
-    "fullName": "Luca Napolitano",
-    "clubName": "SS Lazio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 283735,
-    "fullName": "Mattia Zaccagni",
-    "clubName": "SS Lazio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1026255,
-    "fullName": "Saná Fernandes",
-    "clubName": "SS Lazio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 462823,
-    "fullName": "Gustav Isaksen",
-    "clubName": "SS Lazio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 159372,
-    "fullName": "Felipe Anderson",
-    "clubName": "SS Lazio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 65278,
-    "fullName": "Pedro",
-    "clubName": "SS Lazio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 873981,
-    "fullName": "Diego González",
-    "clubName": "SS Lazio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 240349,
-    "fullName": "Cristiano Lombardi",
-    "clubName": "SS Lazio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 522784,
-    "fullName": "Taty Castellanos",
-    "clubName": "SS Lazio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 105521,
-    "fullName": "Ciro Immobile",
-    "clubName": "SS Lazio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 388516,
-    "fullName": "Josep Martínez",
-    "clubName": "Genoa CFC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 136111,
-    "fullName": "Nicola Leali",
-    "clubName": "Genoa CFC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 462699,
-    "fullName": "Franz Stolz",
-    "clubName": "Genoa CFC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 818929,
-    "fullName": "Simone Calvani",
-    "clubName": "Genoa CFC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 312773,
-    "fullName": "Daniele Sommariva",
-    "clubName": "Genoa CFC",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 568559,
-    "fullName": "Radu Drăgușin",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 490384,
-    "fullName": "Koni De Winter",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 532937,
-    "fullName": "Johan Vásquez",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 861981,
-    "fullName": "Alan Matturro",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 176139,
-    "fullName": "Mattia Bani",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 616628,
-    "fullName": "Giorgio Cittadini",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 330208,
-    "fullName": "Alessandro Vogliacco",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 199927,
-    "fullName": "Davide Biraschi",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 684317,
-    "fullName": "Faroukou Cissé",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 934863,
-    "fullName": "Tommaso Pittino",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 483348,
-    "fullName": "Djed Spence",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 251878,
-    "fullName": "Aarón Martín",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 228444,
-    "fullName": "Ridgeciano Haps",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 237666,
-    "fullName": "Silvan Hefti",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 167491,
-    "fullName": "Stefano Sabelli",
-    "clubName": "Genoa CFC",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 406806,
-    "fullName": "Emil Bohinen",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 242813,
-    "fullName": "Filip Jagiello",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 40633,
-    "fullName": "Milan Badelj",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 503871,
-    "fullName": "Morten Frendrup",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 469787,
-    "fullName": "Berkan Kutlu",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 226524,
-    "fullName": "Morten Thorsby",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 313830,
-    "fullName": "Pablo Galdames",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 315862,
-    "fullName": "Filippo Melegoni",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 68864,
-    "fullName": "Kevin Strootman",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 723485,
-    "fullName": "Léandre Kuavita",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 934876,
-    "fullName": "Riccardo Arboscello",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 207877,
-    "fullName": "Ruslan Malinovskyi",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 200188,
-    "fullName": "Mattia Aramu",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 940135,
-    "fullName": "Christos Papadopoulos",
-    "clubName": "Genoa CFC",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 449151,
-    "fullName": "Junior Messias",
-    "clubName": "Genoa CFC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 866250,
-    "fullName": "Seydou Fini",
-    "clubName": "Genoa CFC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 305947,
-    "fullName": "Albert Gudmundsson",
-    "clubName": "Genoa CFC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 554903,
-    "fullName": "Mateo Retegui",
-    "clubName": "Genoa CFC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 586853,
-    "fullName": "Vitinha",
-    "clubName": "Genoa CFC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 881610,
-    "fullName": "David Ankeye",
-    "clubName": "Genoa CFC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 199953,
-    "fullName": "Caleb Ekuban",
-    "clubName": "Genoa CFC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 208690,
-    "fullName": "George Pușcaș",
-    "clubName": "Genoa CFC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 33763,
-    "fullName": "Massimo Coda",
-    "clubName": "Genoa CFC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 818906,
-    "fullName": "Yoan Bornosuzov",
-    "clubName": "Genoa CFC",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 340353,
-    "fullName": "Maduka Okoye",
-    "clubName": "Udinese Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 85528,
-    "fullName": "Marco Silvestri",
-    "clubName": "Udinese Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 27807,
-    "fullName": "Daniele Padelli",
-    "clubName": "Udinese Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 936595,
-    "fullName": "Federico Mosca",
-    "clubName": "Udinese Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 612059,
-    "fullName": "Edoardo Piana",
-    "clubName": "Udinese Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1060935,
-    "fullName": "Joel Malusà",
-    "clubName": "Udinese Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 491693,
-    "fullName": "Nehuén Pérez",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 371851,
-    "fullName": "Jaka Bijol",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 698259,
-    "fullName": "Thomas Kristensen",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 342877,
-    "fullName": "Enzo Ebosse",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 225963,
-    "fullName": "Lautaro Giannetti",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 286949,
-    "fullName": "Adam Masina",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1058354,
-    "fullName": "Matteo Palma",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 81512,
-    "fullName": "Christian Kabasele",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 797791,
-    "fullName": "Antonio Tikvic",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 925584,
-    "fullName": "Axel Guessand",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 648032,
-    "fullName": "James Abankwah",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 896424,
-    "fullName": "Samuel John Nwachukwu",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 633530,
-    "fullName": "Jordan Zemura",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 290017,
-    "fullName": "Hassane Kamara",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 586756,
-    "fullName": "Festy Ebosele",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 272812,
-    "fullName": "Kingsley Ehizibue",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 481623,
-    "fullName": "João Ferreira",
-    "clubName": "Udinese Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 323954,
-    "fullName": "Walace",
-    "clubName": "Udinese Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 854325,
-    "fullName": "Étienne Camara",
-    "clubName": "Udinese Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 268429,
-    "fullName": "Sandi Lovrić",
-    "clubName": "Udinese Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 555820,
-    "fullName": "Martín Payero",
-    "clubName": "Udinese Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 524010,
-    "fullName": "Oier Zarraga",
-    "clubName": "Udinese Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 112302,
-    "fullName": "Roberto Pereyra",
-    "clubName": "Udinese Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 391719,
-    "fullName": "Domingos Quina",
-    "clubName": "Udinese Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 465279,
-    "fullName": "Marco Ballarini",
-    "clubName": "Udinese Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 942099,
-    "fullName": "Bor Zunec",
-    "clubName": "Udinese Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 528833,
-    "fullName": "Lazar Samardžić",
-    "clubName": "Udinese Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 876400,
-    "fullName": "Simone Pafundi",
-    "clubName": "Udinese Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1009633,
-    "fullName": "David Pejičić",
-    "clubName": "Udinese Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 682032,
-    "fullName": "Marley Aké",
-    "clubName": "Udinese Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 184892,
-    "fullName": "Florian Thauvin",
-    "clubName": "Udinese Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 595809,
-    "fullName": "Beto",
-    "clubName": "Udinese Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 572265,
-    "fullName": "Lorenzo Lucca",
-    "clubName": "Udinese Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 412366,
-    "fullName": "Brenner",
-    "clubName": "Udinese Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 412660,
-    "fullName": "Keinan Davis",
-    "clubName": "Udinese Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 295331,
-    "fullName": "Isaac Success",
-    "clubName": "Udinese Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 129476,
-    "fullName": "Gerard Deulofeu",
-    "clubName": "Udinese Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1014243,
-    "fullName": "Vivaldo Semedo",
-    "clubName": "Udinese Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 654949,
-    "fullName": "Sekou Diawara",
-    "clubName": "Udinese Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 301238,
-    "fullName": "Michele Di Gregorio",
-    "clubName": "AC Monza",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 542588,
-    "fullName": "Alessandro Sorrentino",
-    "clubName": "AC Monza",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 244491,
-    "fullName": "Stefano Gori",
-    "clubName": "AC Monza",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 85240,
-    "fullName": "Eugenio Lamanna",
-    "clubName": "AC Monza",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 815567,
-    "fullName": "Andrea Mazza",
-    "clubName": "AC Monza",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 481834,
-    "fullName": "Andrea Carboni",
-    "clubName": "AC Monza",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 210178,
-    "fullName": "Pablo Marí",
-    "clubName": "AC Monza",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 32113,
-    "fullName": "Armando Izzo",
-    "clubName": "AC Monza",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 616628,
-    "fullName": "Giorgio Cittadini",
-    "clubName": "AC Monza",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 88680,
-    "fullName": "Luca Caldirola",
-    "clubName": "AC Monza",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 357995,
-    "fullName": "Davide Bettella",
-    "clubName": "AC Monza",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 55769,
-    "fullName": "Danilo D'Ambrosio",
-    "clubName": "AC Monza",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 311178,
-    "fullName": "Georgios Kyriakopoulos",
-    "clubName": "AC Monza",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 731491,
-    "fullName": "Franco Carboni",
-    "clubName": "AC Monza",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 461019,
-    "fullName": "Samuele Birindelli",
-    "clubName": "AC Monza",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 314965,
-    "fullName": "Pedro Pereira",
-    "clubName": "AC Monza",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 88684,
-    "fullName": "Giulio Donati",
-    "clubName": "AC Monza",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 891869,
-    "fullName": "Leonardo Colombo",
-    "clubName": "AC Monza",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 332179,
-    "fullName": "Matteo Pessina",
-    "clubName": "AC Monza",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 659516,
-    "fullName": "Warren Bondo",
-    "clubName": "AC Monza",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 197471,
-    "fullName": "Roberto Gagliardini",
-    "clubName": "AC Monza",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 355104,
-    "fullName": "Pepín Machín",
-    "clubName": "AC Monza",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 170481,
-    "fullName": "Jean-Daniel Akpa Akpro",
-    "clubName": "AC Monza",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 898356,
-    "fullName": "Alessandro Berretta",
-    "clubName": "AC Monza",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 255838,
-    "fullName": "Patrick Ciurria",
-    "clubName": "AC Monza",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 392959,
-    "fullName": "Andrea Colpani",
-    "clubName": "AC Monza",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 787618,
-    "fullName": "Valentín Carboni",
-    "clubName": "AC Monza",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 539134,
-    "fullName": "Daniel Maldini",
-    "clubName": "AC Monza",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 650966,
-    "fullName": "Samuele Vignato",
-    "clubName": "AC Monza",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1012421,
-    "fullName": "Matija Popović",
-    "clubName": "AC Monza",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 433584,
-    "fullName": "Alessio Zerbin",
-    "clubName": "AC Monza",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 708079,
-    "fullName": "Andrea Ferraris",
-    "clubName": "AC Monza",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 20005,
-    "fullName": "Papu Gómez",
-    "clubName": "AC Monza",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 347253,
-    "fullName": "Dany Mota",
-    "clubName": "AC Monza",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 146752,
-    "fullName": "Gianluca Caprari",
-    "clubName": "AC Monza",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 487843,
-    "fullName": "Lorenzo Colombo",
-    "clubName": "AC Monza",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 199258,
-    "fullName": "Andrea Petagna",
-    "clubName": "AC Monza",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 67556,
-    "fullName": "Milan Djuric",
-    "clubName": "AC Monza",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 215649,
-    "fullName": "Mirko Marić",
-    "clubName": "AC Monza",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 241923,
-    "fullName": "Lorenzo Montipò",
-    "clubName": "Hellas Verona",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 240675,
-    "fullName": "Simone Perilli",
-    "clubName": "Hellas Verona",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 709986,
-    "fullName": "Giacomo Toniolo",
-    "clubName": "Hellas Verona",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 535881,
-    "fullName": "Mattia Chiesa",
-    "clubName": "Hellas Verona",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 127217,
-    "fullName": "Alessandro Berardi",
-    "clubName": "Hellas Verona",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 503075,
-    "fullName": "Isak Hien",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 660860,
-    "fullName": "Diego Coppola",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 644676,
-    "fullName": "Bruno Amione",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 310458,
-    "fullName": "Giangiacomo Magnani",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 248732,
-    "fullName": "Paweł Dawidowicz",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 163639,
-    "fullName": "Federico Ceccherini",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 115763,
-    "fullName": "Koray Günter",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 936183,
-    "fullName": "Christian Corradi",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 815529,
-    "fullName": "Nicolò Calabrese",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 567129,
-    "fullName": "Josh Doig",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 686965,
-    "fullName": "Juan Cabal",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 357158,
-    "fullName": "Rúben Vinagre",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 631007,
-    "fullName": "Filippo Terracciano",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 384859,
-    "fullName": "Fabien Centonze",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 848509,
-    "fullName": "Jackson Tchatchoua",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 73926,
-    "fullName": "Davide Faraoni",
-    "clubName": "Hellas Verona",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 398808,
-    "fullName": "Martin Hongla",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 372445,
-    "fullName": "Dani Silva",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 982855,
-    "fullName": "Reda Belahyane",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1082519,
-    "fullName": "Charlys",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 776737,
-    "fullName": "Joselito",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 377042,
-    "fullName": "Michael Folorunsho",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 261905,
-    "fullName": "Suat Serdar",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 232418,
-    "fullName": "Ondrej Duda",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 815539,
-    "fullName": "Nicola Patanè",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 70411,
-    "fullName": "Darko Lazović",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 540333,
-    "fullName": "Tomas Suslov",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 964087,
-    "fullName": "Alphadjo Cissè",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 88909,
-    "fullName": "Riccardo Saponara",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 265625,
-    "fullName": "Ajdin Hrustić",
-    "clubName": "Hellas Verona",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 726526,
-    "fullName": "Stefan Mitrović",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 470391,
-    "fullName": "Jayden Braaf",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 358032,
-    "fullName": "Cyril Ngonge",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 457736,
-    "fullName": "Tijjani Noslin",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 331498,
-    "fullName": "Jordi Mboula",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 462086,
-    "fullName": "Elayis Tavsan",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 623040,
-    "fullName": "Yayah Kallon",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 815543,
-    "fullName": "Denis Cazzadori",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 330126,
-    "fullName": "Karol Swiderski",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 241527,
-    "fullName": "Federico Bonazzoli",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 412513,
-    "fullName": "Thomas Henry",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 984708,
-    "fullName": "Siren Diao",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 67556,
-    "fullName": "Milan Djuric",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 748316,
-    "fullName": "Juan Manuel Cruz",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1111820,
-    "fullName": "Junior Ajayi",
-    "clubName": "Hellas Verona",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 12907,
-    "fullName": "Alessio Cragno",
-    "clubName": "US Sassuolo",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 35865,
-    "fullName": "Andrea Consigli",
-    "clubName": "US Sassuolo",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 886189,
-    "fullName": "Daniel Theiner",
-    "clubName": "US Sassuolo",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 21872,
-    "fullName": "Gianluca Pegolo",
-    "clubName": "US Sassuolo",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 892482,
-    "fullName": "Alessandro Scacchetti",
-    "clubName": "US Sassuolo",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 493702,
-    "fullName": "Mattia Viti",
-    "clubName": "US Sassuolo",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 371371,
-    "fullName": "Marash Kumbulla",
-    "clubName": "US Sassuolo",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 357003,
-    "fullName": "Martin Erlić",
-    "clubName": "US Sassuolo",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 555015,
-    "fullName": "Ruan",
-    "clubName": "US Sassuolo",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 277167,
-    "fullName": "Gian Marco Ferrari",
-    "clubName": "US Sassuolo",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 734898,
-    "fullName": "Kevin Miranda",
-    "clubName": "US Sassuolo",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 775985,
-    "fullName": "Seb Loeffen",
-    "clubName": "US Sassuolo",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 439072,
-    "fullName": "Matías Viña",
-    "clubName": "US Sassuolo",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 567129,
-    "fullName": "Josh Doig",
-    "clubName": "US Sassuolo",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 703225,
-    "fullName": "Matteo Falasca",
-    "clubName": "US Sassuolo",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 129674,
-    "fullName": "Jeremy Toljan",
-    "clubName": "US Sassuolo",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 650993,
-    "fullName": "Filippo Missori",
-    "clubName": "US Sassuolo",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 655525,
-    "fullName": "Yeferson Paz",
-    "clubName": "US Sassuolo",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 290862,
-    "fullName": "Maxime Lopez",
-    "clubName": "US Sassuolo",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 441515,
-    "fullName": "Daniel Boloca",
-    "clubName": "US Sassuolo",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 724106,
-    "fullName": "Luca Lipani",
-    "clubName": "US Sassuolo",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 417575,
-    "fullName": "Uros Racic",
-    "clubName": "US Sassuolo",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 552549,
-    "fullName": "Matheus Henrique",
-    "clubName": "US Sassuolo",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 808559,
-    "fullName": "Justin Kumi",
-    "clubName": "US Sassuolo",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 101213,
-    "fullName": "Pedro Obiang",
-    "clubName": "US Sassuolo",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 745436,
-    "fullName": "Salim Abubakar",
-    "clubName": "US Sassuolo",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 583404,
-    "fullName": "Marcus Pedersen",
-    "clubName": "US Sassuolo",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 564785,
-    "fullName": "Kristian Thorstvedt",
-    "clubName": "US Sassuolo",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 390177,
-    "fullName": "Nedim Bajrami",
-    "clubName": "US Sassuolo",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 746891,
-    "fullName": "Cristian Volpato",
-    "clubName": "US Sassuolo",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 579930,
-    "fullName": "Armand Laurienté",
-    "clubName": "US Sassuolo",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 508371,
-    "fullName": "Emil Konradsen Ceide",
-    "clubName": "US Sassuolo",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 177843,
-    "fullName": "Domenico Berardi",
-    "clubName": "US Sassuolo",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 195171,
-    "fullName": "Samu Castillejo",
-    "clubName": "US Sassuolo",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 315865,
-    "fullName": "Andrea Pinamonti",
-    "clubName": "US Sassuolo",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 812625,
-    "fullName": "Agustín Álvarez",
-    "clubName": "US Sassuolo",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 457422,
-    "fullName": "Samuele Mulattieri",
-    "clubName": "US Sassuolo",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 163222,
-    "fullName": "Grégoire Defrel",
-    "clubName": "US Sassuolo",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 543666,
-    "fullName": "Stefano Turati",
-    "clubName": "Frosinone Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 370701,
-    "fullName": "Michele Cerofolini",
-    "clubName": "Frosinone Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 457859,
-    "fullName": "Michele Avella",
-    "clubName": "Frosinone Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 705355,
-    "fullName": "Lorenzo Palmisani",
-    "clubName": "Frosinone Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 43217,
-    "fullName": "Pierluigi Frattali",
-    "clubName": "Frosinone Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 461833,
-    "fullName": "Caleb Okoli",
-    "clubName": "Frosinone Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 550116,
-    "fullName": "Ilario Monterisi",
-    "clubName": "Frosinone Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 247377,
-    "fullName": "Kevin Bonifazi",
-    "clubName": "Frosinone Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 88706,
-    "fullName": "Simone Romagnoli",
-    "clubName": "Frosinone Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 255461,
-    "fullName": "Przemyslaw Szyminski",
-    "clubName": "Frosinone Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1159022,
-    "fullName": "Mateus Lusuardi",
-    "clubName": "Frosinone Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 457237,
-    "fullName": "Sergio Kalaj",
-    "clubName": "Frosinone Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 722377,
-    "fullName": "Matjaz Kamensek-Pahic",
-    "clubName": "Frosinone Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 671543,
-    "fullName": "Daniel Macej",
-    "clubName": "Frosinone Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 297645,
-    "fullName": "Riccardo Marchizza",
-    "clubName": "Frosinone Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 445126,
-    "fullName": "Emanuele Valeri",
-    "clubName": "Frosinone Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 804812,
-    "fullName": "Anthony Oyono",
-    "clubName": "Frosinone Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 298975,
-    "fullName": "Pol Lirola",
-    "clubName": "Frosinone Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 671915,
-    "fullName": "Enzo Barrenechea",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 927905,
-    "fullName": "Matteo Cichella",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 226025,
-    "fullName": "Luca Mazzitelli",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 459128,
-    "fullName": "Marco Brescianini",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 416386,
-    "fullName": "Abdou Harroui",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 131731,
-    "fullName": "Mehdi Bourabia",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 240252,
-    "fullName": "Karlo Lulic",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 989621,
-    "fullName": "İsak Vural",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 572658,
-    "fullName": "Hamza Haoudi",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 679280,
-    "fullName": "Kalifa Kujabi",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 392966,
-    "fullName": "Nadir Zortea",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 490842,
-    "fullName": "Lukas Klitten",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 744728,
-    "fullName": "Arijon Ibrahimovic",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 627226,
-    "fullName": "Reinier",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 398030,
-    "fullName": "Giuseppe Caso",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 205677,
-    "fullName": "Luca Garritano",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 337811,
-    "fullName": "Francesco Gelli",
-    "clubName": "Frosinone Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 238654,
-    "fullName": "Jaime Báez",
-    "clubName": "Frosinone Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 412758,
-    "fullName": "Giorgi Kvernadze",
-    "clubName": "Frosinone Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 90118,
-    "fullName": "Soufiane Bidaoui",
-    "clubName": "Frosinone Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 668951,
-    "fullName": "Matías Soulé",
-    "clubName": "Frosinone Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 551752,
-    "fullName": "Demba Seck",
-    "clubName": "Frosinone Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 188436,
-    "fullName": "Luigi Canotto",
-    "clubName": "Frosinone Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 888738,
-    "fullName": "Farès Ghedjemis",
-    "clubName": "Frosinone Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 521407,
-    "fullName": "Walid Cheddira",
-    "clubName": "Frosinone Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 620477,
-    "fullName": "Kaio Jorge",
-    "clubName": "Frosinone Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 459988,
-    "fullName": "Gennaro Borrelli",
-    "clubName": "Frosinone Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 453864,
-    "fullName": "Marvin Cuni",
-    "clubName": "Frosinone Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 895596,
-    "fullName": "Alessandro Selvini",
-    "clubName": "Frosinone Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1086590,
-    "fullName": "Alejandro Cichero",
-    "clubName": "Frosinone Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 238537,
-    "fullName": "Wladimiro Falcone",
-    "clubName": "US Lecce",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 451154,
-    "fullName": "Federico Brancolini",
-    "clubName": "US Lecce",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 667640,
-    "fullName": "Alexandru Borbei",
-    "clubName": "US Lecce",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 712911,
-    "fullName": "Jasper Samooja",
-    "clubName": "US Lecce",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 282144,
-    "fullName": "Marin Pongracic",
-    "clubName": "US Lecce",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 351955,
-    "fullName": "Federico Baschirotto",
-    "clubName": "US Lecce",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 325924,
-    "fullName": "Ahmed Touba",
-    "clubName": "US Lecce",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 163647,
-    "fullName": "Kastriot Dermaku",
-    "clubName": "US Lecce",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1118086,
-    "fullName": "Sebastian Esposito",
-    "clubName": "US Lecce",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 805696,
-    "fullName": "Mats Lemmens",
-    "clubName": "US Lecce",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 958649,
-    "fullName": "Zinedin Smajlović",
-    "clubName": "US Lecce",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 926952,
-    "fullName": "Patrick Dorgu",
-    "clubName": "US Lecce",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 392516,
-    "fullName": "Antonino Gallo",
-    "clubName": "US Lecce",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 569387,
-    "fullName": "Valentin Gendrey",
-    "clubName": "US Lecce",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 240219,
-    "fullName": "Lorenzo Venuti",
-    "clubName": "US Lecce",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 442703,
-    "fullName": "Ylber Ramadani",
-    "clubName": "US Lecce",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 236041,
-    "fullName": "Alexis Blin",
-    "clubName": "US Lecce",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 651002,
-    "fullName": "Giacomo Faticanti",
-    "clubName": "US Lecce",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 324377,
-    "fullName": "Youssef Maleh",
-    "clubName": "US Lecce",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 692209,
-    "fullName": "Joan González",
-    "clubName": "US Lecce",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 911328,
-    "fullName": "Mohamed Kaba",
-    "clubName": "US Lecce",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 418571,
-    "fullName": "Hamza Rafia",
-    "clubName": "US Lecce",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 671542,
-    "fullName": "Daniel Samek",
-    "clubName": "US Lecce",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 488996,
-    "fullName": "Thórir Jóhann Helgason",
-    "clubName": "US Lecce",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 583046,
-    "fullName": "Medon Berisha",
-    "clubName": "US Lecce",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 399543,
-    "fullName": "Rémi Oudin",
-    "clubName": "US Lecce",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 291276,
-    "fullName": "Marcin Listkowski",
-    "clubName": "US Lecce",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 545538,
-    "fullName": "Lameck Banda",
-    "clubName": "US Lecce",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 38607,
-    "fullName": "Federico Di Francesco",
-    "clubName": "US Lecce",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 82048,
-    "fullName": "Nicola Sansone",
-    "clubName": "US Lecce",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 457673,
-    "fullName": "Gabriel Strefezza",
-    "clubName": "US Lecce",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 300532,
-    "fullName": "Pontus Almqvist",
-    "clubName": "US Lecce",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 674806,
-    "fullName": "Santiago Pierotti",
-    "clubName": "US Lecce",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 709985,
-    "fullName": "Jeppe Corfitzen",
-    "clubName": "US Lecce",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 434433,
-    "fullName": "Nikola Krstović",
-    "clubName": "US Lecce",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 432092,
-    "fullName": "Roberto Piccoli",
-    "clubName": "US Lecce",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 388382,
-    "fullName": "Assan Ceesay",
-    "clubName": "US Lecce",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 731525,
-    "fullName": "Rareș Burnete",
-    "clubName": "US Lecce",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 647534,
-    "fullName": "Joel Voelkerling Persson",
-    "clubName": "US Lecce",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 421873,
-    "fullName": "Elia Caprile",
-    "clubName": "FC Empoli",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 301240,
-    "fullName": "Samuele Perisan",
-    "clubName": "FC Empoli",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 77825,
-    "fullName": "Etrit Berisha",
-    "clubName": "FC Empoli",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 728516,
-    "fullName": "Lovro Stubljar",
-    "clubName": "FC Empoli",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 935777,
-    "fullName": "Jacopo Seghetti",
-    "clubName": "FC Empoli",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1059771,
-    "fullName": "Filippo Vertua",
-    "clubName": "FC Empoli",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 278531,
-    "fullName": "Sebastiano Luperto",
-    "clubName": "FC Empoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 435228,
-    "fullName": "Ardian Ismajli",
-    "clubName": "FC Empoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 345458,
-    "fullName": "Sebastian Walukiewicz",
-    "clubName": "FC Empoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 745427,
-    "fullName": "Gabriele Guarino",
-    "clubName": "FC Empoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 906160,
-    "fullName": "Saba Goglichidze",
-    "clubName": "FC Empoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 111347,
-    "fullName": "Lorenzo Tonelli",
-    "clubName": "FC Empoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 814438,
-    "fullName": "Gabriele Indragoli",
-    "clubName": "FC Empoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 814446,
-    "fullName": "Luca Marianucci",
-    "clubName": "FC Empoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 336960,
-    "fullName": "Giuseppe Pezzella",
-    "clubName": "FC Empoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 469211,
-    "fullName": "Liberato Cacace",
-    "clubName": "FC Empoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 309944,
-    "fullName": "Tyronne Ebuehi",
-    "clubName": "FC Empoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 183841,
-    "fullName": "Petar Stojanović",
-    "clubName": "FC Empoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 144143,
-    "fullName": "Bartosz Bereszyński",
-    "clubName": "FC Empoli",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 295183,
-    "fullName": "Răzvan Marin",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 197473,
-    "fullName": "Alberto Grassi",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 555056,
-    "fullName": "Iwo Kaczmarski",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 691482,
-    "fullName": "Jacopo Fazzini",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 324377,
-    "fullName": "Youssef Maleh",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 489611,
-    "fullName": "Filippo Ranocchia",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 387234,
-    "fullName": "Szymon Żurkowski",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 257751,
-    "fullName": "Simone Bastoni",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 193867,
-    "fullName": "Liam Henderson",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 467994,
-    "fullName": "Luca Belardinelli",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 192638,
-    "fullName": "Nicolas Haas",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 291400,
-    "fullName": "Giovanni Crociata",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 814445,
-    "fullName": "Lorenzo Ignacchiti",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 241076,
-    "fullName": "Emmanuel Gyasi",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 641537,
-    "fullName": "Tommaso Baldanzi",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 539134,
-    "fullName": "Daniel Maldini",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 203842,
-    "fullName": "Viktor Kovalenko",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 814453,
-    "fullName": "Andrea Sodero",
-    "clubName": "FC Empoli",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 459151,
-    "fullName": "Nicolò Cambiaghi",
-    "clubName": "FC Empoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 603891,
-    "fullName": "Emmanuel Ekong",
-    "clubName": "FC Empoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 550106,
-    "fullName": "Matteo Cancellieri",
-    "clubName": "FC Empoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 432092,
-    "fullName": "Roberto Piccoli",
-    "clubName": "FC Empoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 157501,
-    "fullName": "M'Baye Niang",
-    "clubName": "FC Empoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 931567,
-    "fullName": "Stiven Shpendi",
-    "clubName": "FC Empoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 197751,
-    "fullName": "Alberto Cerri",
-    "clubName": "FC Empoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 84765,
-    "fullName": "Francesco Caputo",
-    "clubName": "FC Empoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 88683,
-    "fullName": "Mattia Destro",
-    "clubName": "FC Empoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 909894,
-    "fullName": "Giacomo Corona",
-    "clubName": "FC Empoli",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 29559,
-    "fullName": "Guillermo Ochoa",
-    "clubName": "US Salernitana 1919",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 22628,
-    "fullName": "Benoît Costil",
-    "clubName": "US Salernitana 1919",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 55000,
-    "fullName": "Vincenzo Fiorillo",
-    "clubName": "US Salernitana 1919",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 901980,
-    "fullName": "Pasquale Allocca",
-    "clubName": "US Salernitana 1919",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1194286,
-    "fullName": "Gregorio Salvati",
-    "clubName": "US Salernitana 1919",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 322655,
-    "fullName": "Flavius Daniliuc",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 487834,
-    "fullName": "Lorenzo Pirola",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 459655,
-    "fullName": "Matteo Lovato",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 776303,
-    "fullName": "Marco Pellegrino",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 205054,
-    "fullName": "Norbert Gyömbér",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 450417,
-    "fullName": "Dylan Bronn",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 104752,
-    "fullName": "Konstantinos Manolas",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 470422,
-    "fullName": "Triantafyllos Pasalidis",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 26485,
-    "fullName": "Jérôme Boateng",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 45314,
-    "fullName": "Federico Fazio",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 816930,
-    "fullName": "Andrei Motoc",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 815554,
-    "fullName": "Emanuele Elia",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1060339,
-    "fullName": "Niccolò Guccione",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 357796,
-    "fullName": "Domagoj Bradarić",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 951211,
-    "fullName": "Tommaso Ferrari",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 397225,
-    "fullName": "Alessandro Zanoli",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 250153,
-    "fullName": "Pasquale Mazzocchi",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 335147,
-    "fullName": "Junior Sambia",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 534084,
-    "fullName": "Niccolò Pierozzi",
-    "clubName": "US Salernitana 1919",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 570466,
-    "fullName": "Mateusz Legowski",
-    "clubName": "US Salernitana 1919",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 406806,
-    "fullName": "Emil Bohinen",
-    "clubName": "US Salernitana 1919",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1012516,
-    "fullName": "Ciro Borrelli",
-    "clubName": "US Salernitana 1919",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 386552,
-    "fullName": "Lassana Coulibaly",
-    "clubName": "US Salernitana 1919",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 353796,
-    "fullName": "Giulio Maggiore",
-    "clubName": "US Salernitana 1919",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 334835,
-    "fullName": "Toma Bašić",
-    "clubName": "US Salernitana 1919",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 472161,
-    "fullName": "Mamadou Coulibaly",
-    "clubName": "US Salernitana 1919",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 693352,
-    "fullName": "Iron Gomis",
-    "clubName": "US Salernitana 1919",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 704347,
-    "fullName": "Antonio Pio Iervolino",
-    "clubName": "US Salernitana 1919",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1222050,
-    "fullName": "Rocco Di Vico",
-    "clubName": "US Salernitana 1919",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 732507,
-    "fullName": "Agustín Martegani",
-    "clubName": "US Salernitana 1919",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 298635,
-    "fullName": "Grigoris Kastanos",
-    "clubName": "US Salernitana 1919",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 448466,
-    "fullName": "Jovane Cabral",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 808224,
-    "fullName": "Andres Sfait",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 607226,
-    "fullName": "Loum Tchaouna",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 394346,
-    "fullName": "Emanuel Vignato",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 25488,
-    "fullName": "Antonio Candreva",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1129800,
-    "fullName": "Luca Boncori",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 626913,
-    "fullName": "Boulaye Dia",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 418559,
-    "fullName": "Erik Botheim",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 929494,
-    "fullName": "Chukwubuikem Ikwuemesi",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 247652,
-    "fullName": "Shon Weissman",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 194549,
-    "fullName": "Simy",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 642689,
-    "fullName": "Mikael",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 880054,
-    "fullName": "Trivante Stewart",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 928051,
-    "fullName": "Gerardo Fusco",
-    "clubName": "US Salernitana 1919",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 238993,
-    "fullName": "Simone Scuffet",
-    "clubName": "Cagliari Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 258482,
-    "fullName": "Boris Radunović",
-    "clubName": "Cagliari Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 927933,
-    "fullName": "Velizar-Iliya Iliev",
-    "clubName": "Cagliari Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 41912,
-    "fullName": "Simone Aresti",
-    "clubName": "Cagliari Calcio",
-    "position": "GK",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 385394,
-    "fullName": "Alberto Dossena",
-    "clubName": "Cagliari Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 568333,
-    "fullName": "Adam Obert",
-    "clubName": "Cagliari Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 208172,
-    "fullName": "Mateusz Wieteska",
-    "clubName": "Cagliari Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 289446,
-    "fullName": "Yerry Mina",
-    "clubName": "Cagliari Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 144244,
-    "fullName": "Pantelis Hatzidiakos",
-    "clubName": "Cagliari Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 354909,
-    "fullName": "Giorgio Altare",
-    "clubName": "Cagliari Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 242940,
-    "fullName": "Edoardo Goldaniga",
-    "clubName": "Cagliari Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 238947,
-    "fullName": "Elio Capradossi",
-    "clubName": "Cagliari Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 284595,
-    "fullName": "Tommaso Augello",
-    "clubName": "Cagliari Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 310527,
-    "fullName": "Paulo Azzi",
-    "clubName": "Cagliari Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 392569,
-    "fullName": "Gabriele Zappa",
-    "clubName": "Cagliari Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 457674,
-    "fullName": "Alessandro Di Pardo",
-    "clubName": "Cagliari Calcio",
-    "position": "D",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 876298,
-    "fullName": "Matteo Prati",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 460651,
-    "fullName": "Antoine Makoumbou",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 982267,
-    "fullName": "Ibrahim Sulemana",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 315063,
-    "fullName": "Nahitan Nández",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 235931,
-    "fullName": "Alessandro Deiola",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 317482,
-    "fullName": "Marko Rog",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 650224,
-    "fullName": "Christos Kourfalidis",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 459945,
-    "fullName": "Nunzio Lella",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 319160,
-    "fullName": "Jakub Jankto",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 358008,
-    "fullName": "Gianluca Gaetano",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 613393,
-    "fullName": "Gaetano Oristanio",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 264116,
-    "fullName": "Gastón Pereiro",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 85393,
-    "fullName": "Nicolas Viola",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 51736,
-    "fullName": "Marco Mancosu",
-    "clubName": "Cagliari Calcio",
-    "position": "M",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 885228,
-    "fullName": "Alessandro Vinciguerra",
-    "clubName": "Cagliari Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 610878,
-    "fullName": "Jacopo Desogus",
-    "clubName": "Cagliari Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 666547,
-    "fullName": "Zito Luvumbo",
-    "clubName": "Cagliari Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 358166,
-    "fullName": "Eldor Shomurodov",
-    "clubName": "Cagliari Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 199258,
-    "fullName": "Andrea Petagna",
-    "clubName": "Cagliari Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 130394,
-    "fullName": "Gianluca Lapadula",
-    "clubName": "Cagliari Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 1111663,
-    "fullName": "Kingstone Mutandwa",
-    "clubName": "Cagliari Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 64793,
-    "fullName": "Leonardo Pavoletti",
-    "clubName": "Cagliari Calcio",
-    "position": "F",
-    "league": "Serie A"
-  },
-  {
-    "playerId": 17259,
-    "fullName": "Manuel Neuer",
-    "clubName": "Bayern Munich",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 468539,
-    "fullName": "Daniel Peretz",
-    "clubName": "Bayern Munich",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 40680,
-    "fullName": "Sven Ulreich",
-    "clubName": "Bayern Munich",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 937713,
-    "fullName": "Max Schmitt",
-    "clubName": "Bayern Munich",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 639582,
-    "fullName": "Tom Ritzy Hülsmann",
-    "clubName": "Bayern Munich",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 326031,
-    "fullName": "Matthijs de Ligt",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 353366,
-    "fullName": "Benjamin Pavard",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 344695,
-    "fullName": "Dayot Upamecano",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 503482,
-    "fullName": "Min-jae Kim",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 175722,
-    "fullName": "Eric Dier",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 744729,
-    "fullName": "Tarek Buchmann",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 424204,
-    "fullName": "Alphonso Davies",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 170986,
-    "fullName": "Raphaël Guerreiro",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 604320,
-    "fullName": "Frans Krätzig",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 938146,
-    "fullName": "Adam Aznou",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 920283,
-    "fullName": "Matteo Pérez Vinlöf",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 223967,
-    "fullName": "Konrad Laimer",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 340456,
-    "fullName": "Noussair Mazraoui",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 475413,
-    "fullName": "Sacha Boey",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 190685,
-    "fullName": "Bouna Sarr",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 707350,
-    "fullName": "Max Scholze",
-    "clubName": "Bayern Munich",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 161056,
-    "fullName": "Joshua Kimmich",
-    "clubName": "Bayern Munich",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 478573,
-    "fullName": "Ryan Gravenberch",
-    "clubName": "Bayern Munich",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 792380,
-    "fullName": "Aleksandar Pavlovic",
-    "clubName": "Bayern Munich",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 904974,
-    "fullName": "Noel Aseko",
-    "clubName": "Bayern Munich",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 522242,
-    "fullName": "Luca Denk",
-    "clubName": "Bayern Munich",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 153084,
-    "fullName": "Leon Goretzka",
-    "clubName": "Bayern Munich",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 868622,
-    "fullName": "Taichi Fukui",
-    "clubName": "Bayern Munich",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 580195,
-    "fullName": "Jamal Musiala",
-    "clubName": "Bayern Munich",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 892973,
-    "fullName": "Lovro Zvonarek",
-    "clubName": "Bayern Munich",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 856274,
-    "fullName": "Jonathan Asp Jensen",
-    "clubName": "Bayern Munich",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 243714,
-    "fullName": "Kingsley Coman",
-    "clubName": "Bayern Munich",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 159471,
-    "fullName": "Serge Gnabry",
-    "clubName": "Bayern Munich",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 713644,
-    "fullName": "Bryan Zaragoza",
-    "clubName": "Bayern Munich",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 192565,
-    "fullName": "Leroy Sané",
-    "clubName": "Bayern Munich",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 58358,
-    "fullName": "Thomas Müller",
-    "clubName": "Bayern Munich",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 132098,
-    "fullName": "Harry Kane",
-    "clubName": "Bayern Munich",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 801734,
-    "fullName": "Mathys Tel",
-    "clubName": "Bayern Munich",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 45660,
-    "fullName": "Eric-Maxim Choupo-Moting",
-    "clubName": "Bayern Munich",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 550829,
-    "fullName": "Matej Kovar",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 223972,
-    "fullName": "Patrick Pentz",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 48015,
-    "fullName": "Lukas Hradecky",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 85543,
-    "fullName": "Niklas Lomb",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 564545,
-    "fullName": "Edmond Tapsoba",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 659813,
-    "fullName": "Piero Hincapié",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 644771,
-    "fullName": "Odilon Kossounou",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 196357,
-    "fullName": "Jonathan Tah",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 934645,
-    "fullName": "Reno Münz",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 937113,
-    "fullName": "Madi Monamay",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 193082,
-    "fullName": "Alejandro Grimaldo",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 484547,
-    "fullName": "Jeremie Frimpong",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 483046,
-    "fullName": "Josip Stanisic",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 977464,
-    "fullName": "Arthur",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 315131,
-    "fullName": "Timothy Fosu-Mensah",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 111455,
-    "fullName": "Granit Xhaka",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 159088,
-    "fullName": "Robert Andrich",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 401578,
-    "fullName": "Exequiel Palacios",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 232454,
-    "fullName": "Nadiem Amiri",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 936981,
-    "fullName": "Gustavo Puerta",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 743395,
-    "fullName": "Noah Mbamba",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 598577,
-    "fullName": "Florian Wirtz",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 7161,
-    "fullName": "Jonas Hofmann",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 696027,
-    "fullName": "Ayman Aourir",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 929943,
-    "fullName": "Francis Onyeka",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 532776,
-    "fullName": "Amine Adli",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 340322,
-    "fullName": "Nathan Tella",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 552057,
-    "fullName": "Adam Hlozek",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 656681,
-    "fullName": "Victor Boniface",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 242086,
-    "fullName": "Patrik Schick",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 278359,
-    "fullName": "Borja Iglesias",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 929912,
-    "fullName": "Ken Izekor",
-    "clubName": "Bayer 04 Leverkusen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 57071,
-    "fullName": "Péter Gulácsi",
-    "clubName": "RB Leipzig",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 81173,
-    "fullName": "Janis Blaswich",
-    "clubName": "RB Leipzig",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 897425,
-    "fullName": "Timo Schlieck",
-    "clubName": "RB Leipzig",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 160971,
-    "fullName": "Leopold Zingerle",
-    "clubName": "RB Leipzig",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 618472,
-    "fullName": "Castello Lukeba",
-    "clubName": "RB Leipzig",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 666234,
-    "fullName": "Mohamed Simakan",
-    "clubName": "RB Leipzig",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 787912,
-    "fullName": "El Chadaille Bitshiabu",
-    "clubName": "RB Leipzig",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 93740,
-    "fullName": "Willi Orbán",
-    "clubName": "RB Leipzig",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 215599,
-    "fullName": "Lukas Klostermann",
-    "clubName": "RB Leipzig",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 1006916,
-    "fullName": "Jonathan Norbye",
-    "clubName": "RB Leipzig",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 913429,
-    "fullName": "Tim Köhler",
-    "clubName": "RB Leipzig",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 318204,
-    "fullName": "David Raum",
-    "clubName": "RB Leipzig",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 159844,
-    "fullName": "Christopher Lenz",
-    "clubName": "RB Leipzig",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 202591,
-    "fullName": "Benjamin Henrichs",
-    "clubName": "RB Leipzig",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 668276,
-    "fullName": "Hugo Novoa",
-    "clubName": "RB Leipzig",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 223979,
-    "fullName": "Xaver Schlager",
-    "clubName": "RB Leipzig",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 402008,
-    "fullName": "Amadou Haidara",
-    "clubName": "RB Leipzig",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 404950,
-    "fullName": "Nicolas Seiwald",
-    "clubName": "RB Leipzig",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 53418,
-    "fullName": "Kevin Kampl",
-    "clubName": "RB Leipzig",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 617074,
-    "fullName": "Ilaix Moriba",
-    "clubName": "RB Leipzig",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 566931,
-    "fullName": "Xavi Simons",
-    "clubName": "RB Leipzig",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 293385,
-    "fullName": "Dani Olmo",
-    "clubName": "RB Leipzig",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 324278,
-    "fullName": "Christoph Baumgartner",
-    "clubName": "RB Leipzig",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 559263,
-    "fullName": "Fábio Carvalho",
-    "clubName": "RB Leipzig",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 974561,
-    "fullName": "Nuha Jatta",
-    "clubName": "RB Leipzig",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 400489,
-    "fullName": "Eljif Elmas",
-    "clubName": "RB Leipzig",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 170527,
-    "fullName": "Timo Werner",
-    "clubName": "RB Leipzig",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 111078,
-    "fullName": "Emil Forsberg",
-    "clubName": "RB Leipzig",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 368887,
-    "fullName": "Loïs Openda",
-    "clubName": "RB Leipzig",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 627442,
-    "fullName": "Benjamin Sesko",
-    "clubName": "RB Leipzig",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 157635,
-    "fullName": "Yussuf Poulsen",
-    "clubName": "RB Leipzig",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 930998,
-    "fullName": "Yannick Eduardo",
-    "clubName": "RB Leipzig",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 257814,
-    "fullName": "Gregor Kobel",
-    "clubName": "Borussia Dortmund",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 453737,
-    "fullName": "Marcel Lotka",
-    "clubName": "Borussia Dortmund",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 76158,
-    "fullName": "Alexander Meyer",
-    "clubName": "Borussia Dortmund",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 388198,
-    "fullName": "Nico Schlotterbeck",
-    "clubName": "Borussia Dortmund",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 166601,
-    "fullName": "Niklas Süle",
-    "clubName": "Borussia Dortmund",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 39728,
-    "fullName": "Mats Hummels",
-    "clubName": "Borussia Dortmund",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 804831,
-    "fullName": "Hendry Blank",
-    "clubName": "Borussia Dortmund",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 482573,
-    "fullName": "Antonios Papadopoulos",
-    "clubName": "Borussia Dortmund",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 485585,
-    "fullName": "Ian Maatsen",
-    "clubName": "Borussia Dortmund",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 284732,
-    "fullName": "Ramy Bensebaini",
-    "clubName": "Borussia Dortmund",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 854079,
-    "fullName": "Guille Bueno",
-    "clubName": "Borussia Dortmund",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 370789,
-    "fullName": "Julian Ryerson",
-    "clubName": "Borussia Dortmund",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 193900,
-    "fullName": "Marius Wolf",
-    "clubName": "Borussia Dortmund",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 100986,
-    "fullName": "Thomas Meunier",
-    "clubName": "Borussia Dortmund",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 388513,
-    "fullName": "Mateu Morey",
-    "clubName": "Borussia Dortmund",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 244940,
-    "fullName": "Salih Özcan",
-    "clubName": "Borussia Dortmund",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 119296,
-    "fullName": "Emre Can",
-    "clubName": "Borussia Dortmund",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 718232,
-    "fullName": "Abdoulaye Kamara",
-    "clubName": "Borussia Dortmund",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 406640,
-    "fullName": "Felix Nmecha",
-    "clubName": "Borussia Dortmund",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 106987,
-    "fullName": "Marcel Sabitzer",
-    "clubName": "Borussia Dortmund",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 884810,
-    "fullName": "Kjell Wätjen",
-    "clubName": "Borussia Dortmund",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 187492,
-    "fullName": "Julian Brandt",
-    "clubName": "Borussia Dortmund",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 504215,
-    "fullName": "Giovanni Reyna",
-    "clubName": "Borussia Dortmund",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 102226,
-    "fullName": "Thorgan Hazard",
-    "clubName": "Borussia Dortmund",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 35207,
-    "fullName": "Marco Reus",
-    "clubName": "Borussia Dortmund",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 405690,
-    "fullName": "Ole Pohlmann",
-    "clubName": "Borussia Dortmund",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 401173,
-    "fullName": "Jadon Sancho",
-    "clubName": "Borussia Dortmund",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 670882,
-    "fullName": "Jamie Gittens",
-    "clubName": "Borussia Dortmund",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 819215,
-    "fullName": "Julien Duranville",
-    "clubName": "Borussia Dortmund",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 326029,
-    "fullName": "Donyell Malen",
-    "clubName": "Borussia Dortmund",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 496094,
-    "fullName": "Karim Adeyemi",
-    "clubName": "Borussia Dortmund",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 684318,
-    "fullName": "Samuel Bamba",
-    "clubName": "Borussia Dortmund",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 467720,
-    "fullName": "Youssoufa Moukoko",
-    "clubName": "Borussia Dortmund",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 75489,
-    "fullName": "Niclas Füllkrug",
-    "clubName": "Borussia Dortmund",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 181375,
-    "fullName": "Sébastien Haller",
-    "clubName": "Borussia Dortmund",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 918414,
-    "fullName": "Paris Brunner",
-    "clubName": "Borussia Dortmund",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 195778,
-    "fullName": "Alexander Nübel",
-    "clubName": "VfB Stuttgart",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 187624,
-    "fullName": "Fabian Bredlow",
-    "clubName": "VfB Stuttgart",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 800946,
-    "fullName": "Dennis Seimen",
-    "clubName": "VfB Stuttgart",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 470816,
-    "fullName": "Florian Schock",
-    "clubName": "VfB Stuttgart",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 353892,
-    "fullName": "Hiroki Ito",
-    "clubName": "VfB Stuttgart",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 415912,
-    "fullName": "Konstantinos Mavropanos",
-    "clubName": "VfB Stuttgart",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 193004,
-    "fullName": "Waldemar Anton",
-    "clubName": "VfB Stuttgart",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 344598,
-    "fullName": "Dan-Axel Zagadou",
-    "clubName": "VfB Stuttgart",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 690799,
-    "fullName": "Anthony Rouault",
-    "clubName": "VfB Stuttgart",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 948537,
-    "fullName": "Anrie Chase",
-    "clubName": "VfB Stuttgart",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 282660,
-    "fullName": "Maximilian Mittelstädt",
-    "clubName": "VfB Stuttgart",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 293194,
-    "fullName": "Borna Sosa",
-    "clubName": "VfB Stuttgart",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 620312,
-    "fullName": "Moussa Cissé",
-    "clubName": "VfB Stuttgart",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 448258,
-    "fullName": "Josha Vagnoman",
-    "clubName": "VfB Stuttgart",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 507345,
-    "fullName": "Leonidas Stergiou",
-    "clubName": "VfB Stuttgart",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 195246,
-    "fullName": "Pascal Stenzel",
-    "clubName": "VfB Stuttgart",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 443710,
-    "fullName": "Angelo Stiller",
-    "clubName": "VfB Stuttgart",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 146310,
-    "fullName": "Wataru Endo",
-    "clubName": "VfB Stuttgart",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 232320,
-    "fullName": "Atakan Karazor",
-    "clubName": "VfB Stuttgart",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 191422,
-    "fullName": "Mahmoud Dahoud",
-    "clubName": "VfB Stuttgart",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 400546,
-    "fullName": "Nikolas Nartey",
-    "clubName": "VfB Stuttgart",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 826064,
-    "fullName": "Samuele Di Benedetto",
-    "clubName": "VfB Stuttgart",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 569366,
-    "fullName": "Enzo Millot",
-    "clubName": "VfB Stuttgart",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 297583,
-    "fullName": "Woo-yeong Jeong",
-    "clubName": "VfB Stuttgart",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 472243,
-    "fullName": "Lilian Egloff",
-    "clubName": "VfB Stuttgart",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 79377,
-    "fullName": "Genki Haraguchi",
-    "clubName": "VfB Stuttgart",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 717465,
-    "fullName": "Laurin Ulrich",
-    "clubName": "VfB Stuttgart",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 716756,
-    "fullName": "Raul Paula",
-    "clubName": "VfB Stuttgart",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 272278,
-    "fullName": "Chris Führich",
-    "clubName": "VfB Stuttgart",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 612826,
-    "fullName": "Silas",
-    "clubName": "VfB Stuttgart",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 518505,
-    "fullName": "Jamie Leweling",
-    "clubName": "VfB Stuttgart",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 431561,
-    "fullName": "Roberto Massimo",
-    "clubName": "VfB Stuttgart",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 907489,
-    "fullName": "Luca Raimund",
-    "clubName": "VfB Stuttgart",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 270541,
-    "fullName": "Serhou Guirassy",
-    "clubName": "VfB Stuttgart",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 339314,
-    "fullName": "Deniz Undav",
-    "clubName": "VfB Stuttgart",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 572919,
-    "fullName": "Mohamed Sankoh",
-    "clubName": "VfB Stuttgart",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 943795,
-    "fullName": "Jovan Milosevic",
-    "clubName": "VfB Stuttgart",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 675565,
-    "fullName": "Thomas Kastanaras",
-    "clubName": "VfB Stuttgart",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 45672,
-    "fullName": "Kevin Trapp",
-    "clubName": "Eintracht Frankfurt",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 997861,
-    "fullName": "Kauã Santos",
-    "clubName": "Eintracht Frankfurt",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 726120,
-    "fullName": "Simon Simoni",
-    "clubName": "Eintracht Frankfurt",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 40034,
-    "fullName": "Jens Grahl",
-    "clubName": "Eintracht Frankfurt",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 866609,
-    "fullName": "Luke Gauer",
-    "clubName": "Eintracht Frankfurt",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 1145455,
-    "fullName": "Nils Ramming",
-    "clubName": "Eintracht Frankfurt",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 661171,
-    "fullName": "Willian Pacho",
-    "clubName": "Eintracht Frankfurt",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 328784,
-    "fullName": "Robin Koch",
-    "clubName": "Eintracht Frankfurt",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 546213,
-    "fullName": "Tuta",
-    "clubName": "Eintracht Frankfurt",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 571299,
-    "fullName": "Hrvoje Smolcic",
-    "clubName": "Eintracht Frankfurt",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 684315,
-    "fullName": "Nnamdi Collins",
-    "clubName": "Eintracht Frankfurt",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 666168,
-    "fullName": "Dario Gebuhr",
-    "clubName": "Eintracht Frankfurt",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 993870,
-    "fullName": "Davis Bautista",
-    "clubName": "Eintracht Frankfurt",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 591193,
-    "fullName": "Niels Nkounkou",
-    "clubName": "Eintracht Frankfurt",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 111275,
-    "fullName": "Philipp Max",
-    "clubName": "Eintracht Frankfurt",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 159844,
-    "fullName": "Christopher Lenz",
-    "clubName": "Eintracht Frankfurt",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 258039,
-    "fullName": "Aurélio Buta",
-    "clubName": "Eintracht Frankfurt",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 744857,
-    "fullName": "Elias Baum",
-    "clubName": "Eintracht Frankfurt",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 49723,
-    "fullName": "Timothy Chandler",
-    "clubName": "Eintracht Frankfurt",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 290587,
-    "fullName": "Ellyes Skhiri",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 374954,
-    "fullName": "Kristijan Jakic",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 39259,
-    "fullName": "Makoto Hasebe",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 931838,
-    "fullName": "Hugo Larsson",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 288255,
-    "fullName": "Donny van de Beek",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 44466,
-    "fullName": "Sebastian Rode",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 654872,
-    "fullName": "Marcel Wenig",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 717345,
-    "fullName": "Sidney Raebiger",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 519869,
-    "fullName": "Mehdi Loune",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 486456,
-    "fullName": "Harpreet Ghotra",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 536482,
-    "fullName": "Junior Dina Ebimbe",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 855015,
-    "fullName": "Farès Chaïbi",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 74842,
-    "fullName": "Mario Götze",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 795738,
-    "fullName": "Paxten Aaronson",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 922413,
-    "fullName": "Marko Mladenovic",
-    "clubName": "Eintracht Frankfurt",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 939964,
-    "fullName": "Jean-Mattéo Bahoya",
-    "clubName": "Eintracht Frankfurt",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 422355,
-    "fullName": "Jens Petter Hauge",
-    "clubName": "Eintracht Frankfurt",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 513245,
-    "fullName": "Jesper Lindstrøm",
-    "clubName": "Eintracht Frankfurt",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 429874,
-    "fullName": "Ansgar Knauff",
-    "clubName": "Eintracht Frankfurt",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 487969,
-    "fullName": "Randal Kolo Muani",
-    "clubName": "Eintracht Frankfurt",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 445939,
-    "fullName": "Omar Marmoush",
-    "clubName": "Eintracht Frankfurt",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 709726,
-    "fullName": "Hugo Ekitiké",
-    "clubName": "Eintracht Frankfurt",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 369567,
-    "fullName": "Sasa Kalajdzic",
-    "clubName": "Eintracht Frankfurt",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 867357,
-    "fullName": "Nacho Ferri",
-    "clubName": "Eintracht Frankfurt",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 448177,
-    "fullName": "Jessic Ngankam",
-    "clubName": "Eintracht Frankfurt",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 193782,
-    "fullName": "Lucas Alario",
-    "clubName": "Eintracht Frankfurt",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 675535,
-    "fullName": "Noel Futkeu",
-    "clubName": "Eintracht Frankfurt",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 108880,
-    "fullName": "Koen Casteels",
-    "clubName": "VfL Wolfsburg",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 51977,
-    "fullName": "Pavao Pervan",
-    "clubName": "VfL Wolfsburg",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 574203,
-    "fullName": "Philipp Schulze",
-    "clubName": "VfL Wolfsburg",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 192268,
-    "fullName": "Niklas Klinger",
-    "clubName": "VfL Wolfsburg",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 434224,
-    "fullName": "Maxence Lacroix",
-    "clubName": "VfL Wolfsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 460245,
-    "fullName": "Moritz Jenz",
-    "clubName": "VfL Wolfsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 338629,
-    "fullName": "Sebastiaan Bornauw",
-    "clubName": "VfL Wolfsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 382478,
-    "fullName": "Cédric Zesiger",
-    "clubName": "VfL Wolfsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 923499,
-    "fullName": "Anders Børset",
-    "clubName": "VfL Wolfsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 798773,
-    "fullName": "Felix Lange",
-    "clubName": "VfL Wolfsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 369674,
-    "fullName": "Joakim Mæhle",
-    "clubName": "VfL Wolfsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 401527,
-    "fullName": "Rogério",
-    "clubName": "VfL Wolfsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 485965,
-    "fullName": "Nicolas Cozza",
-    "clubName": "VfL Wolfsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 327251,
-    "fullName": "Ridle Baku",
-    "clubName": "VfL Wolfsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 435796,
-    "fullName": "Kilian Fischer",
-    "clubName": "VfL Wolfsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 814950,
-    "fullName": "Kofi Amoako",
-    "clubName": "VfL Wolfsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 503881,
-    "fullName": "Aster Vranckx",
-    "clubName": "VfL Wolfsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 342405,
-    "fullName": "Mattias Svanberg",
-    "clubName": "VfL Wolfsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 117674,
-    "fullName": "Maximilian Arnold",
-    "clubName": "VfL Wolfsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 119277,
-    "fullName": "Yannick Gerhardt",
-    "clubName": "VfL Wolfsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 711517,
-    "fullName": "Kevin Paredes",
-    "clubName": "VfL Wolfsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 387106,
-    "fullName": "Lovro Majer",
-    "clubName": "VfL Wolfsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 407098,
-    "fullName": "Jakub Kaminski",
-    "clubName": "VfL Wolfsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 469858,
-    "fullName": "Ulysses Llanez",
-    "clubName": "VfL Wolfsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 533295,
-    "fullName": "Patrick Wimmer",
-    "clubName": "VfL Wolfsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 242063,
-    "fullName": "Vaclav Cerny",
-    "clubName": "VfL Wolfsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 897479,
-    "fullName": "Bennit Bröger",
-    "clubName": "VfL Wolfsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 391004,
-    "fullName": "Jonas Wind",
-    "clubName": "VfL Wolfsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 616344,
-    "fullName": "Tiago Tomás",
-    "clubName": "VfL Wolfsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 314288,
-    "fullName": "Lukas Nmecha",
-    "clubName": "VfL Wolfsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 748382,
-    "fullName": "Amin Sarr",
-    "clubName": "VfL Wolfsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 117432,
-    "fullName": "Kevin Behrens",
-    "clubName": "VfL Wolfsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 819636,
-    "fullName": "Dzenan Pejcinovic",
-    "clubName": "VfL Wolfsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 526845,
-    "fullName": "Noah Atubolu",
-    "clubName": "SC Freiburg",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 284769,
-    "fullName": "Florian Müller",
-    "clubName": "SC Freiburg",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 741578,
-    "fullName": "Jaaso Jantunen",
-    "clubName": "SC Freiburg",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 120296,
-    "fullName": "Benjamin Uphoff",
-    "clubName": "SC Freiburg",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 632147,
-    "fullName": "Niklas Sauter",
-    "clubName": "SC Freiburg",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 225657,
-    "fullName": "Philipp Lienhart",
-    "clubName": "SC Freiburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 124502,
-    "fullName": "Matthias Ginter",
-    "clubName": "SC Freiburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 413843,
-    "fullName": "Keven Schlotterbeck",
-    "clubName": "SC Freiburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 263380,
-    "fullName": "Attila Szalai",
-    "clubName": "SC Freiburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 527276,
-    "fullName": "Kenneth Schmidt",
-    "clubName": "SC Freiburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 45683,
-    "fullName": "Manuel Gulde",
-    "clubName": "SC Freiburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 599419,
-    "fullName": "Max Rosenfelder",
-    "clubName": "SC Freiburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 93707,
-    "fullName": "Christian Günter",
-    "clubName": "SC Freiburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 815078,
-    "fullName": "Jordy Makengo",
-    "clubName": "SC Freiburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 332798,
-    "fullName": "Roland Sallai",
-    "clubName": "SC Freiburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 548348,
-    "fullName": "Kiliann Sildillia",
-    "clubName": "SC Freiburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 93604,
-    "fullName": "Lukas Kübler",
-    "clubName": "SC Freiburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 342039,
-    "fullName": "Yannik Keitel",
-    "clubName": "SC Freiburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 55099,
-    "fullName": "Nicolas Höfler",
-    "clubName": "SC Freiburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 230818,
-    "fullName": "Fabian Rüdlin",
-    "clubName": "SC Freiburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 190284,
-    "fullName": "Maximilian Eggestein",
-    "clubName": "SC Freiburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 608832,
-    "fullName": "Merlin Röhl",
-    "clubName": "SC Freiburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 272587,
-    "fullName": "Daniel-Kofi Kyereh",
-    "clubName": "SC Freiburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 337036,
-    "fullName": "Florent Muslija",
-    "clubName": "SC Freiburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 185077,
-    "fullName": "Vincenzo Grifo",
-    "clubName": "SC Freiburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 392163,
-    "fullName": "Noah Weißhaupt",
-    "clubName": "SC Freiburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 720948,
-    "fullName": "Mika Baur",
-    "clubName": "SC Freiburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 351071,
-    "fullName": "Ryan Johansson",
-    "clubName": "SC Freiburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 358504,
-    "fullName": "Ritsu Doan",
-    "clubName": "SC Freiburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 143891,
-    "fullName": "Maximilian Philipp",
-    "clubName": "SC Freiburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 120205,
-    "fullName": "Michael Gregoritsch",
-    "clubName": "SC Freiburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 248999,
-    "fullName": "Lucas Höler",
-    "clubName": "SC Freiburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 452477,
-    "fullName": "Junior Adamu",
-    "clubName": "SC Freiburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 584254,
-    "fullName": "Maximilian Breunig",
-    "clubName": "SC Freiburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 55089,
-    "fullName": "Oliver Baumann",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 600942,
-    "fullName": "Nahuel Noll",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 432671,
-    "fullName": "Luca Philipp",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 361260,
-    "fullName": "Ozan Kabak",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 263380,
-    "fullName": "Attila Szalai",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 160241,
-    "fullName": "Kevin Akpoguma",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 371141,
-    "fullName": "Stanley Nsoki",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 822958,
-    "fullName": "Tim Drexler",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 84435,
-    "fullName": "Kevin Vogt",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 124732,
-    "fullName": "John Brooks",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 790918,
-    "fullName": "Joshua Quarshie",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 263801,
-    "fullName": "Kasim Adams",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 500054,
-    "fullName": "David Jurásek",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 450234,
-    "fullName": "Marco John",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 143798,
-    "fullName": "Pavel Kaderabek",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 443710,
-    "fullName": "Angelo Stiller",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 344069,
-    "fullName": "Anton Stach",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 195736,
-    "fullName": "Florian Grillitsch",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 315604,
-    "fullName": "Diadié Samassékou",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 234029,
-    "fullName": "Grischa Prömel",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 569031,
-    "fullName": "Umut Tohumcu",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 822959,
-    "fullName": "Tom Bischof",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 251309,
-    "fullName": "Dennis Geiger",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 334999,
-    "fullName": "Finn Becker",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 270393,
-    "fullName": "Robert Skov",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 46580,
-    "fullName": "Andrej Kramaric",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 324861,
-    "fullName": "Julian Justvan",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 574193,
-    "fullName": "Bambasé Conté",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 116088,
-    "fullName": "Marius Bülter",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 578392,
-    "fullName": "Maximilian Beier",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 307924,
-    "fullName": "Mergim Berisha",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 228645,
-    "fullName": "Wout Weghorst",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 237164,
-    "fullName": "Ihlas Bebou",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 923595,
-    "fullName": "Max Moerstedt",
-    "clubName": "TSG 1899 Hoffenheim",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 247915,
-    "fullName": "Jonas Omlin",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 284270,
-    "fullName": "Moritz Nicolas",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 455922,
-    "fullName": "Jan Olschowsky",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 31653,
-    "fullName": "Tobias Sippel",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 596103,
-    "fullName": "Maximilian Brüll",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 355816,
-    "fullName": "Ko Itakura",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 192635,
-    "fullName": "Nico Elvedi",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 263361,
-    "fullName": "Maximilian Wöber",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 196231,
-    "fullName": "Marvin Friedrich",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 724104,
-    "fullName": "Fabio Chiarodia",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 340480,
-    "fullName": "Mamadou Doucouré",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 524285,
-    "fullName": "Luca Netz",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 787151,
-    "fullName": "Lukas Ullrich",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 504153,
-    "fullName": "Joe Scally",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 85791,
-    "fullName": "Stefan Lainer",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 912455,
-    "fullName": "Simon Walde",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 47587,
-    "fullName": "Tony Jantschke",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 196792,
-    "fullName": "Julian Weigl",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 82097,
-    "fullName": "Christoph Kramer",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 624690,
-    "fullName": "Manu Koné",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 467434,
-    "fullName": "Rocco Reitz",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 278332,
-    "fullName": "Florian Neuhaus",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 284010,
-    "fullName": "Robin Hack",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 586659,
-    "fullName": "Yvandro Borges Sanches",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 229006,
-    "fullName": "Franck Honorat",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 629588,
-    "fullName": "Nathan Ngoumou",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 321070,
-    "fullName": "Hannes Wolf",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 32711,
-    "fullName": "Patrick Herrmann",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 544148,
-    "fullName": "Tomas Cvancara",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 167329,
-    "fullName": "Alassane Pléa",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 355369,
-    "fullName": "Jordan",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 574201,
-    "fullName": "Grant-Leon Ranos",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 1073997,
-    "fullName": "Shio Fukuda",
-    "clubName": "Borussia Mönchengladbach",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 107775,
-    "fullName": "Frederik Rönnow",
-    "clubName": "1.FC Union Berlin",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 93763,
-    "fullName": "Alexander Schwolow",
-    "clubName": "1.FC Union Berlin",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 203411,
-    "fullName": "Jakob Busk",
-    "clubName": "1.FC Union Berlin",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 698840,
-    "fullName": "Yannic Stein",
-    "clubName": "1.FC Union Berlin",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 387047,
-    "fullName": "Danilho Doekhi",
-    "clubName": "1.FC Union Berlin",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 357156,
-    "fullName": "Diogo Leite",
-    "clubName": "1.FC Union Berlin",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 94201,
-    "fullName": "Robin Knoche",
-    "clubName": "1.FC Union Berlin",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 84435,
-    "fullName": "Kevin Vogt",
-    "clubName": "1.FC Union Berlin",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 284248,
-    "fullName": "Paul Jaeckel",
-    "clubName": "1.FC Union Berlin",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 39983,
-    "fullName": "Leonardo Bonucci",
-    "clubName": "1.FC Union Berlin",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 995520,
-    "fullName": "Oluwaseun Ogbemudia",
-    "clubName": "1.FC Union Berlin",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 273132,
-    "fullName": "Robin Gosens",
-    "clubName": "1.FC Union Berlin",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 127076,
-    "fullName": "Jérôme Roussillon",
-    "clubName": "1.FC Union Berlin",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 451403,
-    "fullName": "Laurenz Dehl",
-    "clubName": "1.FC Union Berlin",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 362977,
-    "fullName": "Josip Juranovic",
-    "clubName": "1.FC Union Berlin",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 75921,
-    "fullName": "Christopher Trimmel",
-    "clubName": "1.FC Union Berlin",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 124410,
-    "fullName": "Rani Khedira",
-    "clubName": "1.FC Union Berlin",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 692737,
-    "fullName": "Aljoscha Kemlein",
-    "clubName": "1.FC Union Berlin",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 353948,
-    "fullName": "Lucas Tousart",
-    "clubName": "1.FC Union Berlin",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 233782,
-    "fullName": "Aïssa Laïdouni",
-    "clubName": "1.FC Union Berlin",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 454863,
-    "fullName": "András Schäfer",
-    "clubName": "1.FC Union Berlin",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 337333,
-    "fullName": "Alex Král",
-    "clubName": "1.FC Union Berlin",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 177779,
-    "fullName": "Janik Haberer",
-    "clubName": "1.FC Union Berlin",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 393323,
-    "fullName": "Brenden Aaronson",
-    "clubName": "1.FC Union Berlin",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 82009,
-    "fullName": "Kevin Volland",
-    "clubName": "1.FC Union Berlin",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 232144,
-    "fullName": "Milos Pantovic",
-    "clubName": "1.FC Union Berlin",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 908952,
-    "fullName": "Tim Schleinitz",
-    "clubName": "1.FC Union Berlin",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 188888,
-    "fullName": "Sheraldo Becker",
-    "clubName": "1.FC Union Berlin",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 787232,
-    "fullName": "David Datro Fofana",
-    "clubName": "1.FC Union Berlin",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 409517,
-    "fullName": "Yorbe Vertessen",
-    "clubName": "1.FC Union Berlin",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 355369,
-    "fullName": "Jordan",
-    "clubName": "1.FC Union Berlin",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 453870,
-    "fullName": "Benedict Hollerbach",
-    "clubName": "1.FC Union Berlin",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 545332,
-    "fullName": "Mikkel Kaufmann",
-    "clubName": "1.FC Union Berlin",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 294791,
-    "fullName": "Chris Bedia",
-    "clubName": "1.FC Union Berlin",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 117432,
-    "fullName": "Kevin Behrens",
-    "clubName": "1.FC Union Berlin",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 160963,
-    "fullName": "Robin Zentner",
-    "clubName": "1.FSV Mainz 05",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 90317,
-    "fullName": "Daniel Batz",
-    "clubName": "1.FSV Mainz 05",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 490609,
-    "fullName": "Lasse Rieß",
-    "clubName": "1.FSV Mainz 05",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 541231,
-    "fullName": "Sepp van den Berg",
-    "clubName": "1.FSV Mainz 05",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 370683,
-    "fullName": "Andreas Hanche-Olsen",
-    "clubName": "1.FSV Mainz 05",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 118847,
-    "fullName": "Dominik Kohr",
-    "clubName": "1.FSV Mainz 05",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 334207,
-    "fullName": "Maxim Leitsch",
-    "clubName": "1.FSV Mainz 05",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 85906,
-    "fullName": "Danny da Costa",
-    "clubName": "1.FSV Mainz 05",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 82350,
-    "fullName": "Stefan Bell",
-    "clubName": "1.FSV Mainz 05",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 692020,
-    "fullName": "Lasse Wilhelm",
-    "clubName": "1.FSV Mainz 05",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 934317,
-    "fullName": "Maxim Dal",
-    "clubName": "1.FSV Mainz 05",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 127573,
-    "fullName": "Phillipp Mwene",
-    "clubName": "1.FSV Mainz 05",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 912438,
-    "fullName": "Tim Müller",
-    "clubName": "1.FSV Mainz 05",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 453016,
-    "fullName": "Anthony Caci",
-    "clubName": "1.FSV Mainz 05",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 168989,
-    "fullName": "Silvan Widmer",
-    "clubName": "1.FSV Mainz 05",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 344069,
-    "fullName": "Anton Stach",
-    "clubName": "1.FSV Mainz 05",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 247555,
-    "fullName": "Edimilson Fernandes",
-    "clubName": "1.FSV Mainz 05",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 93704,
-    "fullName": "Josuha Guilavogui",
-    "clubName": "1.FSV Mainz 05",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 357233,
-    "fullName": "Leandro Barreiro",
-    "clubName": "1.FSV Mainz 05",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 232454,
-    "fullName": "Nadiem Amiri",
-    "clubName": "1.FSV Mainz 05",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 405687,
-    "fullName": "Tom Krauß",
-    "clubName": "1.FSV Mainz 05",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 405689,
-    "fullName": "Merveille Papela",
-    "clubName": "1.FSV Mainz 05",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 314398,
-    "fullName": "Jae-sung Lee",
-    "clubName": "1.FSV Mainz 05",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 279009,
-    "fullName": "Marco Richter",
-    "clubName": "1.FSV Mainz 05",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 315332,
-    "fullName": "Aymen Barkok",
-    "clubName": "1.FSV Mainz 05",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 700106,
-    "fullName": "Brajan Gruda",
-    "clubName": "1.FSV Mainz 05",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 183720,
-    "fullName": "Anwar El Ghazi",
-    "clubName": "1.FSV Mainz 05",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 361508,
-    "fullName": "David Mamutovic",
-    "clubName": "1.FSV Mainz 05",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 333647,
-    "fullName": "Jonathan Burkardt",
-    "clubName": "1.FSV Mainz 05",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 796213,
-    "fullName": "Nelson Weiper",
-    "clubName": "1.FSV Mainz 05",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 283994,
-    "fullName": "Ludovic Ajorque",
-    "clubName": "1.FSV Mainz 05",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 119234,
-    "fullName": "Karim Onisiwo",
-    "clubName": "1.FSV Mainz 05",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 448177,
-    "fullName": "Jessic Ngankam",
-    "clubName": "1.FSV Mainz 05",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 698523,
-    "fullName": "Marcus Müller",
-    "clubName": "1.FSV Mainz 05",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 251299,
-    "fullName": "Finn Dahmen",
-    "clubName": "FC Augsburg",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 146714,
-    "fullName": "Tomas Koubek",
-    "clubName": "FC Augsburg",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 656250,
-    "fullName": "Marcel Lubik",
-    "clubName": "FC Augsburg",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 278343,
-    "fullName": "Felix Uduokhai",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 388363,
-    "fullName": "Maximilian Bauer",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 391742,
-    "fullName": "Patric Pfeiffer",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 106405,
-    "fullName": "Jeffrey Gouweleeuw",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 346478,
-    "fullName": "Japhet Tanganga",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 314295,
-    "fullName": "Reece Oxford",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 569349,
-    "fullName": "Frederik Winther",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 381260,
-    "fullName": "David Deger",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 520468,
-    "fullName": "Iago",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 288429,
-    "fullName": "Mads Pedersen",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 371000,
-    "fullName": "David Colina",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 183321,
-    "fullName": "Kevin Mbabu",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 353826,
-    "fullName": "Robert Gumny",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 146163,
-    "fullName": "Raphael Framberger",
-    "clubName": "FC Augsburg",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 374954,
-    "fullName": "Kristijan Jakic",
-    "clubName": "FC Augsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 251302,
-    "fullName": "Niklas Dorsch",
-    "clubName": "FC Augsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 569457,
-    "fullName": "Tim Breithaupt",
-    "clubName": "FC Augsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 730486,
-    "fullName": "Mahmut Kücüksahin",
-    "clubName": "FC Augsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 565435,
-    "fullName": "Arne Engels",
-    "clubName": "FC Augsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 296397,
-    "fullName": "Arne Maier",
-    "clubName": "FC Augsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 280575,
-    "fullName": "Elvis Rexhbecaj",
-    "clubName": "FC Augsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 730484,
-    "fullName": "Aaron Zehnter",
-    "clubName": "FC Augsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 249157,
-    "fullName": "Fredrik Jensen",
-    "clubName": "FC Augsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 263804,
-    "fullName": "Pep Biel",
-    "clubName": "FC Augsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 777005,
-    "fullName": "Mert Kömür",
-    "clubName": "FC Augsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 605572,
-    "fullName": "Daniel Hausmann",
-    "clubName": "FC Augsburg",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 345886,
-    "fullName": "Rubén Vargas",
-    "clubName": "FC Augsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 557614,
-    "fullName": "Nathanaël Mbuku",
-    "clubName": "FC Augsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 307052,
-    "fullName": "Masaya Okugawa",
-    "clubName": "FC Augsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 186988,
-    "fullName": "Sven Michel",
-    "clubName": "FC Augsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 335457,
-    "fullName": "Ermedin Demirovic",
-    "clubName": "FC Augsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 307924,
-    "fullName": "Mergim Berisha",
-    "clubName": "FC Augsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 288340,
-    "fullName": "Phillip Tietz",
-    "clubName": "FC Augsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 618350,
-    "fullName": "Dion Beljo",
-    "clubName": "FC Augsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 342226,
-    "fullName": "Irvin Cardona",
-    "clubName": "FC Augsburg",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 196813,
-    "fullName": "Michael Zetterer",
-    "clubName": "SV Werder Bremen",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 260053,
-    "fullName": "Jiri Pavlenka",
-    "clubName": "SV Werder Bremen",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 369258,
-    "fullName": "Dudu",
-    "clubName": "SV Werder Bremen",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 914853,
-    "fullName": "Spyros Angelidis",
-    "clubName": "SV Werder Bremen",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 156990,
-    "fullName": "Marco Friedl",
-    "clubName": "SV Werder Bremen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 162434,
-    "fullName": "Niklas Stark",
-    "clubName": "SV Werder Bremen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 202228,
-    "fullName": "Milos Veljkovic",
-    "clubName": "SV Werder Bremen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 334221,
-    "fullName": "Amos Pieper",
-    "clubName": "SV Werder Bremen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 830108,
-    "fullName": "Julián Malatini",
-    "clubName": "SV Werder Bremen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 58995,
-    "fullName": "Anthony Jung",
-    "clubName": "SV Werder Bremen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 117482,
-    "fullName": "Cimo Röcker",
-    "clubName": "SV Werder Bremen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 621802,
-    "fullName": "Olivier Deman",
-    "clubName": "SV Werder Bremen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 393512,
-    "fullName": "Felix Agu",
-    "clubName": "SV Werder Bremen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 119211,
-    "fullName": "Mitchell Weiser",
-    "clubName": "SV Werder Bremen",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 338668,
-    "fullName": "Senne Lynen",
-    "clubName": "SV Werder Bremen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 381753,
-    "fullName": "Ilia Gruev",
-    "clubName": "SV Werder Bremen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 855134,
-    "fullName": "Skelly Alvero",
-    "clubName": "SV Werder Bremen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 185427,
-    "fullName": "Nicolai Rapp",
-    "clubName": "SV Werder Bremen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 58396,
-    "fullName": "Christian Groß",
-    "clubName": "SV Werder Bremen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 289835,
-    "fullName": "Jens Stage",
-    "clubName": "SV Werder Bremen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 93844,
-    "fullName": "Leonardo Bittencourt",
-    "clubName": "SV Werder Bremen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 302215,
-    "fullName": "Naby Keïta",
-    "clubName": "SV Werder Bremen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 681740,
-    "fullName": "Jakob Löpping",
-    "clubName": "SV Werder Bremen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 346853,
-    "fullName": "Romano Schmid",
-    "clubName": "SV Werder Bremen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 670116,
-    "fullName": "Isak Hansen-Aarøen",
-    "clubName": "SV Werder Bremen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 825073,
-    "fullName": "Leon Opitz",
-    "clubName": "SV Werder Bremen",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 948548,
-    "fullName": "Kein Sato",
-    "clubName": "SV Werder Bremen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 596153,
-    "fullName": "Justin Njinmah",
-    "clubName": "SV Werder Bremen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 75489,
-    "fullName": "Niclas Füllkrug",
-    "clubName": "SV Werder Bremen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 125103,
-    "fullName": "Marvin Ducksch",
-    "clubName": "SV Werder Bremen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 323831,
-    "fullName": "Rafael Borré",
-    "clubName": "SV Werder Bremen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 455661,
-    "fullName": "Nick Woltemade",
-    "clubName": "SV Werder Bremen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 208167,
-    "fullName": "Dawid Kownacki",
-    "clubName": "SV Werder Bremen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 341317,
-    "fullName": "Oliver Burke",
-    "clubName": "SV Werder Bremen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 797563,
-    "fullName": "Joel Imasuen",
-    "clubName": "SV Werder Bremen",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 160929,
-    "fullName": "Marvin Schwäbe",
-    "clubName": "1.FC Köln",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 8246,
-    "fullName": "Philipp Pentke",
-    "clubName": "1.FC Köln",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 665971,
-    "fullName": "Jonas Nickisch",
-    "clubName": "1.FC Köln",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 227089,
-    "fullName": "Matthias Köbbing",
-    "clubName": "1.FC Köln",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 303219,
-    "fullName": "Jeff Chabot",
-    "clubName": "1.FC Köln",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 236981,
-    "fullName": "Timo Hübers",
-    "clubName": "1.FC Köln",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 384553,
-    "fullName": "Luca Kilian",
-    "clubName": "1.FC Köln",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 110036,
-    "fullName": "Dominique Heintz",
-    "clubName": "1.FC Köln",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 795762,
-    "fullName": "Elias Bakatukanda",
-    "clubName": "1.FC Köln",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 810649,
-    "fullName": "Max Finkgräfe",
-    "clubName": "1.FC Köln",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 107219,
-    "fullName": "Leart Paçarada",
-    "clubName": "1.FC Köln",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 331779,
-    "fullName": "Kristian Pedersen",
-    "clubName": "1.FC Köln",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 469949,
-    "fullName": "Noah Katterbach",
-    "clubName": "1.FC Köln",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 542697,
-    "fullName": "Rasmus Carstensen",
-    "clubName": "1.FC Köln",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 597000,
-    "fullName": "Eric Martel",
-    "clubName": "1.FC Köln",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 287188,
-    "fullName": "Dejan Ljubicic",
-    "clubName": "1.FC Köln",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 160968,
-    "fullName": "Benno Schmitz",
-    "clubName": "1.FC Köln",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 515017,
-    "fullName": "Jacob Christensen",
-    "clubName": "1.FC Köln",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 490581,
-    "fullName": "Mathias Olesen",
-    "clubName": "1.FC Köln",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 678479,
-    "fullName": "Denis Huseinbasic",
-    "clubName": "1.FC Köln",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 106270,
-    "fullName": "Florian Kainz",
-    "clubName": "1.FC Köln",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 335103,
-    "fullName": "Linton Maina",
-    "clubName": "1.FC Köln",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 456492,
-    "fullName": "Faride Alidou",
-    "clubName": "1.FC Köln",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 720162,
-    "fullName": "Justin Diehl",
-    "clubName": "1.FC Köln",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 472249,
-    "fullName": "Jan Thielmann",
-    "clubName": "1.FC Köln",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 324344,
-    "fullName": "Dimitrios Limnios",
-    "clubName": "1.FC Köln",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 178459,
-    "fullName": "Davie Selke",
-    "clubName": "1.FC Köln",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 196095,
-    "fullName": "Luca Waldschmidt",
-    "clubName": "1.FC Köln",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 820241,
-    "fullName": "Damion Downs",
-    "clubName": "1.FC Köln",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 296879,
-    "fullName": "Steffen Tigges",
-    "clubName": "1.FC Köln",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 112935,
-    "fullName": "Mark Uth",
-    "clubName": "1.FC Köln",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 125614,
-    "fullName": "Sargis Adamyan",
-    "clubName": "1.FC Köln",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 283871,
-    "fullName": "Florian Dietz",
-    "clubName": "1.FC Köln",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 43824,
-    "fullName": "Kevin Müller",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 57796,
-    "fullName": "Vitus Eicher",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 806948,
-    "fullName": "Frank Feller",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 519035,
-    "fullName": "Paul Tschernuth",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 227084,
-    "fullName": "Benedikt Gimber",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 133731,
-    "fullName": "Patrick Mainka",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 337092,
-    "fullName": "Tim Siersleben",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 485747,
-    "fullName": "Thomas Keller",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 192169,
-    "fullName": "Jonas Föhrenbach",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 824353,
-    "fullName": "Seedy Jarju",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 388294,
-    "fullName": "Omar Traoré",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 117478,
-    "fullName": "Marnon Busch",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 392710,
-    "fullName": "Lennard Maloney",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 31599,
-    "fullName": "Norman Theuerkauf",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 825971,
-    "fullName": "Luka Janes",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 581357,
-    "fullName": "Jan Schöppner",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 448028,
-    "fullName": "Kevin Sessa",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 184204,
-    "fullName": "Christian Kühlwetter",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 273669,
-    "fullName": "Adrian Beck",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 94030,
-    "fullName": "Denis Thomalla",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 342967,
-    "fullName": "Niklas Beste",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 645774,
-    "fullName": "Eren Dinkçi",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 191359,
-    "fullName": "Florian Pick",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 120189,
-    "fullName": "Nikola Dovedan",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 193033,
-    "fullName": "Tim Kleindienst",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 471055,
-    "fullName": "Marvin Pieringer",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 394033,
-    "fullName": "Stefan Schimmer",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 741149,
-    "fullName": "Elidon Qenaj",
-    "clubName": "1.FC Heidenheim 1846",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 40792,
-    "fullName": "Manuel Riemann",
-    "clubName": "VfL Bochum",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 348778,
-    "fullName": "Niclas Thiede",
-    "clubName": "VfL Bochum",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 41323,
-    "fullName": "Andreas Luthe",
-    "clubName": "VfL Bochum",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 61989,
-    "fullName": "Michael Esser",
-    "clubName": "VfL Bochum",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 930004,
-    "fullName": "Hugo Rölleke",
-    "clubName": "VfL Bochum",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 413843,
-    "fullName": "Keven Schlotterbeck",
-    "clubName": "VfL Bochum",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 364258,
-    "fullName": "Bernardo",
-    "clubName": "VfL Bochum",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 343959,
-    "fullName": "Erhan Masovic",
-    "clubName": "VfL Bochum",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 696164,
-    "fullName": "Tim Oermann",
-    "clubName": "VfL Bochum",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 118850,
-    "fullName": "Ivan Ordets",
-    "clubName": "VfL Bochum",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 265209,
-    "fullName": "Noah Loosli",
-    "clubName": "VfL Bochum",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 813730,
-    "fullName": "Mohammed Tolba",
-    "clubName": "VfL Bochum",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 196793,
-    "fullName": "Maximilian Wittek",
-    "clubName": "VfL Bochum",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 154396,
-    "fullName": "Danilo Soares",
-    "clubName": "VfL Bochum",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 452222,
-    "fullName": "Moritz Römling",
-    "clubName": "VfL Bochum",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 274461,
-    "fullName": "Felix Passlack",
-    "clubName": "VfL Bochum",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 121686,
-    "fullName": "Cristian Gamboa",
-    "clubName": "VfL Bochum",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 397099,
-    "fullName": "Jordi Osei-Tutu",
-    "clubName": "VfL Bochum",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 443331,
-    "fullName": "Patrick Osterhage",
-    "clubName": "VfL Bochum",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 111266,
-    "fullName": "Anthony Losilla",
-    "clubName": "VfL Bochum",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 204047,
-    "fullName": "Matus Bero",
-    "clubName": "VfL Bochum",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 316575,
-    "fullName": "Moritz-Broni Kwarteng",
-    "clubName": "VfL Bochum",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 505324,
-    "fullName": "Agon Elezi",
-    "clubName": "VfL Bochum",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 796221,
-    "fullName": "Mats Pannewig",
-    "clubName": "VfL Bochum",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 106872,
-    "fullName": "Kevin Stöger",
-    "clubName": "VfL Bochum",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 179635,
-    "fullName": "Philipp Förster",
-    "clubName": "VfL Bochum",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 334213,
-    "fullName": "Lukas Daschner",
-    "clubName": "VfL Bochum",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 289182,
-    "fullName": "Christopher Antwi-Adjei",
-    "clubName": "VfL Bochum",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 245744,
-    "fullName": "Takuma Asano",
-    "clubName": "VfL Bochum",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 406973,
-    "fullName": "Moritz Broschinski",
-    "clubName": "VfL Bochum",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 119037,
-    "fullName": "Philipp Hofmann",
-    "clubName": "VfL Bochum",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 181547,
-    "fullName": "Gonçalo Paciência",
-    "clubName": "VfL Bochum",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 79967,
-    "fullName": "Simon Zoller",
-    "clubName": "VfL Bochum",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 291422,
-    "fullName": "Lys Mousset",
-    "clubName": "VfL Bochum",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 93651,
-    "fullName": "Marcel Schuhen",
-    "clubName": "SV Darmstadt 98",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 146693,
-    "fullName": "Alexander Brunst",
-    "clubName": "SV Darmstadt 98",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 274039,
-    "fullName": "Morten Behrens",
-    "clubName": "SV Darmstadt 98",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 849390,
-    "fullName": "Max Wendt",
-    "clubName": "SV Darmstadt 98",
-    "position": "GK",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 346849,
-    "fullName": "Christoph Klarer",
-    "clubName": "SV Darmstadt 98",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 433388,
-    "fullName": "Matej Maglica",
-    "clubName": "SV Darmstadt 98",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 692070,
-    "fullName": "Clemens Riedel",
-    "clubName": "SV Darmstadt 98",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 77812,
-    "fullName": "Christoph Zimmermann",
-    "clubName": "SV Darmstadt 98",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 119286,
-    "fullName": "Jannik Müller",
-    "clubName": "SV Darmstadt 98",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 322075,
-    "fullName": "Thomas Isherwood",
-    "clubName": "SV Darmstadt 98",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 370998,
-    "fullName": "Bartol Franjic",
-    "clubName": "SV Darmstadt 98",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 286596,
-    "fullName": "Emir Karic",
-    "clubName": "SV Darmstadt 98",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 54846,
-    "fullName": "Fabian Holland",
-    "clubName": "SV Darmstadt 98",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 237162,
-    "fullName": "Matthias Bader",
-    "clubName": "SV Darmstadt 98",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 270027,
-    "fullName": "Frank Ronstadt",
-    "clubName": "SV Darmstadt 98",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 917014,
-    "fullName": "Asaf Arania",
-    "clubName": "SV Darmstadt 98",
-    "position": "D",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 438315,
-    "fullName": "Andreas Müller",
-    "clubName": "SV Darmstadt 98",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 57598,
-    "fullName": "Klaus Gjasula",
-    "clubName": "SV Darmstadt 98",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 94148,
-    "fullName": "Fabian Schnellhardt",
-    "clubName": "SV Darmstadt 98",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 42072,
-    "fullName": "Tobias Kempe",
-    "clubName": "SV Darmstadt 98",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 349433,
-    "fullName": "Fabian Nürnberger",
-    "clubName": "SV Darmstadt 98",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 237226,
-    "fullName": "Marvin Mehlem",
-    "clubName": "SV Darmstadt 98",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 324861,
-    "fullName": "Julian Justvan",
-    "clubName": "SV Darmstadt 98",
-    "position": "M",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 283497,
-    "fullName": "Mathias Honsak",
-    "clubName": "SV Darmstadt 98",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 190289,
-    "fullName": "Gerrit Holtmann",
-    "clubName": "SV Darmstadt 98",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 231590,
-    "fullName": "Braydon Manu",
-    "clubName": "SV Darmstadt 98",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 287920,
-    "fullName": "Tim Skarke",
-    "clubName": "SV Darmstadt 98",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 673071,
-    "fullName": "Oscar Vilhelmsson",
-    "clubName": "SV Darmstadt 98",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 388160,
-    "fullName": "Fraser Hornby",
-    "clubName": "SV Darmstadt 98",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 232463,
-    "fullName": "Luca Pfeiffer",
-    "clubName": "SV Darmstadt 98",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 464195,
-    "fullName": "Filip Stojilkovic",
-    "clubName": "SV Darmstadt 98",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 187499,
-    "fullName": "Aaron Seydel",
-    "clubName": "SV Darmstadt 98",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 60957,
-    "fullName": "Sebastian Polter",
-    "clubName": "SV Darmstadt 98",
-    "position": "F",
-    "league": "Bundesliga"
-  },
-  {
-    "playerId": 917015,
-    "fullName": "Fabio Torsiello",
-    "clubName": "SV Darmstadt 98",
-    "position": "F",
-    "league": "Bundesliga"
+    "fullName": "Чуквуэзе",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216293,
+    "fullName": "Трамони",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216292,
+    "fullName": "Нзола",
+    "clubName": "Пиза",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216121,
+    "fullName": "Исаксен",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216464,
+    "fullName": "Бельтран",
+    "clubName": "Фиорентина",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216495,
+    "fullName": "Маккенни",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215845,
+    "fullName": "Самарджич",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216325,
+    "fullName": "Лоренцо Пеллегрини",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216435,
+    "fullName": "Карлстрем",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216158,
+    "fullName": "Соттиль",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216324,
+    "fullName": "Куадио Коне",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216048,
+    "fullName": "Кутроне",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 215876,
+    "fullName": "Камбьяги",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215877,
+    "fullName": "Одгор",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215878,
+    "fullName": "Льюис Фергюсон",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 215879,
+    "fullName": "Фройлер",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216009,
+    "fullName": "Фолоруншо",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216120,
+    "fullName": "Деле-Баширу",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216326,
+    "fullName": "Эван Фергюсон",
+    "clubName": "Рома",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 216246,
+    "fullName": "Ондрейка",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215946,
+    "fullName": "Станчу",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216465,
+    "fullName": "Зом",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215972,
+    "fullName": "Аслани",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 215974,
+    "fullName": "Зелиньски",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215973,
+    "fullName": "Бонни",
+    "clubName": "Интер",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216173,
+    "fullName": "Адли",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216046,
+    "fullName": "Белотти",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216049,
+    "fullName": "Кюн",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216047,
+    "fullName": "Да Кунья",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216174,
+    "fullName": "Лофтус-Чик",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216175,
+    "fullName": "Риччи",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216176,
+    "fullName": "Фофана",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216092,
+    "fullName": "Вандепютте",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216009,
+    "fullName": "Фолоруншо",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216158,
+    "fullName": "Соттиль",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216461,
+    "fullName": "Додо",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216462,
+    "fullName": "Иконе",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216202,
+    "fullName": "Милинкович-Савич",
+    "clubName": "Наполи",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216245,
+    "fullName": "Эрнани",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216460,
+    "fullName": "Гозенс",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 5.6
+  },
+  {
+    "playerId": 216463,
+    "fullName": "Фаджоли",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216493,
+    "fullName": "Ди Грегорио",
+    "clubName": "Ювентус",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 215839,
+    "fullName": "Белланова",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 5.6
+  },
+  {
+    "playerId": 215840,
+    "fullName": "Брешианини",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215841,
+    "fullName": "Карнезекки",
+    "clubName": "Аталанта",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 215842,
+    "fullName": "Ибрагим Сулемана",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215843,
+    "fullName": "Камаль Сулемана",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215844,
+    "fullName": "Эль-Билаль Туре",
+    "clubName": "Аталанта",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216244,
+    "fullName": "Джурич",
+    "clubName": "Парма",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216118,
+    "fullName": "Нуну Тавареш",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216491,
+    "fullName": "Бремер",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216322,
+    "fullName": "Анхелиньо",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 4.9
+  },
+  {
+    "playerId": 215873,
+    "fullName": "Бернардески",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 215874,
+    "fullName": "Даллинга",
+    "clubName": "Болонья",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215875,
+    "fullName": "Домингес",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216434,
+    "fullName": "Ловрич",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216203,
+    "fullName": "Ррахмани",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216091,
+    "fullName": "Франко Васкес",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216119,
+    "fullName": "Ровелла",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216117,
+    "fullName": "Катальди",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216291,
+    "fullName": "Идрисса Туре",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216290,
+    "fullName": "Морео",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215915,
+    "fullName": "Суслов",
+    "clubName": "Верона",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216170,
+    "fullName": "Беннасер",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216172,
+    "fullName": "Яшари",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216171,
+    "fullName": "Муса",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216396,
+    "fullName": "Нгонж",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216395,
+    "fullName": "Гинейтис",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216398,
+    "fullName": "Симеоне",
+    "clubName": "Торино",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216397,
+    "fullName": "Санабрия",
+    "clubName": "Торино",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215942,
+    "fullName": "Гренбек",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215943,
+    "fullName": "Жуниор Мессиас",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215944,
+    "fullName": "Карбони",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215945,
+    "fullName": "Малиновский",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216459,
+    "fullName": "Брекало",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216201,
+    "fullName": "Мерет",
+    "clubName": "Наполи",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216200,
+    "fullName": "Ди Лоренцо",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 11.9
+  },
+  {
+    "playerId": 216494,
+    "fullName": "Камбьязо",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 5.6
+  },
+  {
+    "playerId": 216492,
+    "fullName": "Гатти",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 215966,
+    "fullName": "Бастони",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 215967,
+    "fullName": "Димарко",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 7.0
+  },
+  {
+    "playerId": 215968,
+    "fullName": "Думфрис",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 10.5
+  },
+  {
+    "playerId": 215969,
+    "fullName": "Залевски",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215970,
+    "fullName": "Зоммер",
+    "clubName": "Интер",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 4.9
+  },
+  {
+    "playerId": 215971,
+    "fullName": "Сучич",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216045,
+    "fullName": "Дувикас",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216044,
+    "fullName": "Батурина",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216199,
+    "fullName": "Буонджорно",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216323,
+    "fullName": "Свилар",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216007,
+    "fullName": "Кылычсой",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216008,
+    "fullName": "Себастьяно Эспозито",
+    "clubName": "Кальяри",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216157,
+    "fullName": "Пьеротти",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216155,
+    "fullName": "Кулибали",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216156,
+    "fullName": "Моренте",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216362,
+    "fullName": "Торстведт",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216154,
+    "fullName": "Хельгасон",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216360,
+    "fullName": "Мулаттьери",
+    "clubName": "Сассуоло",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216394,
+    "fullName": "Казадеи",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215835,
+    "fullName": "Дзаппакоста",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 216359,
+    "fullName": "Исмаэль Коне",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215868,
+    "fullName": "Хуан Миранда",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 215869,
+    "fullName": "Никола Моро",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215870,
+    "fullName": "Побега",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215871,
+    "fullName": "Скорупски",
+    "clubName": "Болонья",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215872,
+    "fullName": "Фаббиан",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216358,
+    "fullName": "Вольпато",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216315,
+    "fullName": "Бальданци",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216320,
+    "fullName": "Франса",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216319,
+    "fullName": "Пизилли",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215911,
+    "fullName": "Жиоване",
+    "clubName": "Верона",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215912,
+    "fullName": "Москера",
+    "clubName": "Верона",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215913,
+    "fullName": "Сарр",
+    "clubName": "Верона",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215914,
+    "fullName": "Сердар",
+    "clubName": "Верона",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216151,
+    "fullName": "Банда",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216152,
+    "fullName": "Бериша",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216169,
+    "fullName": "Эступиньян",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 216391,
+    "fullName": "Абухляль",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216393,
+    "fullName": "Иван Илич",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216392,
+    "fullName": "Анджорин",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215939,
+    "fullName": "Аарон Мартин",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 215940,
+    "fullName": "Витинья",
+    "clubName": "Дженоа",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215941,
+    "fullName": "Торсбю",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216316,
+    "fullName": "Бове",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216321,
+    "fullName": "Эль-Энауи",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216318,
+    "fullName": "Ндика",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216317,
+    "fullName": "Манчини",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216003,
+    "fullName": "Адопо",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216004,
+    "fullName": "Гаэтано",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216005,
+    "fullName": "Дейола",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216006,
+    "fullName": "Прати",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216153,
+    "fullName": "Рамадани",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216361,
+    "fullName": "Пьерини",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216168,
+    "fullName": "Меньян",
+    "clubName": "Милан",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 5.6
+  },
+  {
+    "playerId": 216457,
+    "fullName": "Раньери",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215961,
+    "fullName": "Ачерби",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 215962,
+    "fullName": "Дармиан",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215963,
+    "fullName": "Карлос Аугусто",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215964,
+    "fullName": "Павар",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215965,
+    "fullName": "Франческо Эспозито",
+    "clubName": "Интер",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216154,
+    "fullName": "Хельгасон",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216455,
+    "fullName": "Де Хеа",
+    "clubName": "Фиорентина",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 9.8
+  },
+  {
+    "playerId": 216393,
+    "fullName": "Иван Илич",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216003,
+    "fullName": "Адопо",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216004,
+    "fullName": "Гаэтано",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216005,
+    "fullName": "Дейола",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216006,
+    "fullName": "Прати",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216167,
+    "fullName": "Габбия",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216316,
+    "fullName": "Бове",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216315,
+    "fullName": "Бальданци",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216319,
+    "fullName": "Пизилли",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216317,
+    "fullName": "Манчини",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216321,
+    "fullName": "Эль-Энауи",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216320,
+    "fullName": "Франса",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216359,
+    "fullName": "Исмаэль Коне",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216041,
+    "fullName": "Какре",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216042,
+    "fullName": "Бенжамен Коне",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216043,
+    "fullName": "Энгельхардт",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216392,
+    "fullName": "Анджорин",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216391,
+    "fullName": "Абухляль",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216196,
+    "fullName": "Бекема",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216197,
+    "fullName": "Оливера",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216429,
+    "fullName": "Байо",
+    "clubName": "Удинезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216430,
+    "fullName": "Бреннер",
+    "clubName": "Удинезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216433,
+    "fullName": "Эккеленкамп",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216432,
+    "fullName": "Санчес",
+    "clubName": "Удинезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216087,
+    "fullName": "Бонаццоли",
+    "clubName": "Кремонезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216088,
+    "fullName": "Де Лука",
+    "clubName": "Кремонезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216089,
+    "fullName": "Дзербин",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216090,
+    "fullName": "Юнсен",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216454,
+    "fullName": "Барак",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216487,
+    "fullName": "Дуглас Луис",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216489,
+    "fullName": "Костич",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216488,
+    "fullName": "Калулу",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216113,
+    "fullName": "Весино",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216114,
+    "fullName": "Ладзари",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216115,
+    "fullName": "Марушич",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216116,
+    "fullName": "Проведель",
+    "clubName": "Лацио",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216313,
+    "fullName": "Челик",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216311,
+    "fullName": "Дарбо",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215833,
+    "fullName": "Джимшити",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 215834,
+    "fullName": "Коссуну",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215863,
+    "fullName": "Карлссон",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215864,
+    "fullName": "Ликояннис",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215865,
+    "fullName": "Лукуми",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215866,
+    "fullName": "Пош",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215867,
+    "fullName": "Хольм",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216286,
+    "fullName": "Хойхольт",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215906,
+    "fullName": "Ливраменто",
+    "clubName": "Верона",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215907,
+    "fullName": "Ньяссе",
+    "clubName": "Верона",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215908,
+    "fullName": "Сантьяго",
+    "clubName": "Верона",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215909,
+    "fullName": "Тшатшуа",
+    "clubName": "Верона",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 215910,
+    "fullName": "Харруи",
+    "clubName": "Верона",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216356,
+    "fullName": "Лука Моро",
+    "clubName": "Сассуоло",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 215929,
+    "fullName": "Хоан Васкес",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215930,
+    "fullName": "де Винтер",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215931,
+    "fullName": "Коломбо",
+    "clubName": "Дженоа",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 215932,
+    "fullName": "Леали",
+    "clubName": "Дженоа",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215933,
+    "fullName": "Мазини",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215934,
+    "fullName": "Пападопулос",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215935,
+    "fullName": "Фини",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215936,
+    "fullName": "Экубан",
+    "clubName": "Дженоа",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215937,
+    "fullName": "Эллертссон",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215938,
+    "fullName": "Эхатор",
+    "clubName": "Дженоа",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216164,
+    "fullName": "Павлович",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 215996,
+    "fullName": "Винчигерра",
+    "clubName": "Кальяри",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215997,
+    "fullName": "Дзортеа",
+    "clubName": "Кальяри",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215998,
+    "fullName": "Лувумбу",
+    "clubName": "Кальяри",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215999,
+    "fullName": "Маццителли",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216000,
+    "fullName": "Паволетти",
+    "clubName": "Кальяри",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216001,
+    "fullName": "Рог",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216002,
+    "fullName": "Феличи",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216166,
+    "fullName": "Алехандро Хименес",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216314,
+    "fullName": "Эрмосо",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216357,
+    "fullName": "Фадера",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216355,
+    "fullName": "Гион",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216354,
+    "fullName": "Болока",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216353,
+    "fullName": "Альварес",
+    "clubName": "Сассуоло",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216033,
+    "fullName": "Алли",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216034,
+    "fullName": "Бюте",
+    "clubName": "Комо",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216035,
+    "fullName": "Войвода",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216036,
+    "fullName": "Гольданига",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216037,
+    "fullName": "Кемпф",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216038,
+    "fullName": "Перроне",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216039,
+    "fullName": "Серджи Роберто",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216040,
+    "fullName": "Черри",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216312,
+    "fullName": "Сольбаккен",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216165,
+    "fullName": "Томори",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216384,
+    "fullName": "Бираги",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216388,
+    "fullName": "Мазина",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216387,
+    "fullName": "Лазаро",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216386,
+    "fullName": "Коко",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216390,
+    "fullName": "Нджи",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216389,
+    "fullName": "Марипан",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215999,
+    "fullName": "Маццителли",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216000,
+    "fullName": "Паволетти",
+    "clubName": "Кальяри",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216001,
+    "fullName": "Рог",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216002,
+    "fullName": "Феличи",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216033,
+    "fullName": "Алли",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216034,
+    "fullName": "Бюте",
+    "clubName": "Комо",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216035,
+    "fullName": "Войвода",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216036,
+    "fullName": "Гольданига",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216037,
+    "fullName": "Кемпф",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216038,
+    "fullName": "Перроне",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216039,
+    "fullName": "Серджи Роберто",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216040,
+    "fullName": "Черри",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216313,
+    "fullName": "Челик",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216312,
+    "fullName": "Сольбаккен",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216314,
+    "fullName": "Эрмосо",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216311,
+    "fullName": "Дарбо",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216310,
+    "fullName": "Гиларди",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216284,
+    "fullName": "Мейстер",
+    "clubName": "Пиза",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216079,
+    "fullName": "Афена-Гьян",
+    "clubName": "Кремонезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216080,
+    "fullName": "Бондо",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216081,
+    "fullName": "Грасси",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216082,
+    "fullName": "Дзанимаккья",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216083,
+    "fullName": "Кастаньетти",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216084,
+    "fullName": "Коллоколо",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216085,
+    "fullName": "Окереке",
+    "clubName": "Кремонезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216086,
+    "fullName": "Пикель",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216390,
+    "fullName": "Нджи",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216449,
+    "fullName": "Монтенегро",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216355,
+    "fullName": "Гион",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216354,
+    "fullName": "Болока",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216357,
+    "fullName": "Фадера",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216356,
+    "fullName": "Лука Моро",
+    "clubName": "Сассуоло",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216106,
+    "fullName": "Белаэн",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216107,
+    "fullName": "Канчельери",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216108,
+    "fullName": "Мандас",
+    "clubName": "Лацио",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216109,
+    "fullName": "Лука Пеллегрини",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216110,
+    "fullName": "Романьоли",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216111,
+    "fullName": "Серра",
+    "clubName": "Лацио",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216112,
+    "fullName": "Хила",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216452,
+    "fullName": "Ричардсон",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216279,
+    "fullName": "Акинсанмиро",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216427,
+    "fullName": "Миллер",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216426,
+    "fullName": "Атта",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216144,
+    "fullName": "Галло",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216145,
+    "fullName": "Жослен",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216146,
+    "fullName": "Камарда",
+    "clubName": "Лечче",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216147,
+    "fullName": "Мале",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216148,
+    "fullName": "Пьерре",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216149,
+    "fullName": "Рафья",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216150,
+    "fullName": "Фальконе",
+    "clubName": "Лечче",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216428,
+    "fullName": "Пайеро",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216164,
+    "fullName": "Павлович",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 216165,
+    "fullName": "Томори",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216166,
+    "fullName": "Алехандро Хименес",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216283,
+    "fullName": "Марин",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216483,
+    "fullName": "Жоау Мариу",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216482,
+    "fullName": "Артур",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216486,
+    "fullName": "Савона",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216485,
+    "fullName": "Перин",
+    "clubName": "Ювентус",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216484,
+    "fullName": "Келли",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216192,
+    "fullName": "Гилмор",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216193,
+    "fullName": "Жезус",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216194,
+    "fullName": "Маццокки",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216195,
+    "fullName": "Шеддира",
+    "clubName": "Наполи",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216282,
+    "fullName": "Вурал",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216281,
+    "fullName": "Виньято",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216305,
+    "fullName": "Керубини",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215827,
+    "fullName": "Джоване",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215920,
+    "fullName": "Анкейе",
+    "clubName": "Дженоа",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215921,
+    "fullName": "Араму",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 5.6
+  },
+  {
+    "playerId": 215922,
+    "fullName": "Бохинен",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 215924,
+    "fullName": "Вольякко",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 215925,
+    "fullName": "Куэнка",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215926,
+    "fullName": "Нортон-Каффи",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215927,
+    "fullName": "Сабелли",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215928,
+    "fullName": "Эстигор",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216307,
+    "fullName": "Ренсх",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216309,
+    "fullName": "Салах-Эддин",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216020,
+    "fullName": "Браунедер",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216021,
+    "fullName": "Валье",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216023,
+    "fullName": "Габриэллони",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216024,
+    "fullName": "Джасим",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216025,
+    "fullName": "Доссена",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216026,
+    "fullName": "Керриган",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216028,
+    "fullName": "Маццалья",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216029,
+    "fullName": "Рази",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216030,
+    "fullName": "Рамон",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216031,
+    "fullName": "Родригес",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216032,
+    "fullName": "Смолчич",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216308,
+    "fullName": "Романо",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216306,
+    "fullName": "Кумбула",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216304,
+    "fullName": "Абдельхамид",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216067,
+    "fullName": "Ачелла",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216068,
+    "fullName": "Баскиротто",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216069,
+    "fullName": "Брамбилла",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216070,
+    "fullName": "Бьянкетти",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216071,
+    "fullName": "Валоти",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216072,
+    "fullName": "Лордкипанидзе",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216073,
+    "fullName": "Мамона",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216074,
+    "fullName": "Миланезе",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216422,
+    "fullName": "Сава",
+    "clubName": "Удинезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216015,
+    "fullName": "Абильгор",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 5.6
+  },
+  {
+    "playerId": 216016,
+    "fullName": "Аддай",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216017,
+    "fullName": "Альберто Морено",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216018,
+    "fullName": "Асон",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 216019,
+    "fullName": "Балле",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216020,
+    "fullName": "Браунедер",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216021,
+    "fullName": "Валье",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216022,
+    "fullName": "ван дер Бремпт",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216023,
+    "fullName": "Габриэллони",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216024,
+    "fullName": "Джасим",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216025,
+    "fullName": "Доссена",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216026,
+    "fullName": "Керриган",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216027,
+    "fullName": "Ковачик",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216028,
+    "fullName": "Маццалья",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216029,
+    "fullName": "Рази",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216030,
+    "fullName": "Рамон",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216031,
+    "fullName": "Родригес",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216032,
+    "fullName": "Смолчич",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216425,
+    "fullName": "Эхизибуэ",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216421,
+    "fullName": "Писарро",
+    "clubName": "Удинезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216420,
+    "fullName": "Петровски",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216424,
+    "fullName": "Соле",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216441,
+    "fullName": "Бьянко",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216443,
+    "fullName": "Куадио",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216442,
+    "fullName": "Инфантино",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216067,
+    "fullName": "Ачелла",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216068,
+    "fullName": "Баскиротто",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216069,
+    "fullName": "Брамбилла",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216070,
+    "fullName": "Бьянкетти",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216071,
+    "fullName": "Валоти",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216072,
+    "fullName": "Лордкипанидзе",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216073,
+    "fullName": "Мамона",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216074,
+    "fullName": "Миланезе",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216075,
+    "fullName": "Насти",
+    "clubName": "Кремонезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216137,
+    "fullName": "Гильбер",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216138,
+    "fullName": "Данилу Вейга",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216140,
+    "fullName": "Мархвиньски",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216141,
+    "fullName": "Ндаба",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216142,
+    "fullName": "Уден",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216143,
+    "fullName": "Фатиканти",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216381,
+    "fullName": "Схюрс",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216162,
+    "fullName": "Лазетич",
+    "clubName": "Милан",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216163,
+    "fullName": "Пьетро Терраччано",
+    "clubName": "Милан",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216186,
+    "fullName": "Амброзино",
+    "clubName": "Наполи",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 4.9
+  },
+  {
+    "playerId": 216187,
+    "fullName": "Вергара",
+    "clubName": "Наполи",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216188,
+    "fullName": "Дзаноли",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216189,
+    "fullName": "Каюсте",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216190,
+    "fullName": "Марьянуччи",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216191,
+    "fullName": "Хаса",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216216,
+    "fullName": "Балог",
+    "clubName": "Парма",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216217,
+    "fullName": "Валенти",
+    "clubName": "Парма",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216218,
+    "fullName": "Ковальски",
+    "clubName": "Парма",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216219,
+    "fullName": "Куда",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216220,
+    "fullName": "Левик",
+    "clubName": "Парма",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216221,
+    "fullName": "Леони",
+    "clubName": "Парма",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216222,
+    "fullName": "Миколаевски",
+    "clubName": "Парма",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216223,
+    "fullName": "Ндиайе",
+    "clubName": "Парма",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216224,
+    "fullName": "Партипило",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216225,
+    "fullName": "Пликко",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216226,
+    "fullName": "Трабукки",
+    "clubName": "Парма",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216227,
+    "fullName": "Чиркати",
+    "clubName": "Парма",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216228,
+    "fullName": "Шитс",
+    "clubName": "Парма",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216229,
+    "fullName": "Эно",
+    "clubName": "Парма",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216230,
+    "fullName": "Эстевес",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216409,
+    "fullName": "Браво",
+    "clubName": "Удинезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216408,
+    "fullName": "Балларини",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216411,
+    "fullName": "Де Паоли",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216413,
+    "fullName": "Кабаселе",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216412,
+    "fullName": "Земура",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216410,
+    "fullName": "Гогличидзе",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216414,
+    "fullName": "Абдулай Камара",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216423,
+    "fullName": "Саррага",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216261,
+    "fullName": "Ангори",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216262,
+    "fullName": "Арена",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 5.6
+  },
+  {
+    "playerId": 216263,
+    "fullName": "Буффон",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216264,
+    "fullName": "Джани",
+    "clubName": "Пиза",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216265,
+    "fullName": "Дубицкас",
+    "clubName": "Пиза",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216266,
+    "fullName": "Дурмуш",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216267,
+    "fullName": "Евшенак",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216268,
+    "fullName": "Канестрелли",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216269,
+    "fullName": "Караччоло",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216270,
+    "fullName": "Леончини",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216271,
+    "fullName": "Лерис",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216272,
+    "fullName": "Паванелло",
+    "clubName": "Пиза",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216273,
+    "fullName": "Райчев",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216274,
+    "fullName": "Расмуссен",
+    "clubName": "Пиза",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216275,
+    "fullName": "Маттиа Сала",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216276,
+    "fullName": "Този",
+    "clubName": "Пиза",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216277,
+    "fullName": "Трдан",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216278,
+    "fullName": "Шемпер",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216419,
+    "fullName": "Пейичич",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216417,
+    "fullName": "Окойе",
+    "clubName": "Удинезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216416,
+    "fullName": "Модешту",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216415,
+    "fullName": "Хассан Камара",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216304,
+    "fullName": "Абдельхамид",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216305,
+    "fullName": "Керубини",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216306,
+    "fullName": "Кумбула",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216307,
+    "fullName": "Ренсх",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216308,
+    "fullName": "Романо",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216276,
+    "fullName": "Този",
+    "clubName": "Пиза",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216277,
+    "fullName": "Трдан",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216278,
+    "fullName": "Шемпер",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216441,
+    "fullName": "Бьянко",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216304,
+    "fullName": "Абдельхамид",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216305,
+    "fullName": "Керубини",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216306,
+    "fullName": "Кумбула",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216307,
+    "fullName": "Ренсх",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216308,
+    "fullName": "Романо",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216309,
+    "fullName": "Салах-Эддин",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216443,
+    "fullName": "Куадио",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216341,
+    "fullName": "Дойг",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216342,
+    "fullName": "Идзес",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216343,
+    "fullName": "Калигара",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216344,
+    "fullName": "Кнезович",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216345,
+    "fullName": "Липани",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216346,
+    "fullName": "Одентал",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216347,
+    "fullName": "Еферсон Пас",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216348,
+    "fullName": "Пьераньоло",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216349,
+    "fullName": "Скьеллеруп",
+    "clubName": "Сассуоло",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216350,
+    "fullName": "Турати",
+    "clubName": "Сассуоло",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216351,
+    "fullName": "Чьерво",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216352,
+    "fullName": "Яннони",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216425,
+    "fullName": "Эхизибуэ",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216479,
+    "fullName": "Ругани",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216478,
+    "fullName": "Пьетрелли",
+    "clubName": "Ювентус",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216477,
+    "fullName": "Кабаль",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216374,
+    "fullName": "Ди Марко",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216375,
+    "fullName": "Илкхан",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216376,
+    "fullName": "Исмайли",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216377,
+    "fullName": "Педерсен",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216378,
+    "fullName": "Перчун",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216379,
+    "fullName": "Раути",
+    "clubName": "Торино",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216380,
+    "fullName": "Савва",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216381,
+    "fullName": "Схюрс",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216382,
+    "fullName": "Тамез",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216383,
+    "fullName": "Чаммальикелла",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216476,
+    "fullName": "Аджич",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216424,
+    "fullName": "Соле",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216423,
+    "fullName": "Саррага",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216422,
+    "fullName": "Сава",
+    "clubName": "Удинезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216408,
+    "fullName": "Балларини",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216409,
+    "fullName": "Браво",
+    "clubName": "Удинезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216410,
+    "fullName": "Гогличидзе",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216411,
+    "fullName": "Де Паоли",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216412,
+    "fullName": "Земура",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216413,
+    "fullName": "Кабаселе",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216414,
+    "fullName": "Абдулай Камара",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216415,
+    "fullName": "Хассан Камара",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216416,
+    "fullName": "Модешту",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216417,
+    "fullName": "Окойе",
+    "clubName": "Удинезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216418,
+    "fullName": "Пафунди",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216419,
+    "fullName": "Пейичич",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216420,
+    "fullName": "Петровски",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216421,
+    "fullName": "Писарро",
+    "clubName": "Удинезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 215822,
+    "fullName": "Джованни Бонфанти",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215856,
+    "fullName": "Эрлич",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215890,
+    "fullName": "Тоньоло",
+    "clubName": "Верона",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 215916,
+    "fullName": "Зигрист",
+    "clubName": "Дженоа",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 215917,
+    "fullName": "Маркандалли",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 215918,
+    "fullName": "Отоа",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216011,
+    "fullName": "Вигорито",
+    "clubName": "Комо",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216012,
+    "fullName": "Кассандро",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216013,
+    "fullName": "Марко Сала",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216014,
+    "fullName": "Феллипе Джек",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216053,
+    "fullName": "Аудеро",
+    "clubName": "Кремонезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 14.7
+  },
+  {
+    "playerId": 216054,
+    "fullName": "Ацци",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 9.1
+  },
+  {
+    "playerId": 216055,
+    "fullName": "Барбьери",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 5.6
+  },
+  {
+    "playerId": 216056,
+    "fullName": "Маловец",
+    "clubName": "Кремонезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216057,
+    "fullName": "Моретти",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216058,
+    "fullName": "Нава",
+    "clubName": "Кремонезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216059,
+    "fullName": "Павези",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216060,
+    "fullName": "Раванелли",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216061,
+    "fullName": "Роккетти",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216062,
+    "fullName": "Саро",
+    "clubName": "Кремонезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216063,
+    "fullName": "Серникола",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216064,
+    "fullName": "Флориани",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216213,
+    "fullName": "Аморан",
+    "clubName": "Парма",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 9.8
+  },
+  {
+    "playerId": 216214,
+    "fullName": "Корви",
+    "clubName": "Парма",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216215,
+    "fullName": "Ринальди",
+    "clubName": "Парма",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216247,
+    "fullName": "Беруатто",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216248,
+    "fullName": "Вукович",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216249,
+    "fullName": "Гуаданьо",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216250,
+    "fullName": "Денун",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216251,
+    "fullName": "Калабрези",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216252,
+    "fullName": "Коппола",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216253,
+    "fullName": "Ливьери",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216254,
+    "fullName": "Лория",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216255,
+    "fullName": "Лузуарди",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216256,
+    "fullName": "Николас",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216257,
+    "fullName": "Рус",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216259,
+    "fullName": "Томаш Эштевеш",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216260,
+    "fullName": "Шапола",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216294,
+    "fullName": "Боер",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216295,
+    "fullName": "Девис Васкес",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216296,
+    "fullName": "Голлини",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216297,
+    "fullName": "Де Марци",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216298,
+    "fullName": "Железный",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216299,
+    "fullName": "Маркаччини",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216300,
+    "fullName": "Нардин",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216058,
+    "fullName": "Нава",
+    "clubName": "Кремонезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216059,
+    "fullName": "Павези",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216060,
+    "fullName": "Раванелли",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216061,
+    "fullName": "Роккетти",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216062,
+    "fullName": "Саро",
+    "clubName": "Кремонезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216063,
+    "fullName": "Серникола",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216064,
+    "fullName": "Флориани",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216065,
+    "fullName": "Фолино",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216066,
+    "fullName": "Чеккерини",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216093,
+    "fullName": "Каменович",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216094,
+    "fullName": "Фарес",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216095,
+    "fullName": "Фурланетто",
+    "clubName": "Лацио",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216128,
+    "fullName": "Борбей",
+    "clubName": "Лечче",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216129,
+    "fullName": "Габриэл",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216130,
+    "fullName": "Жан",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216131,
+    "fullName": "Куасси",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216132,
+    "fullName": "Самооя",
+    "clubName": "Лечче",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216133,
+    "fullName": "Фрюхтль",
+    "clubName": "Лечче",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216134,
+    "fullName": "Себастьян Эспозито",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216160,
+    "fullName": "Бартезаги",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 4.2
+  },
+  {
+    "playerId": 216161,
+    "fullName": "Торрьяни",
+    "clubName": "Милан",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216184,
+    "fullName": "Контини-Барановский",
+    "clubName": "Наполи",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216185,
+    "fullName": "Обаретин",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216213,
+    "fullName": "Аморан",
+    "clubName": "Парма",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 9.8
+  },
+  {
+    "playerId": 216214,
+    "fullName": "Корви",
+    "clubName": "Парма",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216215,
+    "fullName": "Ринальди",
+    "clubName": "Парма",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216247,
+    "fullName": "Беруатто",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216248,
+    "fullName": "Вукович",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216249,
+    "fullName": "Гуаданьо",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216250,
+    "fullName": "Денун",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216251,
+    "fullName": "Калабрези",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216252,
+    "fullName": "Коппола",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216253,
+    "fullName": "Ливьери",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216254,
+    "fullName": "Лория",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216255,
+    "fullName": "Лузуарди",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216256,
+    "fullName": "Николас",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216257,
+    "fullName": "Рус",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216258,
+    "fullName": "Скуффет",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 216259,
+    "fullName": "Томаш Эштевеш",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216260,
+    "fullName": "Шапола",
+    "clubName": "Пиза",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216294,
+    "fullName": "Боер",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216295,
+    "fullName": "Девис Васкес",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216296,
+    "fullName": "Голлини",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216297,
+    "fullName": "Де Марци",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216298,
+    "fullName": "Железный",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216299,
+    "fullName": "Маркаччини",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216300,
+    "fullName": "Нардин",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216301,
+    "fullName": "Оливерас",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216302,
+    "fullName": "Реале",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216303,
+    "fullName": "Сангаре",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216332,
+    "fullName": "Валюкевич",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216333,
+    "fullName": "Дзакки",
+    "clubName": "Сассуоло",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216334,
+    "fullName": "Канде",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216335,
+    "fullName": "Кевин Миранда",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216336,
+    "fullName": "Миссори",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216337,
+    "fullName": "Мухаремович",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216338,
+    "fullName": "Романья",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216339,
+    "fullName": "Руссо",
+    "clubName": "Сассуоло",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216340,
+    "fullName": "Саталино",
+    "clubName": "Сассуоло",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216366,
+    "fullName": "Беэй",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216367,
+    "fullName": "Бьяне-Балько",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216368,
+    "fullName": "Дембеле",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216369,
+    "fullName": "Доннарумма",
+    "clubName": "Торино",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216370,
+    "fullName": "Маллен",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216371,
+    "fullName": "Палеари",
+    "clubName": "Торино",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216372,
+    "fullName": "Попа",
+    "clubName": "Торино",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216373,
+    "fullName": "Сазонов",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216402,
+    "fullName": "Бертола",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 216403,
+    "fullName": "Джанетти",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216404,
+    "fullName": "Кристенсен",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216405,
+    "fullName": "Нунцианте",
+    "clubName": "Удинезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216406,
+    "fullName": "Паделли",
+    "clubName": "Удинезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216407,
+    "fullName": "Пальма",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216436,
+    "fullName": "Кошпо",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 216437,
+    "fullName": "Ледзерини",
+    "clubName": "Фиорентина",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 216438,
+    "fullName": "Леонарделли",
+    "clubName": "Фиорентина",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216439,
+    "fullName": "Мартинелли",
+    "clubName": "Фиорентина",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216440,
+    "fullName": "Фортини",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216470,
+    "fullName": "Факундо Гонсалес",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 216471,
+    "fullName": "Пинсольо",
+    "clubName": "Ювентус",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216472,
+    "fullName": "Рухи",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216473,
+    "fullName": "Скалья",
+    "clubName": "Ювентус",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216474,
+    "fullName": "Фускальдо",
+    "clubName": "Ювентус",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0
+  },
+  {
+    "playerId": 216475,
+    "fullName": "Хиль",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213183,
+    "fullName": "Кейн",
+    "clubName": "Бавария",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 11.5,
+    "popularity": 58.7
+  },
+  {
+    "playerId": 213182,
+    "fullName": "Олисе",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 11.0,
+    "popularity": 40.8
+  },
+  {
+    "playerId": 213239,
+    "fullName": "Гирасси",
+    "clubName": "Боруссия Д",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 10.5,
+    "popularity": 37.5
+  },
+  {
+    "playerId": 213181,
+    "fullName": "Мусиала",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 10.5,
+    "popularity": 8.4
+  },
+  {
+    "playerId": 213444,
+    "fullName": "Симонс",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 10.0,
+    "popularity": 7.6
+  },
+  {
+    "playerId": 213207,
+    "fullName": "Шик",
+    "clubName": "Байер",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 9.0,
+    "popularity": 14.2
+  },
+  {
+    "playerId": 213238,
+    "fullName": "Адейеми",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 9.0,
+    "popularity": 12.4
+  },
+  {
+    "playerId": 213618,
+    "fullName": "Ундав",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 9.0,
+    "popularity": 8.8
+  },
+  {
+    "playerId": 213443,
+    "fullName": "Шешко",
+    "clubName": "РБ Лейпциг",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 9.0,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 213180,
+    "fullName": "Диас",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 9.0,
+    "popularity": 16.6
+  },
+  {
+    "playerId": 213237,
+    "fullName": "Брандт",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 8.5,
+    "popularity": 8.6
+  },
+  {
+    "playerId": 213442,
+    "fullName": "Опенда",
+    "clubName": "РБ Лейпциг",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 8.5,
+    "popularity": 10.0
+  },
+  {
+    "playerId": 213533,
+    "fullName": "Доан",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 8.5,
+    "popularity": 6.1
+  },
+  {
+    "playerId": 213268,
+    "fullName": "Кляйндинст",
+    "clubName": "Боруссия М",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 8.5,
+    "popularity": 8.8
+  },
+  {
+    "playerId": 213206,
+    "fullName": "Тилльман",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 5.7
+  },
+  {
+    "playerId": 213532,
+    "fullName": "Грифо",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 9.7
+  },
+  {
+    "playerId": 213236,
+    "fullName": "Байер",
+    "clubName": "Боруссия Д",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213591,
+    "fullName": "Крамарич",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 11.6
+  },
+  {
+    "playerId": 213127,
+    "fullName": "Буркардт",
+    "clubName": "Айнтрахт Ф",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 15.2
+  },
+  {
+    "playerId": 213205,
+    "fullName": "Бонифасе",
+    "clubName": "Байер",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 9.2
+  },
+  {
+    "playerId": 213617,
+    "fullName": "Вольтемаде",
+    "clubName": "Штутгарт",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 9.2
+  },
+  {
+    "playerId": 213441,
+    "fullName": "Бакайоко",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 5.7
+  },
+  {
+    "playerId": 213204,
+    "fullName": "Телла",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213406,
+    "fullName": "Небель",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 4.1
+  },
+  {
+    "playerId": 213266,
+    "fullName": "Онора",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 3.0
+  },
+  {
+    "playerId": 213235,
+    "fullName": "Беллингем",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 27.0
+  },
+  {
+    "playerId": 213616,
+    "fullName": "Демирович",
+    "clubName": "Штутгарт",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 3.2
+  },
+  {
+    "playerId": 213126,
+    "fullName": "Батшуайи",
+    "clubName": "Айнтрахт Ф",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 3.0
+  },
+  {
+    "playerId": 213440,
+    "fullName": "Нуса",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 3.0
+  },
+  {
+    "playerId": 213404,
+    "fullName": "Амири",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 7.8
+  },
+  {
+    "playerId": 213405,
+    "fullName": "Ли Чжэ Сон",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 213265,
+    "fullName": "Матино",
+    "clubName": "Боруссия М",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213321,
+    "fullName": "Амура",
+    "clubName": "Вольфсбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 3.7
+  },
+  {
+    "playerId": 213177,
+    "fullName": "Гнабри",
+    "clubName": "Бавария",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 213178,
+    "fullName": "Киммих",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 17.5
+  },
+  {
+    "playerId": 213179,
+    "fullName": "Коман",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 213267,
+    "fullName": "Хак",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 2.2
+  },
+  {
+    "playerId": 213201,
+    "fullName": "Адли",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 4.5
+  },
+  {
+    "playerId": 213234,
+    "fullName": "Гросс",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 5.4
+  },
+  {
+    "playerId": 213264,
+    "fullName": "Штегер",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213531,
+    "fullName": "Хелер",
+    "clubName": "Фрайбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213614,
+    "fullName": "Фюрих",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213123,
+    "fullName": "Ваи",
+    "clubName": "Айнтрахт Ф",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 2.6
+  },
+  {
+    "playerId": 213124,
+    "fullName": "Кнауфф",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 3.3
+  },
+  {
+    "playerId": 213125,
+    "fullName": "Узун",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213203,
+    "fullName": "Терье",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213613,
+    "fullName": "Левелинг",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 213292,
+    "fullName": "Дукш",
+    "clubName": "Вердер",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 213294,
+    "fullName": "Романо Шмид",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213293,
+    "fullName": "Стаге",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 3.1
+  },
+  {
+    "playerId": 213403,
+    "fullName": "Холлербах",
+    "clubName": "Майнц",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213156,
+    "fullName": "Клод-Морис",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213202,
+    "fullName": "Алеиш Гарсия",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213318,
+    "fullName": "Винд",
+    "clubName": "Вольфсбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 2.9
+  },
+  {
+    "playerId": 213317,
+    "fullName": "Виммер",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 213319,
+    "fullName": "Маер",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 213320,
+    "fullName": "Черны",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213175,
+    "fullName": "Бисхоф",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213176,
+    "fullName": "Горетцка",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 213615,
+    "fullName": "Штиллер",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 5.3
+  },
+  {
+    "playerId": 213200,
+    "fullName": "Хофманн",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213199,
+    "fullName": "Гримальдо",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 32.0
+  },
+  {
+    "playerId": 213471,
+    "fullName": "Ирвайн",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213233,
+    "fullName": "Нмеча",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213530,
+    "fullName": "Шерхант",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213529,
+    "fullName": "Судзуки",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213590,
+    "fullName": "Гложек",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 213379,
+    "fullName": "Бюльтер",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213118,
+    "fullName": "Ааронсон",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213119,
+    "fullName": "Баойя",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213120,
+    "fullName": "Гетце",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 2.9
+  },
+  {
+    "playerId": 213121,
+    "fullName": "Ларссон",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 2.2
+  },
+  {
+    "playerId": 213122,
+    "fullName": "Шаиби",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213439,
+    "fullName": "Диоманде",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213349,
+    "fullName": "Поульсен",
+    "clubName": "Гамбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 213437,
+    "fullName": "Баумгартнер",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 2.9
+  },
+  {
+    "playerId": 213230,
+    "fullName": "Аллер",
+    "clubName": "Боруссия Д",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213232,
+    "fullName": "Забитцер",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 3.2
+  },
+  {
+    "playerId": 213380,
+    "fullName": "Вальдшмидт",
+    "clubName": "Кельн",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213290,
+    "fullName": "Мбангула",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213289,
+    "fullName": "Грюлль",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213291,
+    "fullName": "Топп",
+    "clubName": "Вердер",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213402,
+    "fullName": "Сано",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213401,
+    "fullName": "Вайпер",
+    "clubName": "Майнц",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213154,
+    "fullName": "Титц",
+    "clubName": "Аугсбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213155,
+    "fullName": "Эссенде",
+    "clubName": "Аугсбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213314,
+    "fullName": "Арнольд",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 4.4
+  },
+  {
+    "playerId": 213316,
+    "fullName": "Тиагу Томаш",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213315,
+    "fullName": "Линдстрем",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213527,
+    "fullName": "Адаму",
+    "clubName": "Фрайбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213528,
+    "fullName": "Динкчи",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213173,
+    "fullName": "Ваннер",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213174,
+    "fullName": "Павлович",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213438,
+    "fullName": "Вернер",
+    "clubName": "РБ Лейпциг",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 4.4
+  },
+  {
+    "playerId": 213472,
+    "fullName": "Перейра Лаже",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213589,
+    "fullName": "Аслани",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213231,
+    "fullName": "Дюранвиль",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213612,
+    "fullName": "Каразор",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213152,
+    "fullName": "Кемюр",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213153,
+    "fullName": "Саад",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213347,
+    "fullName": "Кенигсдорффер",
+    "clubName": "Гамбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213374,
+    "fullName": "Ахе",
+    "clubName": "Кельн",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213378,
+    "fullName": "Тильманн",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213558,
+    "fullName": "Хонзак",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213432,
+    "fullName": "Гулачи",
+    "clubName": "РБ Лейпциг",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 6.9
+  },
+  {
+    "playerId": 213433,
+    "fullName": "Зайвальд",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213470,
+    "fullName": "Синани",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213116,
+    "fullName": "Браун",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 7.3
+  },
+  {
+    "playerId": 213117,
+    "fullName": "Схири",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213346,
+    "fullName": "Домпе",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 2.5
+  },
+  {
+    "playerId": 213376,
+    "fullName": "Каминьски",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213375,
+    "fullName": "Кайнц",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213377,
+    "fullName": "Майна",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213501,
+    "fullName": "Чжон Ву Ен",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213523,
+    "fullName": "Грегорич",
+    "clubName": "Фрайбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213526,
+    "fullName": "Эггештайн",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213152,
+    "fullName": "Кемюр",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213153,
+    "fullName": "Саад",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213434,
+    "fullName": "Раум",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 9.6
+  },
+  {
+    "playerId": 213168,
+    "fullName": "Геррейру",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 5.4
+  },
+  {
+    "playerId": 213169,
+    "fullName": "Дэвис",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 6.8
+  },
+  {
+    "playerId": 213170,
+    "fullName": "Лаймер",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 3.3
+  },
+  {
+    "playerId": 213171,
+    "fullName": "Нойер",
+    "clubName": "Бавария",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 9.5
+  },
+  {
+    "playerId": 213172,
+    "fullName": "Та",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 8.9
+  },
+  {
+    "playerId": 213588,
+    "fullName": "Туре",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213524,
+    "fullName": "Матанович",
+    "clubName": "Фрайбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213522,
+    "fullName": "Бесте",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 213525,
+    "fullName": "Рель",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213195,
+    "fullName": "Андрих",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 3.4
+  },
+  {
+    "playerId": 213196,
+    "fullName": "Маза",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213197,
+    "fullName": "Паласиос",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 2.2
+  },
+  {
+    "playerId": 213198,
+    "fullName": "Флеккен",
+    "clubName": "Байер",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 6.0
+  },
+  {
+    "playerId": 213557,
+    "fullName": "Пирингер",
+    "clubName": "Хайденхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213587,
+    "fullName": "Лемперле",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213430,
+    "fullName": "Андре Силва",
+    "clubName": "РБ Лейпциг",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 213431,
+    "fullName": "Баку",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 5.1
+  },
+  {
+    "playerId": 213429,
+    "fullName": "Айдара",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213227,
+    "fullName": "Кобель",
+    "clubName": "Боруссия Д",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 14.9
+  },
+  {
+    "playerId": 213228,
+    "fullName": "Рюэрсон",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 6.0
+  },
+  {
+    "playerId": 213229,
+    "fullName": "Свенссон",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 7.9
+  },
+  {
+    "playerId": 213313,
+    "fullName": "Ольсен",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213435,
+    "fullName": "Шлагер",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213348,
+    "fullName": "Райан Филипп",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213499,
+    "fullName": "Бенеш",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213469,
+    "fullName": "Афолайян",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213260,
+    "fullName": "Вайгль",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 3.8
+  },
+  {
+    "playerId": 213261,
+    "fullName": "Нгуму",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213262,
+    "fullName": "Райтц",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213263,
+    "fullName": "Табакович",
+    "clubName": "Боруссия М",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213400,
+    "fullName": "Норден",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213500,
+    "fullName": "Илич",
+    "clubName": "Унион Берлин",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213286,
+    "fullName": "Вайзер",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 6.6
+  },
+  {
+    "playerId": 213287,
+    "fullName": "Линен",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213288,
+    "fullName": "Нджинма",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213308,
+    "fullName": "Винисиус",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213311,
+    "fullName": "Паредес",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213494,
+    "fullName": "Ансах",
+    "clubName": "Унион Берлин",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213582,
+    "fullName": "Бебу",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213556,
+    "fullName": "Сиенза",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213112,
+    "fullName": "Расмус Кристенсен",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 11.5
+  },
+  {
+    "playerId": 213113,
+    "fullName": "Теате",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 3.1
+  },
+  {
+    "playerId": 213114,
+    "fullName": "Трапп",
+    "clubName": "Айнтрахт Ф",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 9.6
+  },
+  {
+    "playerId": 213115,
+    "fullName": "Хейлунд",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213345,
+    "fullName": "Сахити",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213310,
+    "fullName": "Грабара",
+    "clubName": "Вольфсбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 3.0
+  },
+  {
+    "playerId": 213344,
+    "fullName": "Капальдо",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213519,
+    "fullName": "Манзамби",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213555,
+    "fullName": "Зивзивадзе",
+    "clubName": "Хайденхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213554,
+    "fullName": "Бек",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213149,
+    "fullName": "Арне Майер",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213150,
+    "fullName": "Мунье",
+    "clubName": "Аугсбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213151,
+    "fullName": "Реджбечай",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213343,
+    "fullName": "Глатцель",
+    "clubName": "Гамбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213163,
+    "fullName": "Ким Мин Чжэ",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 213164,
+    "fullName": "Пальинья",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213165,
+    "fullName": "Станишич",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213166,
+    "fullName": "Упамекано",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 3.3
+  },
+  {
+    "playerId": 213167,
+    "fullName": "Урбиг",
+    "clubName": "Бавария",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213521,
+    "fullName": "Максимилиан Филипп",
+    "clubName": "Фрайбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213192,
+    "fullName": "Артур",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 3.8
+  },
+  {
+    "playerId": 213193,
+    "fullName": "Инкапиэ",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 5.9
+  },
+  {
+    "playerId": 213194,
+    "fullName": "Тапсоба",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 4.7
+  },
+  {
+    "playerId": 213518,
+    "fullName": "Ириэ",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213583,
+    "fullName": "Гриллич",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213467,
+    "fullName": "Унтонджи",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213468,
+    "fullName": "Фудзита",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213496,
+    "fullName": "Роте",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213495,
+    "fullName": "Берк",
+    "clubName": "Унион Берлин",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213498,
+    "fullName": "Шефер",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213497,
+    "fullName": "Скарке",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213259,
+    "fullName": "Зандер",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213312,
+    "fullName": "Сванберг",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213309,
+    "fullName": "Герхардт",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213398,
+    "fullName": "Мвене",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 2.6
+  },
+  {
+    "playerId": 213397,
+    "fullName": "Каси",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 6.2
+  },
+  {
+    "playerId": 213515,
+    "fullName": "Атуболу",
+    "clubName": "Фрайбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 7.1
+  },
+  {
+    "playerId": 213399,
+    "fullName": "Центнер",
+    "clubName": "Майнц",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 3.3
+  },
+  {
+    "playerId": 213517,
+    "fullName": "Гюнтер",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 6.9
+  },
+  {
+    "playerId": 213520,
+    "fullName": "Остерхаге",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213284,
+    "fullName": "Битенкур",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213311,
+    "fullName": "Паредес",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213312,
+    "fullName": "Сванберг",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213428,
+    "fullName": "Уэдраого",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213398,
+    "fullName": "Мвене",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 2.6
+  },
+  {
+    "playerId": 213582,
+    "fullName": "Бебу",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213584,
+    "fullName": "Морстедт",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213583,
+    "fullName": "Гриллич",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213585,
+    "fullName": "Гифт Орбан",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213343,
+    "fullName": "Глатцель",
+    "clubName": "Гамбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213344,
+    "fullName": "Капальдо",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213345,
+    "fullName": "Сахити",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213397,
+    "fullName": "Каси",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 6.2
+  },
+  {
+    "playerId": 213610,
+    "fullName": "Миттельштедт",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 18.3
+  },
+  {
+    "playerId": 213607,
+    "fullName": "Диль",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213467,
+    "fullName": "Унтонджи",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213468,
+    "fullName": "Фудзита",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213606,
+    "fullName": "Ассиньон",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 3.3
+  },
+  {
+    "playerId": 213611,
+    "fullName": "Нюбель",
+    "clubName": "Штутгарт",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 9.3
+  },
+  {
+    "playerId": 213494,
+    "fullName": "Ансах",
+    "clubName": "Унион Берлин",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213497,
+    "fullName": "Скарке",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213496,
+    "fullName": "Роте",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213419,
+    "fullName": "Гомис",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213422,
+    "fullName": "Лукеба",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 213418,
+    "fullName": "Гертрюйда",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 3.3
+  },
+  {
+    "playerId": 213553,
+    "fullName": "Конте",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213576,
+    "fullName": "Бекер",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213580,
+    "fullName": "Премель",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213108,
+    "fullName": "Коллинз",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213109,
+    "fullName": "Кох",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213110,
+    "fullName": "Нкунку",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213111,
+    "fullName": "Сантос",
+    "clubName": "Айнтрахт Ф",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213421,
+    "fullName": "Клостерманн",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.2
+  },
+  {
+    "playerId": 213550,
+    "fullName": "Бройниг",
+    "clubName": "Хайденхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213552,
+    "fullName": "Ибрагимович",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213140,
+    "fullName": "Вольф",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.4
+  },
+  {
+    "playerId": 213141,
+    "fullName": "Гауэлеу",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213142,
+    "fullName": "Дамен",
+    "clubName": "Аугсбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 213143,
+    "fullName": "Донг",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213144,
+    "fullName": "Кабадайы",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213145,
+    "fullName": "Массенго",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213146,
+    "fullName": "Фелльхауэр",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213147,
+    "fullName": "Якич",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213148,
+    "fullName": "Яннулис",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213416,
+    "fullName": "Битшиабу",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213161,
+    "fullName": "Ито",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213188,
+    "fullName": "Белосьян",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213189,
+    "fullName": "Кофан",
+    "clubName": "Байер",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213190,
+    "fullName": "Куанса",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 4.4
+  },
+  {
+    "playerId": 213191,
+    "fullName": "Сарко",
+    "clubName": "Байер",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213461,
+    "fullName": "Скотт Бэнкс",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213551,
+    "fullName": "Дорш",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213488,
+    "fullName": "Реннов",
+    "clubName": "Унион Берлин",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213217,
+    "fullName": "Зюле",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.0
+  },
+  {
+    "playerId": 213218,
+    "fullName": "Кэмпбелл",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213424,
+    "fullName": "Неделькович",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213511,
+    "fullName": "Кюблер",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 9.4
+  },
+  {
+    "playerId": 213510,
+    "fullName": "Гинтер",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 7.2
+  },
+  {
+    "playerId": 213514,
+    "fullName": "Хефлер",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213250,
+    "fullName": "Итакура",
+    "clubName": "Боруссия М",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 213251,
+    "fullName": "Кастроп",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213252,
+    "fullName": "Николас",
+    "clubName": "Боруссия М",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213253,
+    "fullName": "Омлин",
+    "clubName": "Боруссия М",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 213254,
+    "fullName": "Скалли",
+    "clubName": "Боруссия М",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213255,
+    "fullName": "Ульрих",
+    "clubName": "Боруссия М",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213256,
+    "fullName": "Фрауло",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213257,
+    "fullName": "Фукуда",
+    "clubName": "Боруссия М",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213258,
+    "fullName": "Эльведи",
+    "clubName": "Боруссия М",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 3.1
+  },
+  {
+    "playerId": 213423,
+    "fullName": "Максимович",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213420,
+    "fullName": "Кампль",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213282,
+    "fullName": "Агу",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 3.3
+  },
+  {
+    "playerId": 213283,
+    "fullName": "Фридль",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213303,
+    "fullName": "Вранкс",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213304,
+    "fullName": "Дардаи",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213305,
+    "fullName": "Кульеракис",
+    "clubName": "Вольфсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213306,
+    "fullName": "Мэле",
+    "clubName": "Вольфсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 5.2
+  },
+  {
+    "playerId": 213307,
+    "fullName": "Пейчинович",
+    "clubName": "Вольфсбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213574,
+    "fullName": "Авдуллаху",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213577,
+    "fullName": "Бериша",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213575,
+    "fullName": "Бауманн",
+    "clubName": "Хоффенхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 4.6
+  },
+  {
+    "playerId": 213579,
+    "fullName": "Гайгер",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213581,
+    "fullName": "Тохумджу",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213578,
+    "fullName": "Бургер",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213340,
+    "fullName": "Бакери Джатта",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213341,
+    "fullName": "Мухайм",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213342,
+    "fullName": "Ремберг",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213512,
+    "fullName": "Линхарт",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213490,
+    "fullName": "Триммель",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213462,
+    "fullName": "Валь",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 213466,
+    "fullName": "Смит",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213485,
+    "fullName": "Дуки",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213487,
+    "fullName": "Крал",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213486,
+    "fullName": "Кемляйн",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213369,
+    "fullName": "Йоуханнессон",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213370,
+    "fullName": "Краус",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213371,
+    "fullName": "Мартель",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213372,
+    "fullName": "Тиггес",
+    "clubName": "Кельн",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213373,
+    "fullName": "Хусейнбашич",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213489,
+    "fullName": "Сков",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213492,
+    "fullName": "Хаберер",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213493,
+    "fullName": "Хедира",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213423,
+    "fullName": "Максимович",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213424,
+    "fullName": "Неделькович",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213575,
+    "fullName": "Бауманн",
+    "clubName": "Хоффенхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 4.6
+  },
+  {
+    "playerId": 213461,
+    "fullName": "Скотт Бэнкс",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213462,
+    "fullName": "Валь",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.3
+  },
+  {
+    "playerId": 213463,
+    "fullName": "Василь",
+    "clubName": "Санкт-Паули",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 9.6
+  },
+  {
+    "playerId": 213464,
+    "fullName": "Меткалф",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213465,
+    "fullName": "Салиакас",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213466,
+    "fullName": "Смит",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213493,
+    "fullName": "Хедира",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213484,
+    "fullName": "Диогу Лейте",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213485,
+    "fullName": "Дуки",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213486,
+    "fullName": "Кемляйн",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213487,
+    "fullName": "Крал",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213488,
+    "fullName": "Реннов",
+    "clubName": "Унион Берлин",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213489,
+    "fullName": "Сков",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213490,
+    "fullName": "Триммель",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213491,
+    "fullName": "Тузар",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213492,
+    "fullName": "Хаберер",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213566,
+    "fullName": "Акпогума",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213101,
+    "fullName": "Дина-Эбимбе",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213102,
+    "fullName": "Инанолу",
+    "clubName": "Айнтрахт Ф",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213103,
+    "fullName": "Листеш",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213104,
+    "fullName": "Нганкам",
+    "clubName": "Айнтрахт Ф",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213105,
+    "fullName": "Тута",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213106,
+    "fullName": "Фенье",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213133,
+    "fullName": "Брайтхаупт",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213134,
+    "fullName": "Дардари",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213135,
+    "fullName": "Кудоссу",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213136,
+    "fullName": "Кюджюксахын",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213137,
+    "fullName": "Матсима",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213138,
+    "fullName": "Цезигер",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213139,
+    "fullName": "Кевен Шлоттербек",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213540,
+    "fullName": "Зирслебен",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213185,
+    "fullName": "Альфа-Рупрехт",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213186,
+    "fullName": "Градецки",
+    "clubName": "Байер",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 213187,
+    "fullName": "Тап",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213568,
+    "fullName": "Жандре",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213567,
+    "fullName": "Бернардо",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213549,
+    "fullName": "Янеш",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213214,
+    "fullName": "Азхиль",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213215,
+    "fullName": "Боямба",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213216,
+    "fullName": "Диалло",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213539,
+    "fullName": "Гимбер",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213249,
+    "fullName": "Фридрих",
+    "clubName": "Боруссия М",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213548,
+    "fullName": "Шиммер",
+    "clubName": "Хайденхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213273,
+    "fullName": "Аде",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 10.3
+  },
+  {
+    "playerId": 213274,
+    "fullName": "Альверо",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 3.4
+  },
+  {
+    "playerId": 213275,
+    "fullName": "Вебер",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 213276,
+    "fullName": "Деман",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213277,
+    "fullName": "Опиц",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213278,
+    "fullName": "Пипер",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213279,
+    "fullName": "Хансен-Ороэн",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213280,
+    "fullName": "Чович",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213281,
+    "fullName": "Штарк",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213547,
+    "fullName": "Траоре",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213546,
+    "fullName": "Рамай",
+    "clubName": "Хайденхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213299,
+    "fullName": "Вавро",
+    "clubName": "Вольфсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213300,
+    "fullName": "Мариус Мюллер",
+    "clubName": "Вольфсбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213301,
+    "fullName": "Фишер",
+    "clubName": "Вольфсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213302,
+    "fullName": "Центер",
+    "clubName": "Вольфсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213545,
+    "fullName": "Нихьюс",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213328,
+    "fullName": "Аджекум",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213329,
+    "fullName": "Бальде",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 4.4
+  },
+  {
+    "playerId": 213330,
+    "fullName": "Мефферт",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213331,
+    "fullName": "Микельбрансис",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213332,
+    "fullName": "Озтуналы",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213333,
+    "fullName": "Перец",
+    "clubName": "Гамбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 3.5
+  },
+  {
+    "playerId": 213334,
+    "fullName": "Сумаоро",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213335,
+    "fullName": "Торунарига",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213336,
+    "fullName": "Фераи",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213337,
+    "fullName": "Хойер",
+    "clubName": "Гамбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213338,
+    "fullName": "Эльфадли",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213339,
+    "fullName": "Ялчинкая",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213410,
+    "fullName": "Бунги",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213411,
+    "fullName": "Вигго Гебель",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213412,
+    "fullName": "Нуха Джатта",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213413,
+    "fullName": "Рамсак",
+    "clubName": "РБ Лейпциг",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213414,
+    "fullName": "Финкгрефе",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213415,
+    "fullName": "Хенрихс",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213542,
+    "fullName": "Кербер",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 213450,
+    "fullName": "Айгбекэн",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 2.2
+  },
+  {
+    "playerId": 213451,
+    "fullName": "Альстранд",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 11.4
+  },
+  {
+    "playerId": 213452,
+    "fullName": "Джонс",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 213453,
+    "fullName": "Метс",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213454,
+    "fullName": "Немет",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213455,
+    "fullName": "Оппи",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213456,
+    "fullName": "Пырка",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213457,
+    "fullName": "Ритцка",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213458,
+    "fullName": "Сисей",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213459,
+    "fullName": "Сэндс",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213460,
+    "fullName": "Шмиц",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213544,
+    "fullName": "Кевин Мюллер",
+    "clubName": "Хайденхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213543,
+    "fullName": "Майнка",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213477,
+    "fullName": "Бурджу",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213478,
+    "fullName": "Кверфельд",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213479,
+    "fullName": "Любичич",
+    "clubName": "Унион Берлин",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213480,
+    "fullName": "Маркграф",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213481,
+    "fullName": "Нсоки",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213482,
+    "fullName": "Прой",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213413,
+    "fullName": "Рамсак",
+    "clubName": "РБ Лейпциг",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213414,
+    "fullName": "Финкгрефе",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213415,
+    "fullName": "Хенрихс",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213450,
+    "fullName": "Айгбекэн",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 2.2
+  },
+  {
+    "playerId": 213451,
+    "fullName": "Альстранд",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 11.4
+  },
+  {
+    "playerId": 213452,
+    "fullName": "Джонс",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 2.1
+  },
+  {
+    "playerId": 213453,
+    "fullName": "Метс",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213454,
+    "fullName": "Немет",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213455,
+    "fullName": "Оппи",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213456,
+    "fullName": "Пырка",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213457,
+    "fullName": "Ритцка",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213458,
+    "fullName": "Сисей",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213459,
+    "fullName": "Сэндс",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213460,
+    "fullName": "Шмиц",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213596,
+    "fullName": "Ельч",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213477,
+    "fullName": "Бурджу",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213478,
+    "fullName": "Кверфельд",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213479,
+    "fullName": "Любичич",
+    "clubName": "Унион Берлин",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213480,
+    "fullName": "Маркграф",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.1
+  },
+  {
+    "playerId": 213481,
+    "fullName": "Нсоки",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213482,
+    "fullName": "Прой",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213483,
+    "fullName": "Юранович",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213505,
+    "fullName": "Кьере",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213506,
+    "fullName": "Макенго",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213507,
+    "fullName": "Муслия",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213508,
+    "fullName": "Розенфельдер",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213509,
+    "fullName": "Юнг",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213539,
+    "fullName": "Гимбер",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213540,
+    "fullName": "Зирслебен",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213541,
+    "fullName": "Кауфманн",
+    "clubName": "Хайденхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213542,
+    "fullName": "Кербер",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 213543,
+    "fullName": "Майнка",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213544,
+    "fullName": "Кевин Мюллер",
+    "clubName": "Хайденхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213545,
+    "fullName": "Нихьюс",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213546,
+    "fullName": "Рамай",
+    "clubName": "Хайденхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213547,
+    "fullName": "Траоре",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213548,
+    "fullName": "Шиммер",
+    "clubName": "Хайденхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213549,
+    "fullName": "Янеш",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.6
+  },
+  {
+    "playerId": 213566,
+    "fullName": "Акпогума",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213567,
+    "fullName": "Бернардо",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213568,
+    "fullName": "Жандре",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.2
+  },
+  {
+    "playerId": 213569,
+    "fullName": "Матида",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213570,
+    "fullName": "Моква",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213571,
+    "fullName": "Хюрюляйнен",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213572,
+    "fullName": "Цайтлер",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213573,
+    "fullName": "Чавес",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213595,
+    "fullName": "Бредлов",
+    "clubName": "Штутгарт",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213092,
+    "fullName": "Баум",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 7.2
+  },
+  {
+    "playerId": 213093,
+    "fullName": "Бута",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 2.2
+  },
+  {
+    "playerId": 213094,
+    "fullName": "Граль",
+    "clubName": "Айнтрахт Ф",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213095,
+    "fullName": "Думбия",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213096,
+    "fullName": "Смолчич",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213097,
+    "fullName": "Чендлер",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213129,
+    "fullName": "Ноакай Бэнкс",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213130,
+    "fullName": "Кляйн",
+    "clubName": "Аугсбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213158,
+    "fullName": "Кланац",
+    "clubName": "Бавария",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213184,
+    "fullName": "Ломб",
+    "clubName": "Байер",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213208,
+    "fullName": "Бенкара",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.8
+  },
+  {
+    "playerId": 213209,
+    "fullName": "Патрик Гебель",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.3
+  },
+  {
+    "playerId": 213210,
+    "fullName": "Древес",
+    "clubName": "Боруссия Д",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213211,
+    "fullName": "Кабар",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213212,
+    "fullName": "Люрс",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.4
+  },
+  {
+    "playerId": 213241,
+    "fullName": "Кьяродиа",
+    "clubName": "Боруссия М",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213242,
+    "fullName": "Перейра Кардозу",
+    "clubName": "Боруссия М",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213269,
+    "fullName": "Бакхаус",
+    "clubName": "Вердер",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 15.5
+  },
+  {
+    "playerId": 213270,
+    "fullName": "Кольке",
+    "clubName": "Вердер",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213272,
+    "fullName": "Шметгенс",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213295,
+    "fullName": "Зелиньски",
+    "clubName": "Вольфсбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 2.7
+  },
+  {
+    "playerId": 213296,
+    "fullName": "Йенц",
+    "clubName": "Вольфсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213297,
+    "fullName": "Перван",
+    "clubName": "Вольфсбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.5
+  },
+  {
+    "playerId": 213298,
+    "fullName": "Рожерио",
+    "clubName": "Вольфсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213322,
+    "fullName": "Дикес",
+    "clubName": "Гамбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 7.6
+  },
+  {
+    "playerId": 213323,
+    "fullName": "Каттербах",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 213324,
+    "fullName": "Рамуш",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 213325,
+    "fullName": "Херман",
+    "clubName": "Гамбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213326,
+    "fullName": "Хефти",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.3
+  },
+  {
+    "playerId": 213383,
+    "fullName": "Даль",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213408,
+    "fullName": "Келер",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213409,
+    "fullName": "Цингерле",
+    "clubName": "РБ Лейпциг",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213445,
+    "fullName": "Дзвигала",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 213446,
+    "fullName": "Робатш",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213447,
+    "fullName": "Стивенс",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213448,
+    "fullName": "Фолль",
+    "clubName": "Санкт-Паули",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213449,
+    "fullName": "Шпари",
+    "clubName": "Санкт-Паули",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213474,
+    "fullName": "Огбемудиа",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213475,
+    "fullName": "Рааб",
+    "clubName": "Унион Берлин",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213476,
+    "fullName": "Штайн",
+    "clubName": "Унион Берлин",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213502,
+    "fullName": "Флориан Мюллер",
+    "clubName": "Фрайбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213503,
+    "fullName": "Огбус",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213504,
+    "fullName": "Хут",
+    "clubName": "Фрайбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213534,
+    "fullName": "Буш",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 4.3
+  },
+  {
+    "playerId": 213535,
+    "fullName": "Келлер",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213536,
+    "fullName": "Феллер",
+    "clubName": "Хайденхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213537,
+    "fullName": "Ференбах",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213538,
+    "fullName": "Чернут",
+    "clubName": "Хайденхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213560,
+    "fullName": "Беренс",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 7.5
+  },
+  {
+    "playerId": 213561,
+    "fullName": "Гранач",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213562,
+    "fullName": "Дрекслер",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 213563,
+    "fullName": "Кабак",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 213564,
+    "fullName": "Петерссон",
+    "clubName": "Хоффенхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213409,
+    "fullName": "Цингерле",
+    "clubName": "РБ Лейпциг",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213445,
+    "fullName": "Дзвигала",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 2.8
+  },
+  {
+    "playerId": 213446,
+    "fullName": "Робатш",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213447,
+    "fullName": "Стивенс",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.8
+  },
+  {
+    "playerId": 213448,
+    "fullName": "Фолль",
+    "clubName": "Санкт-Паули",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213449,
+    "fullName": "Шпари",
+    "clubName": "Санкт-Паули",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.4
+  },
+  {
+    "playerId": 213473,
+    "fullName": "Клаус",
+    "clubName": "Унион Берлин",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.2
+  },
+  {
+    "playerId": 213474,
+    "fullName": "Огбемудиа",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.7
+  },
+  {
+    "playerId": 213475,
+    "fullName": "Рааб",
+    "clubName": "Унион Берлин",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213476,
+    "fullName": "Штайн",
+    "clubName": "Унион Берлин",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.5
+  },
+  {
+    "playerId": 213502,
+    "fullName": "Флориан Мюллер",
+    "clubName": "Фрайбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213503,
+    "fullName": "Огбус",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213504,
+    "fullName": "Хут",
+    "clubName": "Фрайбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213534,
+    "fullName": "Буш",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 4.3
+  },
+  {
+    "playerId": 213535,
+    "fullName": "Келлер",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213536,
+    "fullName": "Феллер",
+    "clubName": "Хайденхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213537,
+    "fullName": "Ференбах",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213538,
+    "fullName": "Чернут",
+    "clubName": "Хайденхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.9
+  },
+  {
+    "playerId": 213560,
+    "fullName": "Беренс",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 7.5
+  },
+  {
+    "playerId": 213561,
+    "fullName": "Гранач",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.1
+  },
+  {
+    "playerId": 213562,
+    "fullName": "Дрекслер",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.7
+  },
+  {
+    "playerId": 213563,
+    "fullName": "Кабак",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.9
+  },
+  {
+    "playerId": 213564,
+    "fullName": "Петерссон",
+    "clubName": "Хоффенхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213565,
+    "fullName": "Лука Филипп",
+    "clubName": "Хоффенхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6
+  },
+  {
+    "playerId": 213592,
+    "fullName": "Аль-Дахиль",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 10.9
+  },
+  {
+    "playerId": 213593,
+    "fullName": "Дрляча",
+    "clubName": "Штутгарт",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.0
+  },
+  {
+    "playerId": 213594,
+    "fullName": "Загаду",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.6
   }
 ]

--- a/draft_app/static/js/draft_common.js
+++ b/draft_app/static/js/draft_common.js
@@ -7,4 +7,28 @@ document.addEventListener('DOMContentLoaded', function () {
       sel.addEventListener('change', () => form.submit());
     });
   }
+
+  // FP 2024/25 sorting (data already in table)
+  const sortBtn = document.getElementById('fp-sort-btn');
+  const sortArrow = document.getElementById('fp-sort-arrow');
+
+  function sortByFp(dir) {
+    const body = document.querySelector('#players tbody');
+    if (!body) return;
+    const rows = Array.from(body.querySelectorAll('tr'));
+    rows.sort((a, b) => {
+      const afp = Number(a.querySelector('.fp-cell')?.getAttribute('data-fp') || '0');
+      const bfp = Number(b.querySelector('.fp-cell')?.getAttribute('data-fp') || '0');
+      return dir === 'asc' ? (afp - bfp) : (bfp - afp);
+    });
+    rows.forEach(r => body.appendChild(r));
+  }
+
+  sortBtn?.addEventListener('click', () => {
+    const cur = sortBtn.getAttribute('data-dir') || 'desc';
+    const next = cur === 'desc' ? 'asc' : 'desc';
+    sortBtn.setAttribute('data-dir', next);
+    if (sortArrow) sortArrow.textContent = next === 'desc' ? '↓' : '↑';
+    sortByFp(next);
+  });
 });

--- a/draft_app/top4_routes.py
+++ b/draft_app/top4_routes.py
@@ -77,6 +77,15 @@ def index():
     if pos_filter:
         players = [p for p in players if p.get("position") == pos_filter]
 
+    # Sorting
+    sort_field = request.args.get("sort") or "price"
+    sort_dir = request.args.get("dir") or "desc"
+    reverse = sort_dir == "desc"
+    if sort_field == "price":
+        players.sort(key=lambda p: (p.get("price") is None, p.get("price")), reverse=reverse)
+    elif sort_field == "popularity":
+        players.sort(key=lambda p: (p.get("popularity") is None, p.get("popularity")), reverse=reverse)
+
     annotate_can_pick(players, state, current_user)
 
     return render_template(

--- a/draft_app/top4_services.py
+++ b/draft_app/top4_services.py
@@ -15,7 +15,7 @@ PLAYERS_CACHE = BASE / "data" / "cache" / "top4_players.json"
 WISHLIST_DIR = BASE / "data" / "wishlist" / "top4"
 
 LEAGUE_TOURNAMENTS = {
-    # IDs of tournaments on fantasy-h2h.ru
+    # IDs of tournaments on fantasy-h2h.ru for 2025 season
     "La Liga": 315,
     "EPL": 316,
     "Serie A": 318,
@@ -86,7 +86,9 @@ def _fetch_league_players(tournament_id: int, league: str) -> List[Dict[str, Any
     url = f"https://fantasy-h2h.ru/analytics/fantasy_players_statistics/{tournament_id}"
     offset = 0
     while True:
-        resp = requests.get(url, params={"ajax": 1, "offset": offset}, headers=HEADERS)
+        resp = requests.get(
+            url, params={"ajax": 1, "offset": offset, "limit": 100}, headers=HEADERS
+        )
         try:
             html = resp.json().get("data", "")
         except Exception:
@@ -133,13 +135,15 @@ def _fetch_league_players(tournament_id: int, league: str) -> List[Dict[str, Any
     return players
 
 
-def _fetch_prev_fp(tournament_id: int) -> Dict[int, float]:
+def _fetch_prev_fp(tournament_id: int) -> Dict[str, float]:
     """Fetch last season FP (Pts) for given tournament id."""
-    fp: Dict[int, float] = {}
+    fp: Dict[str, float] = {}
     url = f"https://fantasy-h2h.ru/analytics/fantasy_players_statistics/{tournament_id}"
     offset = 0
     while True:
-        resp = requests.get(url, params={"ajax": 1, "offset": offset}, headers=HEADERS)
+        resp = requests.get(
+            url, params={"ajax": 1, "offset": offset, "limit": 100}, headers=HEADERS
+        )
         try:
             html = resp.json().get("data", "")
         except Exception:

--- a/templates/index.html
+++ b/templates/index.html
@@ -81,7 +81,9 @@
   {% set show_price = players and players[0].get('price') is not none %}
   {% set current_sort = request.args.get('sort') or 'price' %}
   {% set current_dir = request.args.get('dir', 'desc') %}
+  {% set route = (table_league or 'epl') ~ '.index' %}
   {% set next_dir_price = 'asc' if current_sort == 'price' and current_dir == 'desc' else 'desc' %}
+  {% set next_dir_pop = 'asc' if current_sort == 'popularity' and current_dir == 'desc' else 'desc' %}
 
   {% if players %}
     <div class="table-wrap">
@@ -95,15 +97,26 @@
             <th>Игрок</th>
             <th>Клуб</th>
             <th>Позиция</th>
-            <th>Статистика</th>
+            {% if table_league == 'epl' %}<th>Статистика</th>{% endif %}
             <th class="num">
               <button type="button" id="fp-sort-btn" class="link" data-dir="desc" title="Сортировать по FP 2024/25">
                 FP 2024/25 <span id="fp-sort-arrow">↓</span>
               </button>
             </th>
+            {% if table_league == 'top4' %}
+              <th class="num">
+                <a href="{{ url_for(route, league=league_filter, club=club_filter, position=pos_filter, sort='popularity', dir=next_dir_pop) }}"
+                   style="text-decoration:none;color:inherit">
+                  Популярность
+                  {% if current_sort == 'popularity' %}
+                    {{ '↑' if current_dir == 'asc' else '↓' }}
+                  {% endif %}
+                </a>
+              </th>
+            {% endif %}
             {% if show_price %}
               <th class="num">
-                <a href="{{ url_for('epl.index', club=club_filter, position=pos_filter, sort='price', dir=next_dir_price) }}"
+                <a href="{{ url_for(route, league=league_filter, club=club_filter, position=pos_filter, sort='price', dir=next_dir_price) }}"
                    style="text-decoration:none;color:inherit">
                   Цена
                   {% if current_sort == 'price' %}
@@ -126,12 +139,15 @@
               <td>{{ p.shortName or p.fullName }}</td>
               <td>{{ p.clubName }}</td>
               <td>{{ p.position }}</td>
+              {% if table_league == 'epl' %}
               <td>
                 <button type="button" class="link link-stat" data-pid="{{ p.playerId }}" data-name="{{ p.shortName or p.fullName }}">stat</button>
               </td>
+              {% endif %}
               <td class="num">
-                <span class="fp-cell" data-pid="{{ p.playerId }}" data-fp="0">0</span>
+                <span class="fp-cell" data-pid="{{ p.playerId }}" data-fp="{{ p.fp_last or 0 }}">{{ (p.fp_last or 0)|int }}</span>
               </td>
+              {% if table_league == 'top4' %}<td class="num">{{ '%.1f'|format(p.popularity) }}</td>{% endif %}
               {% if show_price %}<td class="num">{{ '%.1f'|format(p.price) }}</td>{% endif %}
               <td class="num">
                 <form method="post" style="display:inline;">
@@ -149,6 +165,7 @@
   {% endif %}
 </div>
 
+{% if table_league == 'epl' %}
 <!-- Modal для статистики -->
 <div id="stat-modal" class="modal" aria-hidden="true">
   <div class="modal-backdrop" data-close="1"></div>
@@ -184,6 +201,7 @@
     </div>
   </div>
 </div>
+{% endif %}
 
 {% if table_league == 'epl' %}
 <script src="{{ url_for('static', filename='js/draft_epl.js') }}"></script>


### PR DESCRIPTION
## Summary
- Fetch Top-4 league players from fantasy-h2h analytics pages
- Store club, name, price and popularity for each player
- Regenerate cached `top4_players.json`

## Testing
- `python -m py_compile draft_app/top4_services.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5c2ede6188323a15deea2ebc4336c