### PR TITLE
Fetch all club players for top4 leagues

### DIFF
--- a/data/cache/top4_players.json
+++ b/data/cache/top4_players.json
@@ -1,183 +1,13 @@
 [
   {
-    "playerId": 213728,
-    "fullName": "Ямаль",
-    "clubName": "Барселона",
+    "playerId": 213638,
+    "fullName": "Антонио Бланко",
+    "clubName": "Алавес",
     "position": "MID",
-    "league": "La Liga",
-    "price": 10.5,
-    "popularity": 70.1,
-    "fp_last": 185.0
-  },
-  {
-    "playerId": 213748,
-    "fullName": "Руибаль",
-    "clubName": "Бетис",
-    "position": "DEF",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 6.8,
-    "fp_last": 57.0
-  },
-  {
-    "playerId": 213928,
-    "fullName": "Де Фрутос",
-    "clubName": "Райо Вальекано",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 6.1,
-    "fp_last": 112.0
-  },
-  {
-    "playerId": 213670,
-    "fullName": "Нико Уильямс",
-    "clubName": "Атлетик",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 8.5,
-    "popularity": 25.6,
-    "fp_last": 108.0
-  },
-  {
-    "playerId": 214086,
-    "fullName": "Уче",
-    "clubName": "Хетафе",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 3.8,
-    "fp_last": 107.0
-  },
-  {
-    "playerId": 214076,
-    "fullName": "Лисо",
-    "clubName": "Хетафе",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 2.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213792,
-    "fullName": "Жуниор",
-    "clubName": "Вильярреал",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 15.1,
-    "fp_last": 57.0
-  },
-  {
-    "playerId": 213929,
-    "fullName": "Паласон",
-    "clubName": "Райо Вальекано",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 1.8,
-    "fp_last": 103.0
-  },
-  {
-    "playerId": 213800,
-    "fullName": "Гуйе",
-    "clubName": "Вильярреал",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 3.4,
+    "popularity": 0.9,
     "fp_last": 87.0
-  },
-  {
-    "playerId": 214062,
-    "fullName": "Бекуша",
-    "clubName": "Хетафе",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 10.5,
-    "fp_last": 3.0
-  },
-  {
-    "playerId": 213826,
-    "fullName": "Хоэль Рока",
-    "clubName": "Жирона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 2.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213938,
-    "fullName": "Милитао",
-    "clubName": "Реал Мадрид",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 4.4,
-    "fp_last": 43.0
-  },
-  {
-    "playerId": 214027,
-    "fullName": "Агуме",
-    "clubName": "Севилья",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 84.0
-  },
-  {
-    "playerId": 213780,
-    "fullName": "Диего Лопес",
-    "clubName": "Валенсия",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 2.5,
-    "fp_last": 142.0
-  },
-  {
-    "playerId": 213851,
-    "fullName": "Толян",
-    "clubName": "Леванте",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 2.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214038,
-    "fullName": "Лукебакио",
-    "clubName": "Севилья",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.5,
-    "popularity": 5.4,
-    "fp_last": 159.0
-  },
-  {
-    "playerId": 214106,
-    "fullName": "Валера",
-    "clubName": "Эльче",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213788,
-    "fullName": "Моуриньо",
-    "clubName": "Вильярреал",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 10.7,
-    "fp_last": 0.0
   },
   {
     "playerId": 213636,
@@ -190,174 +20,14 @@
     "fp_last": 101.0
   },
   {
-    "playerId": 213729,
-    "fullName": "Рафинья",
-    "clubName": "Барселона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 11.5,
-    "popularity": 38.3,
-    "fp_last": 219.0
-  },
-  {
-    "playerId": 213638,
-    "fullName": "Антонио Бланко",
+    "playerId": 213640,
+    "fullName": "Тони Мартинес",
     "clubName": "Алавес",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.9,
-    "fp_last": 87.0
-  },
-  {
-    "playerId": 213700,
-    "fullName": "Хулиан Альварес",
-    "clubName": "Атлетико",
     "position": "FWD",
     "league": "La Liga",
-    "price": 9.5,
-    "popularity": 34.8,
-    "fp_last": 152.0
-  },
-  {
-    "playerId": 213798,
-    "fullName": "Кардона",
-    "clubName": "Вильярреал",
-    "position": "DEF",
-    "league": "La Liga",
     "price": 5.5,
-    "popularity": 13.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213796,
-    "fullName": "Этта-Эйонг",
-    "clubName": "Вильярреал",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 12.8,
-    "fp_last": 9.0
-  },
-  {
-    "playerId": 214009,
-    "fullName": "Кубо",
-    "clubName": "Реал Сосьедад",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.5,
-    "popularity": 6.6,
-    "fp_last": 106.0
-  },
-  {
-    "playerId": 213795,
-    "fullName": "Фойт",
-    "clubName": "Вильярреал",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 8.6,
-    "fp_last": 59.0
-  },
-  {
-    "playerId": 213794,
-    "fullName": "Рафа Марин",
-    "clubName": "Вильярреал",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 3.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213709,
-    "fullName": "Кубарси",
-    "clubName": "Барселона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 13.8,
-    "fp_last": 99.0
-  },
-  {
-    "playerId": 213708,
-    "fullName": "Араухо",
-    "clubName": "Барселона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 4.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214136,
-    "fullName": "Экспосито",
-    "clubName": "Эспаньол",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 42.0
-  },
-  {
-    "playerId": 214032,
-    "fullName": "Хуанлу Санчес",
-    "clubName": "Севилья",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 83.0
-  },
-  {
-    "playerId": 213930,
-    "fullName": "Альваро Гарсия",
-    "clubName": "Райо Вальекано",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 0.8,
-    "fp_last": 117.0
-  },
-  {
-    "playerId": 214125,
-    "fullName": "Рубио",
-    "clubName": "Эспаньол",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213753,
-    "fullName": "Рикельме",
-    "clubName": "Бетис",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 3.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213807,
-    "fullName": "Пино",
-    "clubName": "Вильярреал",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.5,
-    "popularity": 7.3,
-    "fp_last": 97.0
-  },
-  {
-    "playerId": 213806,
-    "fullName": "Пепе",
-    "clubName": "Вильярреал",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 11.1,
-    "fp_last": 84.0
+    "popularity": 2.2,
+    "fp_last": 43.0
   },
   {
     "playerId": 213637,
@@ -370,613 +40,33 @@
     "fp_last": 56.0
   },
   {
-    "playerId": 213640,
-    "fullName": "Тони Мартинес",
+    "playerId": 213641,
+    "fullName": "Висенте",
     "clubName": "Алавес",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 2.2,
-    "fp_last": 43.0
-  },
-  {
-    "playerId": 213939,
-    "fullName": "Альваро Каррерас",
-    "clubName": "Реал Мадрид",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 4.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213956,
-    "fullName": "Мбаппе",
-    "clubName": "Реал Мадрид",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 11.5,
-    "popularity": 69.7,
-    "fp_last": 218.0
-  },
-  {
-    "playerId": 213945,
-    "fullName": "Александер-Арнолд",
-    "clubName": "Реал Мадрид",
-    "position": "DEF",
+    "position": "MID",
     "league": "La Liga",
     "price": 6.5,
-    "popularity": 30.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213714,
-    "fullName": "Бальде",
-    "clubName": "Барселона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 8.5,
-    "fp_last": 98.0
-  },
-  {
-    "playerId": 214132,
-    "fullName": "Пере Милья",
-    "clubName": "Эспаньол",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 32.0
-  },
-  {
-    "playerId": 213716,
-    "fullName": "Жоан Гарсия",
-    "clubName": "Барселона",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 5.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213719,
-    "fullName": "Эрик Гарсия",
-    "clubName": "Барселона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 1.8,
-    "fp_last": 89.0
-  },
-  {
-    "playerId": 214083,
-    "fullName": "Сория",
-    "clubName": "Хетафе",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 4.8,
-    "fp_last": 129.0
-  },
-  {
-    "playerId": 213940,
-    "fullName": "Куртуа",
-    "clubName": "Реал Мадрид",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 14.6,
-    "fp_last": 111.0
-  },
-  {
-    "playerId": 213696,
-    "fullName": "Симеоне",
-    "clubName": "Атлетико",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 4.6,
-    "fp_last": 82.0
-  },
-  {
-    "playerId": 213944,
-    "fullName": "Хейсен",
-    "clubName": "Реал Мадрид",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 14.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213725,
-    "fullName": "Ферран Торрес",
-    "clubName": "Барселона",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 8.0,
-    "popularity": 12.2,
-    "fp_last": 103.0
-  },
-  {
-    "playerId": 214033,
-    "fullName": "Адамс",
-    "clubName": "Севилья",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.0,
     "popularity": 1.0,
-    "fp_last": 5.0
+    "fp_last": 144.0
   },
   {
-    "playerId": 213657,
-    "fullName": "Роберт Наварро",
-    "clubName": "Атлетик",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214071,
-    "fullName": "Хуан Иглесиас",
-    "clubName": "Хетафе",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.9,
-    "fp_last": 86.0
-  },
-  {
-    "playerId": 214063,
-    "fullName": "Давинчи",
-    "clubName": "Хетафе",
+    "playerId": 213622,
+    "fullName": "Парада",
+    "clubName": "Алавес",
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 8.2,
+    "popularity": 1.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 214069,
-    "fullName": "Джене",
-    "clubName": "Хетафе",
+    "playerId": 213625,
+    "fullName": "Гарсес",
+    "clubName": "Алавес",
     "position": "DEF",
     "league": "La Liga",
     "price": 4.5,
     "popularity": 1.2,
-    "fp_last": 78.0
-  },
-  {
-    "playerId": 213837,
-    "fullName": "Цыганков",
-    "clubName": "Жирона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 2.7,
-    "fp_last": 90.0
-  },
-  {
-    "playerId": 214008,
-    "fullName": "Браис Мендес",
-    "clubName": "Реал Сосьедад",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 1.9,
-    "fp_last": 73.0
-  },
-  {
-    "playerId": 214079,
-    "fullName": "Рико",
-    "clubName": "Хетафе",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 1.9,
-    "fp_last": 92.0
-  },
-  {
-    "playerId": 213663,
-    "fullName": "Саннади",
-    "clubName": "Атлетик",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 1.4,
-    "fp_last": 31.0
-  },
-  {
-    "playerId": 213723,
-    "fullName": "Педри",
-    "clubName": "Барселона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 8.0,
-    "popularity": 16.9,
-    "fp_last": 129.0
-  },
-  {
-    "playerId": 214087,
-    "fullName": "Арамбарри",
-    "clubName": "Хетафе",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 1.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213754,
-    "fullName": "Форнальс",
-    "clubName": "Бетис",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 1.5,
-    "fp_last": 67.0
-  },
-  {
-    "playerId": 213857,
-    "fullName": "Ури Рей",
-    "clubName": "Леванте",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213980,
-    "fullName": "Шаира",
-    "clubName": "Реал Овьедо",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213858,
-    "fullName": "Бруги",
-    "clubName": "Леванте",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213693,
-    "fullName": "Галлахер",
-    "clubName": "Атлетико",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 4.3,
-    "fp_last": 81.0
-  },
-  {
-    "playerId": 214085,
-    "fullName": "Луис Милья",
-    "clubName": "Хетафе",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.5,
-    "fp_last": 111.0
-  },
-  {
-    "playerId": 214077,
-    "fullName": "Марио Мартин",
-    "clubName": "Хетафе",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214096,
-    "fullName": "Аффенгрубер",
-    "clubName": "Эльче",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213781,
-    "fullName": "Раба",
-    "clubName": "Валенсия",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213892,
-    "fullName": "Розье",
-    "clubName": "Осасуна",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213747,
-    "fullName": "Серджи Альтимира",
-    "clubName": "Бетис",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 2.0,
-    "fp_last": 65.0
-  },
-  {
-    "playerId": 213907,
-    "fullName": "Будимир",
-    "clubName": "Осасуна",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 8.0,
-    "popularity": 8.0,
-    "fp_last": 190.0
-  },
-  {
-    "playerId": 213904,
-    "fullName": "Торро",
-    "clubName": "Осасуна",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.3,
-    "fp_last": 109.0
-  },
-  {
-    "playerId": 214124,
-    "fullName": "Карлос Ромеро",
-    "clubName": "Эспаньол",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 89.0
-  },
-  {
-    "playerId": 214108,
-    "fullName": "Мартим Нету",
-    "clubName": "Эльче",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214110,
-    "fullName": "Фебас",
-    "clubName": "Эльче",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213926,
-    "fullName": "Унаи Лопес",
-    "clubName": "Райо Вальекано",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.6,
-    "fp_last": 61.0
-  },
-  {
-    "playerId": 213756,
-    "fullName": "Ло Чельсо",
-    "clubName": "Бетис",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 16.0,
-    "fp_last": 89.0
-  },
-  {
-    "playerId": 214101,
-    "fullName": "Мендоса",
-    "clubName": "Эльче",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 4.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213720,
-    "fullName": "Гави",
-    "clubName": "Барселона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 3.5,
-    "fp_last": 50.0
-  },
-  {
-    "playerId": 213721,
-    "fullName": "де Йонг",
-    "clubName": "Барселона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 2.9,
-    "fp_last": 50.0
-  },
-  {
-    "playerId": 213768,
-    "fullName": "Фулькье",
-    "clubName": "Валенсия",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.0,
-    "fp_last": 57.0
-  },
-  {
-    "playerId": 214129,
-    "fullName": "Эль-Хилали",
-    "clubName": "Эспаньол",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 87.0
-  },
-  {
-    "playerId": 213948,
-    "fullName": "Браим Диас",
-    "clubName": "Реал Мадрид",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 1.8,
-    "fp_last": 80.0
-  },
-  {
-    "playerId": 213802,
-    "fullName": "Комесанья",
-    "clubName": "Вильярреал",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.3,
-    "fp_last": 105.0
-  },
-  {
-    "playerId": 214001,
-    "fullName": "Барренечеа",
-    "clubName": "Реал Сосьедад",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 2.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213880,
-    "fullName": "Антонио Санчес",
-    "clubName": "Мальорка",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 48.0
-  },
-  {
-    "playerId": 214010,
-    "fullName": "Ойарсабаль",
-    "clubName": "Реал Сосьедад",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 7.5,
-    "popularity": 14.2,
-    "fp_last": 108.0
-  },
-  {
-    "playerId": 213662,
-    "fullName": "Руис де Галаррета",
-    "clubName": "Атлетик",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.4,
-    "fp_last": 60.0
-  },
-  {
-    "playerId": 213665,
-    "fullName": "Хаурегисар",
-    "clubName": "Атлетик",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 0.9,
-    "fp_last": 89.0
-  },
-  {
-    "playerId": 213877,
-    "fullName": "Мохика",
-    "clubName": "Мальорка",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.8,
-    "fp_last": 94.0
-  },
-  {
-    "playerId": 214000,
-    "fullName": "Пабло Марин",
-    "clubName": "Реал Сосьедад",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213952,
-    "fullName": "Гюлер",
-    "clubName": "Реал Мадрид",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 8.0,
-    "popularity": 13.7,
-    "fp_last": 78.0
-  },
-  {
-    "playerId": 213950,
-    "fullName": "Вальверде",
-    "clubName": "Реал Мадрид",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 8.0,
-    "popularity": 13.7,
-    "fp_last": 151.0
-  },
-  {
-    "playerId": 213947,
-    "fullName": "Тчуамени",
-    "clubName": "Реал Мадрид",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 2.4,
-    "fp_last": 94.0
-  },
-  {
-    "playerId": 213695,
-    "fullName": "Альмада",
-    "clubName": "Атлетико",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 1.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214135,
-    "fullName": "Поль Лосано",
-    "clubName": "Эспаньол",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.1,
     "fp_last": 0.0
   },
   {
@@ -990,656 +80,6 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213822,
-    "fullName": "Давид Лопес",
-    "clubName": "Жирона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 79.0
-  },
-  {
-    "playerId": 213975,
-    "fullName": "Сибо",
-    "clubName": "Реал Овьедо",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213641,
-    "fullName": "Висенте",
-    "clubName": "Алавес",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 1.0,
-    "fp_last": 144.0
-  },
-  {
-    "playerId": 214105,
-    "fullName": "Хори",
-    "clubName": "Эльче",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 2.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213745,
-    "fullName": "Рикардо Родригес",
-    "clubName": "Бетис",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.9,
-    "fp_last": 44.0
-  },
-  {
-    "playerId": 213897,
-    "fullName": "Катена",
-    "clubName": "Осасуна",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.6,
-    "fp_last": 93.0
-  },
-  {
-    "playerId": 213901,
-    "fullName": "Монкайола",
-    "clubName": "Осасуна",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 59.0
-  },
-  {
-    "playerId": 213899,
-    "fullName": "Серхио Эррера",
-    "clubName": "Осасуна",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 1.6,
-    "fp_last": 118.0
-  },
-  {
-    "playerId": 214103,
-    "fullName": "Петро",
-    "clubName": "Эльче",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214102,
-    "fullName": "Нуньес",
-    "clubName": "Эльче",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213906,
-    "fullName": "Орос",
-    "clubName": "Осасуна",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 0.7,
-    "fp_last": 126.0
-  },
-  {
-    "playerId": 213625,
-    "fullName": "Гарсес",
-    "clubName": "Алавес",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213622,
-    "fullName": "Парада",
-    "clubName": "Алавес",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 1.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213896,
-    "fullName": "Бойомо",
-    "clubName": "Осасуна",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 1.5,
-    "fp_last": 105.0
-  },
-  {
-    "playerId": 214097,
-    "fullName": "Бигас",
-    "clubName": "Эльче",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213823,
-    "fullName": "Крейчи",
-    "clubName": "Жирона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 2.0,
-    "fp_last": 57.0
-  },
-  {
-    "playerId": 214099,
-    "fullName": "Дитуро",
-    "clubName": "Эльче",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213969,
-    "fullName": "Эскандель",
-    "clubName": "Реал Овьедо",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214031,
-    "fullName": "Соу",
-    "clubName": "Севилья",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 79.0
-  },
-  {
-    "playerId": 214024,
-    "fullName": "Салас",
-    "clubName": "Севилья",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214058,
-    "fullName": "Аспас",
-    "clubName": "Сельта",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 14.3,
-    "fp_last": 102.0
-  },
-  {
-    "playerId": 213886,
-    "fullName": "Дардер",
-    "clubName": "Мальорка",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 0.6,
-    "fp_last": 113.0
-  },
-  {
-    "playerId": 213691,
-    "fullName": "Руджери",
-    "clubName": "Атлетико",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 4.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213856,
-    "fullName": "Иван Ромеро",
-    "clubName": "Леванте",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214122,
-    "fullName": "Дмитрович",
-    "clubName": "Эспаньол",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 3.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213927,
-    "fullName": "Сисс",
-    "clubName": "Райо Вальекано",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.1,
-    "fp_last": 82.0
-  },
-  {
-    "playerId": 214141,
-    "fullName": "Пуадо",
-    "clubName": "Эспаньол",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.5,
-    "popularity": 2.3,
-    "fp_last": 163.0
-  },
-  {
-    "playerId": 213925,
-    "fullName": "Рациу",
-    "clubName": "Райо Вальекано",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 2.4,
-    "fp_last": 110.0
-  },
-  {
-    "playerId": 213924,
-    "fullName": "Лежен",
-    "clubName": "Райо Вальекано",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 1.5,
-    "fp_last": 111.0
-  },
-  {
-    "playerId": 213922,
-    "fullName": "Диас",
-    "clubName": "Райо Вальекано",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.3,
-    "fp_last": 53.0
-  },
-  {
-    "playerId": 213669,
-    "fullName": "Иньяки Уильямс",
-    "clubName": "Атлетик",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 8.0,
-    "popularity": 5.9,
-    "fp_last": 134.0
-  },
-  {
-    "playerId": 213737,
-    "fullName": "Бартра",
-    "clubName": "Бетис",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 13.6,
-    "fp_last": 70.0
-  },
-  {
-    "playerId": 213955,
-    "fullName": "Винисиус Жуниор",
-    "clubName": "Реал Мадрид",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 10.0,
-    "popularity": 12.0,
-    "fp_last": 146.0
-  },
-  {
-    "playerId": 213779,
-    "fullName": "Риоха",
-    "clubName": "Валенсия",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 0.4,
-    "fp_last": 120.0
-  },
-  {
-    "playerId": 213915,
-    "fullName": "Чаваррия",
-    "clubName": "Райо Вальекано",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.2,
-    "fp_last": 85.0
-  },
-  {
-    "playerId": 213698,
-    "fullName": "Алекс Баэна",
-    "clubName": "Атлетико",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 8.5,
-    "popularity": 10.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213836,
-    "fullName": "Янхель Эррера",
-    "clubName": "Жирона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214054,
-    "fullName": "Мориба",
-    "clubName": "Сельта",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 1.7,
-    "fp_last": 70.0
-  },
-  {
-    "playerId": 213733,
-    "fullName": "Бельерин",
-    "clubName": "Бетис",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 2.4,
-    "fp_last": 22.0
-  },
-  {
-    "playerId": 213961,
-    "fullName": "Альхассан",
-    "clubName": "Реал Овьедо",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213827,
-    "fullName": "Солис",
-    "clubName": "Жирона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 25.0
-  },
-  {
-    "playerId": 213774,
-    "fullName": "Таррега",
-    "clubName": "Валенсия",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.9,
-    "fp_last": 93.0
-  },
-  {
-    "playerId": 213782,
-    "fullName": "Дуро",
-    "clubName": "Валенсия",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 7.5,
-    "popularity": 4.2,
-    "fp_last": 116.0
-  },
-  {
-    "playerId": 214042,
-    "fullName": "Ристич",
-    "clubName": "Сельта",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 1.0,
-    "fp_last": 23.0
-  },
-  {
-    "playerId": 213879,
-    "fullName": "Раильо",
-    "clubName": "Мальорка",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 1.0,
-    "fp_last": 105.0
-  },
-  {
-    "playerId": 213867,
-    "fullName": "Вальент",
-    "clubName": "Мальорка",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 93.0
-  },
-  {
-    "playerId": 213799,
-    "fullName": "Бьюкенен",
-    "clubName": "Вильярреал",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.4,
-    "fp_last": 24.0
-  },
-  {
-    "playerId": 214036,
-    "fullName": "Эджуке",
-    "clubName": "Севилья",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.5,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 213777,
-    "fullName": "Герра",
-    "clubName": "Валенсия",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 1.3,
-    "fp_last": 107.0
-  },
-  {
-    "playerId": 213770,
-    "fullName": "Агирресабала",
-    "clubName": "Валенсия",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 4.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213778,
-    "fullName": "Пепелу",
-    "clubName": "Валенсия",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 0.7,
-    "fp_last": 73.0
-  },
-  {
-    "playerId": 213872,
-    "fullName": "Роман",
-    "clubName": "Мальорка",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.5,
-    "fp_last": 30.0
-  },
-  {
-    "playerId": 214053,
-    "fullName": "Мингеса",
-    "clubName": "Сельта",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 21.9,
-    "fp_last": 114.0
-  },
-  {
-    "playerId": 213654,
-    "fullName": "Берчиче",
-    "clubName": "Атлетик",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 7.7,
-    "fp_last": 89.0
-  },
-  {
-    "playerId": 214056,
-    "fullName": "Бельтран",
-    "clubName": "Сельта",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.8,
-    "fp_last": 89.0
-  },
-  {
-    "playerId": 213766,
-    "fullName": "Копете",
-    "clubName": "Валенсия",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213666,
-    "fullName": "Беренгер",
-    "clubName": "Атлетик",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 4.0,
-    "fp_last": 134.0
-  },
-  {
-    "playerId": 213664,
-    "fullName": "Унаи Симон",
-    "clubName": "Атлетик",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 12.5,
-    "fp_last": 93.0
-  },
-  {
-    "playerId": 213661,
-    "fullName": "Вивиан",
-    "clubName": "Атлетик",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 9.8,
-    "fp_last": 125.0
-  },
-  {
-    "playerId": 213658,
-    "fullName": "Паредес",
-    "clubName": "Атлетик",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 2.7,
-    "fp_last": 68.0
-  },
-  {
-    "playerId": 213962,
-    "fullName": "Начо Видаль",
-    "clubName": "Реал Овьедо",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214131,
-    "fullName": "Кабрера",
-    "clubName": "Эспаньол",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 1.3,
-    "fp_last": 106.0
-  },
-  {
-    "playerId": 215666,
-    "fullName": "Чалета-Цар",
-    "clubName": "Реал Сосьедад",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213997,
-    "fullName": "Туррьентес",
-    "clubName": "Реал Сосьедад",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 30.0
-  },
-  {
-    "playerId": 214003,
-    "fullName": "Ремиро",
-    "clubName": "Реал Сосьедад",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 2.5,
-    "fp_last": 132.0
-  },
-  {
     "playerId": 213639,
     "fullName": "Гуриди",
     "clubName": "Алавес",
@@ -1648,56 +88,6 @@
     "price": 5.5,
     "popularity": 0.4,
     "fp_last": 83.0
-  },
-  {
-    "playerId": 213998,
-    "fullName": "Арамбуру",
-    "clubName": "Реал Сосьедад",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 2.5,
-    "fp_last": 90.0
-  },
-  {
-    "playerId": 213634,
-    "fullName": "Ибаньес",
-    "clubName": "Алавес",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214061,
-    "fullName": "Жуджла",
-    "clubName": "Сельта",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 3.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214139,
-    "fullName": "Роберто Фернандес",
-    "clubName": "Эспаньол",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.4,
-    "fp_last": 67.0
-  },
-  {
-    "playerId": 213690,
-    "fullName": "Облак",
-    "clubName": "Атлетико",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 23.7,
-    "fp_last": 143.0
   },
   {
     "playerId": 213630,
@@ -1710,9 +100,19 @@
     "fp_last": 91.0
   },
   {
-    "playerId": 214111,
-    "fullName": "Альваро Родригес",
-    "clubName": "Эльче",
+    "playerId": 213634,
+    "fullName": "Ибаньес",
+    "clubName": "Алавес",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215655,
+    "fullName": "Мариано Диас",
+    "clubName": "Алавес",
     "position": "FWD",
     "league": "La Liga",
     "price": 5.5,
@@ -1720,793 +120,13 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 214095,
-    "fullName": "Марк Агуадо",
-    "clubName": "Эльче",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 16.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214100,
-    "fullName": "Искьердо",
-    "clubName": "Эльче",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213757,
-    "fullName": "Кучо Эрнандес",
-    "clubName": "Бетис",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 5.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213905,
-    "fullName": "Рубен Гарсия",
-    "clubName": "Осасуна",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 0.4,
-    "fp_last": 116.0
-  },
-  {
-    "playerId": 213743,
-    "fullName": "Натан",
-    "clubName": "Бетис",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 3.6,
-    "fp_last": 59.0
-  },
-  {
-    "playerId": 213740,
-    "fullName": "Пау Лопес",
-    "clubName": "Бетис",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 3.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213994,
-    "fullName": "Айен Муньос",
-    "clubName": "Реал Сосьедад",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 36.0
-  },
-  {
-    "playerId": 214019,
-    "fullName": "Гудель",
-    "clubName": "Севилья",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 1.8,
-    "fp_last": 79.0
-  },
-  {
-    "playerId": 213995,
-    "fullName": "Субельдия",
-    "clubName": "Реал Сосьедад",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 2.2,
-    "fp_last": 65.0
-  },
-  {
-    "playerId": 213921,
-    "fullName": "Баталья",
-    "clubName": "Райо Вальекано",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 1.6,
-    "fp_last": 109.0
-  },
-  {
-    "playerId": 214050,
-    "fullName": "Сотело",
-    "clubName": "Сельта",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 40.0
-  },
-  {
-    "playerId": 213859,
-    "fullName": "Пабло Мартинес",
-    "clubName": "Леванте",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214021,
-    "fullName": "Кармона",
-    "clubName": "Севилья",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 78.0
-  },
-  {
-    "playerId": 214020,
-    "fullName": "Идумбо-Музамбо",
-    "clubName": "Севилья",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 25.0
-  },
-  {
-    "playerId": 213978,
-    "fullName": "Илич",
-    "clubName": "Реал Овьедо",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214051,
-    "fullName": "Хави Родригес",
-    "clubName": "Сельта",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 3.3,
-    "fp_last": 86.0
-  },
-  {
-    "playerId": 214057,
-    "fullName": "Дуран",
-    "clubName": "Сельта",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.8,
-    "fp_last": 71.0
-  },
-  {
-    "playerId": 213850,
-    "fullName": "Ману Санчес",
-    "clubName": "Леванте",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213866,
-    "fullName": "Тони Лато",
-    "clubName": "Мальорка",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 1.1,
-    "fp_last": 25.0
-  },
-  {
-    "playerId": 213852,
-    "fullName": "Эльхесабаль",
-    "clubName": "Леванте",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214052,
-    "fullName": "Алонсо",
-    "clubName": "Сельта",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 9.5,
-    "fp_last": 78.0
-  },
-  {
-    "playerId": 213860,
-    "fullName": "Моралес",
-    "clubName": "Леванте",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213861,
-    "fullName": "Карлос Альварес",
-    "clubName": "Леванте",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213990,
-    "fullName": "Элустондо",
-    "clubName": "Реал Сосьедад",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 37.0
-  },
-  {
-    "playerId": 214026,
-    "fullName": "Янузай",
-    "clubName": "Севилья",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214047,
-    "fullName": "Раду",
-    "clubName": "Сельта",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 6.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213936,
-    "fullName": "Карвахаль",
-    "clubName": "Реал Мадрид",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 1.9,
-    "fp_last": 34.0
-  },
-  {
-    "playerId": 213979,
-    "fullName": "Рондон",
-    "clubName": "Реал Овьедо",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 2.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213977,
-    "fullName": "Хассан",
-    "clubName": "Реал Овьедо",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213972,
-    "fullName": "Касорла",
-    "clubName": "Реал Овьедо",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 3.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213970,
-    "fullName": "Виньяс",
-    "clubName": "Реал Овьедо",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213968,
-    "fullName": "Борха Санчес",
-    "clubName": "Реал Овьедо",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213967,
-    "fullName": "Луэнго",
-    "clubName": "Реал Овьедо",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214005,
-    "fullName": "Серхио Гомес",
-    "clubName": "Реал Сосьедад",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 3.9,
-    "fp_last": 129.0
-  },
-  {
-    "playerId": 213964,
-    "fullName": "Кальво",
-    "clubName": "Реал Овьедо",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214007,
-    "fullName": "Оускарссон",
-    "clubName": "Реал Сосьедад",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 0.8,
-    "fp_last": 42.0
-  },
-  {
-    "playerId": 214012,
-    "fullName": "Маркао Тейшейра",
-    "clubName": "Севилья",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 1.0,
-    "fp_last": 10.0
-  },
-  {
-    "playerId": 213951,
-    "fullName": "Гонсало Гарсия",
-    "clubName": "Реал Мадрид",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 8.0,
-    "popularity": 3.0,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 213942,
-    "fullName": "Себальос",
-    "clubName": "Реал Мадрид",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.2,
-    "fp_last": 41.0
-  },
-  {
-    "playerId": 214022,
-    "fullName": "Нюланд",
-    "clubName": "Севилья",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 1.0,
-    "fp_last": 97.0
-  },
-  {
-    "playerId": 213874,
-    "fullName": "Маскарель",
-    "clubName": "Мальорка",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 69.0
-  },
-  {
-    "playerId": 214023,
-    "fullName": "Рафа Мир",
-    "clubName": "Эльче",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213919,
-    "fullName": "Оскар Валентин",
-    "clubName": "Райо Вальекано",
+    "playerId": 213635,
+    "fullName": "Калебе",
+    "clubName": "Алавес",
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
     "popularity": 0.1,
-    "fp_last": 61.0
-  },
-  {
-    "playerId": 213918,
-    "fullName": "Нтека",
-    "clubName": "Райо Вальекано",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 49.0
-  },
-  {
-    "playerId": 213917,
-    "fullName": "Гумбау",
-    "clubName": "Райо Вальекано",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 28.0
-  },
-  {
-    "playerId": 213916,
-    "fullName": "Эспино",
-    "clubName": "Райо Вальекано",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 22.0
-  },
-  {
-    "playerId": 213848,
-    "fullName": "Морено",
-    "clubName": "Леванте",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213910,
-    "fullName": "Пелайо Фернандес",
-    "clubName": "Райо Вальекано",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.8,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 213903,
-    "fullName": "Рауль Гарсия",
-    "clubName": "Осасуна",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 213902,
-    "fullName": "Виктор Муньос",
-    "clubName": "Осасуна",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213900,
-    "fullName": "Мойсес Гомес",
-    "clubName": "Осасуна",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 34.0
-  },
-  {
-    "playerId": 214035,
-    "fullName": "Исаак Ромеро",
-    "clubName": "Севилья",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 1.0,
-    "fp_last": 72.0
-  },
-  {
-    "playerId": 213883,
-    "fullName": "Дани Родригес",
-    "clubName": "Мальорка",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.5,
-    "fp_last": 106.0
-  },
-  {
-    "playerId": 213881,
-    "fullName": "Асано",
-    "clubName": "Мальорка",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 48.0
-  },
-  {
-    "playerId": 213849,
-    "fullName": "Пампин",
-    "clubName": "Леванте",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213805,
-    "fullName": "Молейро",
-    "clubName": "Вильярреал",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 1.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214059,
-    "fullName": "Сарагоса",
-    "clubName": "Сельта",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 4.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213718,
-    "fullName": "Кунде",
-    "clubName": "Барселона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 17.3,
-    "fp_last": 102.0
-  },
-  {
-    "playerId": 214134,
-    "fullName": "Каррерас",
-    "clubName": "Эспаньол",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 89.0
-  },
-  {
-    "playerId": 213687,
-    "fullName": "Ганцко",
-    "clubName": "Атлетико",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 5.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213688,
-    "fullName": "Коке",
-    "clubName": "Атлетико",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 1.2,
-    "fp_last": 70.0
-  },
-  {
-    "playerId": 213692,
-    "fullName": "Барриос",
-    "clubName": "Атлетико",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 1.6,
-    "fp_last": 93.0
-  },
-  {
-    "playerId": 213697,
-    "fullName": "Гризманн",
-    "clubName": "Атлетико",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 8.0,
-    "popularity": 7.6,
-    "fp_last": 144.0
-  },
-  {
-    "playerId": 213699,
-    "fullName": "Серлот",
-    "clubName": "Атлетико",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 8.5,
-    "popularity": 4.8,
-    "fp_last": 131.0
-  },
-  {
-    "playerId": 214123,
-    "fullName": "Калеро",
-    "clubName": "Эспаньол",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 35.0
-  },
-  {
-    "playerId": 213722,
-    "fullName": "Фермин Лопес",
-    "clubName": "Барселона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 7.5,
-    "popularity": 2.7,
-    "fp_last": 84.0
-  },
-  {
-    "playerId": 214138,
-    "fullName": "Терратс",
-    "clubName": "Эспаньол",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213846,
-    "fullName": "Серхио Лосано",
-    "clubName": "Леванте",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213726,
-    "fullName": "Ольмо",
-    "clubName": "Барселона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 9.0,
-    "popularity": 2.3,
-    "fp_last": 106.0
-  },
-  {
-    "playerId": 214109,
-    "fullName": "Мурад",
-    "clubName": "Эльче",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213750,
-    "fullName": "Чими Авила",
-    "clubName": "Бетис",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 24.0
-  },
-  {
-    "playerId": 213751,
-    "fullName": "Бакамбу",
-    "clubName": "Бетис",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 1.4,
-    "fp_last": 42.0
-  },
-  {
-    "playerId": 213752,
-    "fullName": "Борха Иглесиас",
-    "clubName": "Сельта",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 3.0,
-    "fp_last": 115.0
-  },
-  {
-    "playerId": 213769,
-    "fullName": "Хесус Васкес",
-    "clubName": "Валенсия",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 29.0
-  },
-  {
-    "playerId": 213771,
-    "fullName": "Гайя",
-    "clubName": "Валенсия",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 5.9,
-    "fp_last": 62.0
-  },
-  {
-    "playerId": 214137,
-    "fullName": "Долан",
-    "clubName": "Эспаньол",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214140,
-    "fullName": "Кике Гарсия",
-    "clubName": "Эспаньол",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 1.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213776,
-    "fullName": "Андре Алмейда",
-    "clubName": "Валенсия",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 78.0
-  },
-  {
-    "playerId": 213647,
-    "fullName": "Рего Мора",
-    "clubName": "Атлетик",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
     "fp_last": 0.0
   },
   {
@@ -2520,16 +140,6 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216529,
-    "fullName": "Фернандес",
-    "clubName": "Мальорка",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
     "playerId": 213629,
     "fullName": "Реббаш",
     "clubName": "Алавес",
@@ -2538,16 +148,6 @@
     "price": 4.5,
     "popularity": 0.4,
     "fp_last": 12.0
-  },
-  {
-    "playerId": 216527,
-    "fullName": "Гарсия",
-    "clubName": "Бетис",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 2.0
   },
   {
     "playerId": 213633,
@@ -2560,32 +160,202 @@
     "fp_last": 71.0
   },
   {
-    "playerId": 213635,
-    "fullName": "Калебе",
+    "playerId": 213619,
+    "fullName": "Адриан Родригес",
+    "clubName": "Алавес",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 7.8,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 213632,
+    "fullName": "Вильялибре",
+    "clubName": "Алавес",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 23.0
+  },
+  {
+    "playerId": 213620,
+    "fullName": "Хоседа Альварес",
+    "clubName": "Алавес",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 10.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213628,
+    "fullName": "Новоа",
+    "clubName": "Алавес",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 213626,
+    "fullName": "Диарра",
+    "clubName": "Алавес",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 38.0
+  },
+  {
+    "playerId": 213623,
+    "fullName": "Рауль Фернандес",
+    "clubName": "Алавес",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213621,
+    "fullName": "Мараш",
+    "clubName": "Алавес",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213631,
+    "fullName": "Бенавидес",
     "clubName": "Алавес",
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.1,
+    "popularity": 0.2,
     "fp_last": 0.0
   },
   {
-    "playerId": 216525,
-    "fullName": "Торрентс",
-    "clubName": "Барселона",
+    "playerId": 213670,
+    "fullName": "Нико Уильямс",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.5,
+    "popularity": 25.6,
+    "fp_last": 108.0
+  },
+  {
+    "playerId": 213657,
+    "fullName": "Роберт Наварро",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213663,
+    "fullName": "Саннади",
+    "clubName": "Атлетик",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.4,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 213665,
+    "fullName": "Хаурегисар",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.9,
+    "fp_last": 89.0
+  },
+  {
+    "playerId": 213662,
+    "fullName": "Руис де Галаррета",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.4,
+    "fp_last": 60.0
+  },
+  {
+    "playerId": 213669,
+    "fullName": "Иньяки Уильямс",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 5.9,
+    "fp_last": 134.0
+  },
+  {
+    "playerId": 213661,
+    "fullName": "Вивиан",
+    "clubName": "Атлетик",
     "position": "DEF",
     "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
+    "price": 6.0,
+    "popularity": 9.8,
+    "fp_last": 125.0
   },
   {
-    "playerId": 216524,
-    "fullName": "Распадори",
-    "clubName": "Атлетико",
+    "playerId": 213654,
+    "fullName": "Берчиче",
+    "clubName": "Атлетик",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 7.7,
+    "fp_last": 89.0
+  },
+  {
+    "playerId": 213664,
+    "fullName": "Унаи Симон",
+    "clubName": "Атлетик",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 12.5,
+    "fp_last": 93.0
+  },
+  {
+    "playerId": 213658,
+    "fullName": "Паредес",
+    "clubName": "Атлетик",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.7,
+    "fp_last": 68.0
+  },
+  {
+    "playerId": 213666,
+    "fullName": "Беренгер",
+    "clubName": "Атлетик",
     "position": "MID",
     "league": "La Liga",
     "price": 7.0,
+    "popularity": 4.0,
+    "fp_last": 134.0
+  },
+  {
+    "playerId": 213647,
+    "fullName": "Рего Мора",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
     "popularity": 0.3,
     "fp_last": 0.0
   },
@@ -2600,34 +370,14 @@
     "fp_last": 65.0
   },
   {
-    "playerId": 215655,
-    "fullName": "Мариано Диас",
-    "clubName": "Алавес",
+    "playerId": 213667,
+    "fullName": "Гурусета",
+    "clubName": "Атлетик",
     "position": "FWD",
     "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215667,
-    "fullName": "Гедеш",
-    "clubName": "Реал Сосьедад",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 1.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215665,
-    "fullName": "Рейс",
-    "clubName": "Жирона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
+    "price": 7.0,
+    "popularity": 2.4,
+    "fp_last": 87.0
   },
   {
     "playerId": 213653,
@@ -2650,254 +400,14 @@
     "fp_last": 36.0
   },
   {
-    "playerId": 215663,
-    "fullName": "Парти",
-    "clubName": "Вильярреал",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215662,
-    "fullName": "Угринич",
-    "clubName": "Валенсия",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213667,
-    "fullName": "Гурусета",
+    "playerId": 213668,
+    "fullName": "Сансет",
     "clubName": "Атлетик",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 7.0,
-    "popularity": 2.4,
-    "fp_last": 87.0
-  },
-  {
-    "playerId": 215661,
-    "fullName": "Сантамария",
-    "clubName": "Валенсия",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214091,
-    "fullName": "Дональд",
-    "clubName": "Эльче",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 1.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213724,
-    "fullName": "Рэшфорд",
-    "clubName": "Барселона",
     "position": "MID",
     "league": "La Liga",
     "price": 8.0,
     "popularity": 2.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213991,
-    "fullName": "Урко Гонсалес",
-    "clubName": "Реал Сосьедад",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213841,
-    "fullName": "Адри",
-    "clubName": "Леванте",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213804,
-    "fullName": "Парехо",
-    "clubName": "Вильярреал",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 1.9,
-    "fp_last": 89.0
-  },
-  {
-    "playerId": 213803,
-    "fullName": "Данджума",
-    "clubName": "Валенсия",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 1.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213831,
-    "fullName": "Порту",
-    "clubName": "Жирона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 45.0
-  },
-  {
-    "playerId": 213832,
-    "fullName": "Асприлья",
-    "clubName": "Жирона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 2.0,
-    "fp_last": 63.0
-  },
-  {
-    "playerId": 213825,
-    "fullName": "Миовски",
-    "clubName": "Жирона",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 1.6,
-    "fp_last": 39.0
-  },
-  {
-    "playerId": 214080,
-    "fullName": "Сола",
-    "clubName": "Хетафе",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213833,
-    "fullName": "Лемар",
-    "clubName": "Жирона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213820,
-    "fullName": "Блинд",
-    "clubName": "Жирона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 5.2,
-    "fp_last": 82.0
-  },
-  {
-    "playerId": 213838,
-    "fullName": "Кабельо",
-    "clubName": "Леванте",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 7.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213801,
-    "fullName": "Жерар Морено",
-    "clubName": "Вильярреал",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 11.5,
-    "fp_last": 43.0
-  },
-  {
-    "playerId": 213842,
-    "fullName": "Виктор Гарсия",
-    "clubName": "Леванте",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213810,
-    "fullName": "Крапивцов",
-    "clubName": "Жирона",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 2.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213817,
-    "fullName": "Ринкон",
-    "clubName": "Жирона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213790,
-    "fullName": "Педраса",
-    "clubName": "Вильярреал",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 24.0
-  },
-  {
-    "playerId": 213845,
-    "fullName": "Куньят",
-    "clubName": "Леванте",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215664,
-    "fullName": "Кебе",
-    "clubName": "Жирона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214068,
-    "fullName": "Альдерете",
-    "clubName": "Хетафе",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.2,
-    "fp_last": 92.0
+    "fp_last": 130.0
   },
   {
     "playerId": 215656,
@@ -2910,1284 +420,14 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 214014,
-    "fullName": "Ньянзу",
-    "clubName": "Севилья",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 18.0
-  },
-  {
-    "playerId": 214055,
-    "fullName": "Уго Альварес",
-    "clubName": "Сельта",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 1.5,
-    "fp_last": 74.0
-  },
-  {
-    "playerId": 215658,
-    "fullName": "Кочен",
-    "clubName": "Барселона",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215657,
-    "fullName": "Хисмера",
-    "clubName": "Атлетико",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215660,
-    "fullName": "Деосса",
-    "clubName": "Бетис",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214070,
-    "fullName": "Дуарте",
-    "clubName": "Хетафе",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 54.0
-  },
-  {
-    "playerId": 214011,
-    "fullName": "Альберто Флорес",
-    "clubName": "Севилья",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 1.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215659,
-    "fullName": "Форт",
-    "clubName": "Барселона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 31.0
-  },
-  {
-    "playerId": 214072,
-    "fullName": "Петер Федерико",
-    "clubName": "Хетафе",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 17.0
-  },
-  {
-    "playerId": 214067,
-    "fullName": "Абкар",
-    "clubName": "Хетафе",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214013,
-    "fullName": "Рамон Мартинес",
-    "clubName": "Севилья",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 12.0
-  },
-  {
-    "playerId": 214037,
-    "fullName": "Варгас",
-    "clubName": "Севилья",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 0.3,
-    "fp_last": 34.0
-  },
-  {
-    "playerId": 215668,
-    "fullName": "Виктор Чуст",
-    "clubName": "Эльче",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214066,
-    "fullName": "Эрранс",
-    "clubName": "Хетафе",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 1.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214060,
-    "fullName": "Сведберг",
-    "clubName": "Сельта",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 0.7,
-    "fp_last": 83.0
-  },
-  {
-    "playerId": 213992,
-    "fullName": "Захарян",
-    "clubName": "Реал Сосьедад",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 2.3,
-    "fp_last": 8.0
-  },
-  {
-    "playerId": 213993,
-    "fullName": "Каррикабуру",
-    "clubName": "Реал Сосьедад",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216532,
-    "fullName": "Яньес",
-    "clubName": "Реал Мадрид",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216531,
-    "fullName": "Мартин",
-    "clubName": "Реал Мадрид",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213996,
-    "fullName": "Траоре",
-    "clubName": "Реал Сосьедад",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.6,
-    "fp_last": 35.0
-  },
-  {
-    "playerId": 216530,
-    "fullName": "Диего Агуадо",
-    "clubName": "Реал Мадрид",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213999,
-    "fullName": "Горрочатеги",
-    "clubName": "Реал Сосьедад",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216528,
-    "fullName": "Витцель",
-    "clubName": "Жирона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214006,
-    "fullName": "Сучич",
-    "clubName": "Реал Сосьедад",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.4,
-    "fp_last": 70.0
-  },
-  {
-    "playerId": 214064,
-    "fullName": "Летачек",
-    "clubName": "Хетафе",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216526,
-    "fullName": "Дро Фернандес",
-    "clubName": "Барселона",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214002,
-    "fullName": "Беккер",
-    "clubName": "Реал Сосьедад",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.3,
-    "fp_last": 42.0
-  },
-  {
-    "playerId": 214065,
-    "fullName": "Трилья",
-    "clubName": "Хетафе",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214004,
-    "fullName": "Садик",
-    "clubName": "Реал Сосьедад",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216523,
-    "fullName": "Марио де Луис",
-    "clubName": "Атлетико",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216522,
-    "fullName": "Хон де Луис",
+    "playerId": 213642,
+    "fullName": "Лекуэ",
     "clubName": "Атлетик",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214073,
-    "fullName": "Риско",
-    "clubName": "Хетафе",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 5.0
-  },
-  {
-    "playerId": 214015,
-    "fullName": "Альваро Фернандес",
-    "clubName": "Севилья",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 20.0
-  },
-  {
-    "playerId": 214048,
-    "fullName": "Дамиан Родригес",
-    "clubName": "Сельта",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 29.0
-  },
-  {
-    "playerId": 214074,
-    "fullName": "Фемения",
-    "clubName": "Хетафе",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214098,
-    "fullName": "Боаяр",
-    "clubName": "Эльче",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 9.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214112,
-    "fullName": "Хосан",
-    "clubName": "Эльче",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214028,
-    "fullName": "Жордан",
-    "clubName": "Севилья",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214029,
-    "fullName": "Ихеаначо",
-    "clubName": "Севилья",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.8,
-    "fp_last": 13.0
-  },
-  {
-    "playerId": 214043,
-    "fullName": "Руэда",
-    "clubName": "Сельта",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214030,
-    "fullName": "Пеке",
-    "clubName": "Севилья",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 45.0
-  },
-  {
-    "playerId": 214107,
-    "fullName": "де Сантьяго",
-    "clubName": "Эльче",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214104,
-    "fullName": "Рафаэль Нуньес",
-    "clubName": "Эльче",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214081,
-    "fullName": "Хуанми",
-    "clubName": "Хетафе",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 33.0
-  },
-  {
-    "playerId": 214041,
-    "fullName": "Карлос Домингес",
-    "clubName": "Сельта",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.9,
-    "fp_last": 31.0
-  },
-  {
-    "playerId": 214094,
-    "fullName": "Хесус Лопес",
-    "clubName": "Эльче",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214114,
-    "fullName": "Рамон",
-    "clubName": "Эспаньол",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214093,
-    "fullName": "Кастильо",
-    "clubName": "Эльче",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214082,
-    "fullName": "Санкрис",
-    "clubName": "Хетафе",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214040,
-    "fullName": "Марк Видаль",
-    "clubName": "Сельта",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214092,
-    "fullName": "Итурбе",
-    "clubName": "Эльче",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 2.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214039,
-    "fullName": "Айду",
-    "clubName": "Сельта",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 6.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214090,
-    "fullName": "Диаби",
-    "clubName": "Эльче",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 1.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214034,
-    "fullName": "Альфон Гонсалес",
-    "clubName": "Севилья",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214089,
-    "fullName": "Барзич",
-    "clubName": "Эльче",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 12.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214088,
-    "fullName": "Майораль",
-    "clubName": "Хетафе",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 1.2,
-    "fp_last": 58.0
-  },
-  {
-    "playerId": 214113,
-    "fullName": "Инохо",
-    "clubName": "Эспаньол",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214115,
-    "fullName": "Рубен Санчес",
-    "clubName": "Эспаньол",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 1.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214016,
-    "fullName": "Баде",
-    "clubName": "Севилья",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 79.0
-  },
-  {
-    "playerId": 214045,
-    "fullName": "Каррейра",
-    "clubName": "Сельта",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.0,
-    "fp_last": 59.0
-  },
-  {
-    "playerId": 214049,
-    "fullName": "Серви",
-    "clubName": "Сельта",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 8.0
-  },
-  {
-    "playerId": 214017,
-    "fullName": "Буэно",
-    "clubName": "Севилья",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.4,
-    "fp_last": 16.0
-  },
-  {
-    "playerId": 214084,
-    "fullName": "Хави Муньос",
-    "clubName": "Хетафе",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214133,
-    "fullName": "Антониу Рока",
-    "clubName": "Эспаньол",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 35.0
-  },
-  {
-    "playerId": 214075,
-    "fullName": "да Коста",
-    "clubName": "Хетафе",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 32.0
-  },
-  {
-    "playerId": 214018,
-    "fullName": "Педроса",
-    "clubName": "Севилья",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 83.0
-  },
-  {
-    "playerId": 214078,
-    "fullName": "Неу",
-    "clubName": "Хетафе",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214130,
-    "fullName": "Хави Эрнандес",
-    "clubName": "Эспаньол",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214046,
-    "fullName": "Старфельт",
-    "clubName": "Сельта",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 2.2,
-    "fp_last": 66.0
-  },
-  {
-    "playerId": 214128,
-    "fullName": "Маркос Фернандес",
-    "clubName": "Эспаньол",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214116,
-    "fullName": "Тристан",
-    "clubName": "Эспаньол",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214127,
-    "fullName": "Салинас",
-    "clubName": "Эспаньол",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214126,
-    "fullName": "Саласар",
-    "clubName": "Эспаньол",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214121,
-    "fullName": "Гастон Вальес",
-    "clubName": "Эспаньол",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 3.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214120,
-    "fullName": "Бауса",
-    "clubName": "Эспаньол",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 2.5,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 214119,
-    "fullName": "Фортуньо",
-    "clubName": "Эспаньол",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214118,
-    "fullName": "Форнс",
-    "clubName": "Эспаньол",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214117,
-    "fullName": "Уго Перес",
-    "clubName": "Эспаньол",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214044,
-    "fullName": "Вильяр",
-    "clubName": "Сельта",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 13.0
-  },
-  {
-    "playerId": 214025,
-    "fullName": "Суасо",
-    "clubName": "Севилья",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213619,
-    "fullName": "Адриан Родригес",
-    "clubName": "Алавес",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 7.8,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 213893,
-    "fullName": "Хуан Крус",
-    "clubName": "Осасуна",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 59.0
-  },
-  {
-    "playerId": 213989,
-    "fullName": "Хави Лопес",
-    "clubName": "Реал Сосьедад",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 213732,
-    "fullName": "Нобель Менди",
-    "clubName": "Бетис",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213744,
-    "fullName": "Петит",
-    "clubName": "Бетис",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213742,
-    "fullName": "Диего Льоренте",
-    "clubName": "Бетис",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 85.0
-  },
-  {
-    "playerId": 213741,
-    "fullName": "Лосада",
-    "clubName": "Бетис",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213739,
-    "fullName": "Гомес",
-    "clubName": "Бетис",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213738,
-    "fullName": "Альваро Вальес",
-    "clubName": "Бетис",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 1.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213736,
-    "fullName": "Сенхаджи",
-    "clubName": "Бетис",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213735,
-    "fullName": "Перро",
-    "clubName": "Бетис",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 53.0
-  },
-  {
-    "playerId": 213734,
-    "fullName": "Ортис",
-    "clubName": "Бетис",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 15.0
-  },
-  {
-    "playerId": 213731,
-    "fullName": "Вьейтес",
-    "clubName": "Бетис",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 8.0
-  },
-  {
-    "playerId": 213749,
-    "fullName": "Фирпо",
-    "clubName": "Бетис",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 4.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213730,
-    "fullName": "Адриан",
-    "clubName": "Бетис",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 18.1,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 213727,
-    "fullName": "Левандовски",
-    "clubName": "Барселона",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 10.0,
-    "popularity": 5.5,
-    "fp_last": 192.0
-  },
-  {
-    "playerId": 213717,
-    "fullName": "Касадо",
-    "clubName": "Барселона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.2,
-    "fp_last": 66.0
-  },
-  {
-    "playerId": 213715,
-    "fullName": "Бардагжи",
-    "clubName": "Барселона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213713,
-    "fullName": "Шченсны",
-    "clubName": "Барселона",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.9,
-    "fp_last": 62.0
-  },
-  {
-    "playerId": 213712,
-    "fullName": "тер Стеген",
-    "clubName": "Барселона",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.3,
-    "fp_last": 21.0
-  },
-  {
-    "playerId": 213711,
-    "fullName": "Иньиго Мартинес",
-    "clubName": "Барселона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 1.1,
-    "fp_last": 89.0
-  },
-  {
-    "playerId": 213710,
-    "fullName": "Жерар Мартин",
-    "clubName": "Барселона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.3,
-    "fp_last": 48.0
-  },
-  {
-    "playerId": 213746,
-    "fullName": "Марк Рока",
-    "clubName": "Бетис",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 43.0
-  },
-  {
-    "playerId": 213755,
-    "fullName": "Эззальзули",
-    "clubName": "Бетис",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 0.6,
-    "fp_last": 76.0
-  },
-  {
-    "playerId": 213706,
-    "fullName": "Кристенсен",
-    "clubName": "Барселона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 8.0
-  },
-  {
-    "playerId": 213773,
-    "fullName": "Мари",
-    "clubName": "Валенсия",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 213791,
-    "fullName": "Денис Суарес",
-    "clubName": "Вильярреал",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 1.0,
-    "fp_last": 33.0
-  },
-  {
-    "playerId": 213789,
-    "fullName": "Пау Наварро",
-    "clubName": "Вильярреал",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 28.0
-  },
-  {
-    "playerId": 213787,
-    "fullName": "Конде",
-    "clubName": "Вильярреал",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213786,
-    "fullName": "Камбвала",
-    "clubName": "Вильярреал",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213785,
-    "fullName": "Кабанес",
-    "clubName": "Вильярреал",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213784,
-    "fullName": "Адриа Альтимира",
-    "clubName": "Вильярреал",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213783,
-    "fullName": "Рубен Гомес",
-    "clubName": "Вильярреал",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213775,
-    "fullName": "Франсиско Перес",
-    "clubName": "Райо Вальекано",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213772,
-    "fullName": "Канос",
-    "clubName": "Валенсия",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 19.0
-  },
-  {
-    "playerId": 213758,
-    "fullName": "Иско",
-    "clubName": "Бетис",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 8.0,
-    "popularity": 4.3,
-    "fp_last": 115.0
-  },
-  {
-    "playerId": 213767,
-    "fullName": "Тьерри Коррейя",
-    "clubName": "Валенсия",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 25.0
-  },
-  {
-    "playerId": 213765,
-    "fullName": "Димитриевски",
-    "clubName": "Валенсия",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.9,
-    "fp_last": 11.0
-  },
-  {
-    "playerId": 213764,
-    "fullName": "Диакаби",
-    "clubName": "Валенсия",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.4,
-    "fp_last": 30.0
-  },
-  {
-    "playerId": 213763,
-    "fullName": "Гильямон",
-    "clubName": "Валенсия",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.2,
-    "fp_last": 14.0
-  },
-  {
-    "playerId": 213762,
-    "fullName": "Риверо",
-    "clubName": "Валенсия",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213761,
-    "fullName": "Озкаджар",
-    "clubName": "Валенсия",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213760,
-    "fullName": "Ирансо",
-    "clubName": "Валенсия",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213759,
-    "fullName": "Джемерт",
-    "clubName": "Валенсия",
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
     "popularity": 1.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213707,
-    "fullName": "Ромеу",
-    "clubName": "Барселона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213705,
-    "fullName": "Берналь",
-    "clubName": "Барселона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 213797,
-    "fullName": "Ахомаш",
-    "clubName": "Вильярреал",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 22.0
-  },
-  {
-    "playerId": 213645,
-    "fullName": "Венседор",
-    "clubName": "Атлетик",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.2,
-    "fp_last": 0.0
+    "fp_last": 32.0
   },
   {
     "playerId": 213660,
@@ -4208,6 +448,16 @@
     "price": 5.5,
     "popularity": 0.1,
     "fp_last": 60.0
+  },
+  {
+    "playerId": 213643,
+    "fullName": "Эхилус",
+    "clubName": "Атлетик",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213656,
@@ -4270,6 +520,16 @@
     "fp_last": 11.0
   },
   {
+    "playerId": 213645,
+    "fullName": "Венседор",
+    "clubName": "Атлетик",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2,
+    "fp_last": 0.0
+  },
+  {
     "playerId": 213644,
     "fullName": "Арес",
     "clubName": "Атлетик",
@@ -4280,119 +540,159 @@
     "fp_last": 1.0
   },
   {
-    "playerId": 213671,
-    "fullName": "Боньяр",
-    "clubName": "Атлетико",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 1.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213643,
-    "fullName": "Эхилус",
+    "playerId": 216522,
+    "fullName": "Хон де Луис",
     "clubName": "Атлетик",
     "position": "DEF",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213642,
-    "fullName": "Лекуэ",
-    "clubName": "Атлетик",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 1.8,
-    "fp_last": 32.0
-  },
-  {
-    "playerId": 213632,
-    "fullName": "Вильялибре",
-    "clubName": "Алавес",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 23.0
-  },
-  {
-    "playerId": 213631,
-    "fullName": "Бенавидес",
-    "clubName": "Алавес",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
     "popularity": 0.2,
     "fp_last": 0.0
   },
   {
-    "playerId": 213628,
-    "fullName": "Новоа",
-    "clubName": "Алавес",
+    "playerId": 213700,
+    "fullName": "Хулиан Альварес",
+    "clubName": "Атлетико",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 9.5,
+    "popularity": 34.8,
+    "fp_last": 152.0
+  },
+  {
+    "playerId": 213696,
+    "fullName": "Симеоне",
+    "clubName": "Атлетико",
     "position": "MID",
     "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 5.0
+    "price": 7.0,
+    "popularity": 4.6,
+    "fp_last": 82.0
   },
   {
-    "playerId": 213626,
-    "fullName": "Диарра",
-    "clubName": "Алавес",
-    "position": "DEF",
+    "playerId": 213693,
+    "fullName": "Галлахер",
+    "clubName": "Атлетико",
+    "position": "MID",
     "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 38.0
+    "price": 6.5,
+    "popularity": 4.3,
+    "fp_last": 81.0
   },
   {
-    "playerId": 213623,
-    "fullName": "Рауль Фернандес",
-    "clubName": "Алавес",
-    "position": "GK",
+    "playerId": 213695,
+    "fullName": "Альмада",
+    "clubName": "Атлетико",
+    "position": "MID",
     "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.9,
+    "price": 7.0,
+    "popularity": 1.9,
     "fp_last": 0.0
   },
   {
-    "playerId": 213621,
-    "fullName": "Мараш",
-    "clubName": "Алавес",
-    "position": "DEF",
+    "playerId": 213698,
+    "fullName": "Алекс Баэна",
+    "clubName": "Атлетико",
+    "position": "MID",
     "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.5,
+    "price": 8.5,
+    "popularity": 10.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 213668,
-    "fullName": "Сансет",
-    "clubName": "Атлетик",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 8.0,
-    "popularity": 2.7,
-    "fp_last": 130.0
-  },
-  {
-    "playerId": 213672,
-    "fullName": "Костис",
+    "playerId": 213691,
+    "fullName": "Руджери",
     "clubName": "Атлетико",
     "position": "DEF",
     "league": "La Liga",
-    "price": 4.0,
+    "price": 6.0,
+    "popularity": 4.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213690,
+    "fullName": "Облак",
+    "clubName": "Атлетико",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 23.7,
+    "fp_last": 143.0
+  },
+  {
+    "playerId": 216524,
+    "fullName": "Распадори",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
     "popularity": 0.3,
     "fp_last": 0.0
   },
   {
-    "playerId": 213704,
-    "fullName": "Тони Фернандес",
-    "clubName": "Барселона",
+    "playerId": 213688,
+    "fullName": "Коке",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.2,
+    "fp_last": 70.0
+  },
+  {
+    "playerId": 213699,
+    "fullName": "Серлот",
+    "clubName": "Атлетико",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 8.5,
+    "popularity": 4.8,
+    "fp_last": 131.0
+  },
+  {
+    "playerId": 213697,
+    "fullName": "Гризманн",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 7.6,
+    "fp_last": 144.0
+  },
+  {
+    "playerId": 213692,
+    "fullName": "Барриос",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.6,
+    "fp_last": 93.0
+  },
+  {
+    "playerId": 213687,
+    "fullName": "Ганцко",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 5.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213684,
+    "fullName": "Муссо",
+    "clubName": "Атлетико",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 213678,
+    "fullName": "Хавьер Серрано",
+    "clubName": "Атлетико",
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
@@ -4400,29 +700,59 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213683,
-    "fullName": "Молина",
+    "playerId": 216523,
+    "fullName": "Марио де Луис",
     "clubName": "Атлетико",
-    "position": "DEF",
+    "position": "GK",
     "league": "La Liga",
-    "price": 5.5,
-    "popularity": 1.8,
-    "fp_last": 82.0
-  },
-  {
-    "playerId": 213703,
-    "fullName": "Гилье Фернандес",
-    "clubName": "Барселона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.0,
+    "price": 4.0,
+    "popularity": 0.1,
     "fp_last": 0.0
   },
   {
-    "playerId": 213702,
-    "fullName": "Дани Родригес",
-    "clubName": "Барселона",
+    "playerId": 215657,
+    "fullName": "Хисмера",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213673,
+    "fullName": "Эскивель",
+    "clubName": "Атлетико",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213674,
+    "fullName": "Белаид",
+    "clubName": "Атлетико",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213675,
+    "fullName": "Джанне",
+    "clubName": "Атлетико",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213676,
+    "fullName": "Монсеррате",
+    "clubName": "Атлетико",
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
@@ -4430,10 +760,10 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213701,
-    "fullName": "Пенья",
-    "clubName": "Барселона",
-    "position": "GK",
+    "playerId": 213677,
+    "fullName": "Сейду",
+    "clubName": "Атлетико",
+    "position": "MID",
     "league": "La Liga",
     "price": 4.5,
     "popularity": 0.1,
@@ -4450,26 +780,6 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213689,
-    "fullName": "Маркос Льоренте",
-    "clubName": "Атлетико",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 14.8,
-    "fp_last": 112.0
-  },
-  {
-    "playerId": 213686,
-    "fullName": "Хименес",
-    "clubName": "Атлетико",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 1.2,
-    "fp_last": 0.0
-  },
-  {
     "playerId": 213685,
     "fullName": "Пубиль",
     "clubName": "Атлетико",
@@ -4478,56 +788,6 @@
     "price": 5.5,
     "popularity": 0.4,
     "fp_last": 0.0
-  },
-  {
-    "playerId": 213684,
-    "fullName": "Муссо",
-    "clubName": "Атлетико",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.3,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 213682,
-    "fullName": "Ле Норман",
-    "clubName": "Атлетико",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 16.9,
-    "fp_last": 91.0
-  },
-  {
-    "playerId": 213673,
-    "fullName": "Эскивель",
-    "clubName": "Атлетико",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213681,
-    "fullName": "Лангле",
-    "clubName": "Атлетико",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 2.7,
-    "fp_last": 92.0
-  },
-  {
-    "playerId": 213680,
-    "fullName": "Галан",
-    "clubName": "Атлетико",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 76.0
   },
   {
     "playerId": 213679,
@@ -4540,9 +800,389 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213678,
-    "fullName": "Хавьер Серрано",
+    "playerId": 213680,
+    "fullName": "Галан",
     "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 76.0
+  },
+  {
+    "playerId": 213681,
+    "fullName": "Лангле",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.7,
+    "fp_last": 92.0
+  },
+  {
+    "playerId": 213682,
+    "fullName": "Ле Норман",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 16.9,
+    "fp_last": 91.0
+  },
+  {
+    "playerId": 213689,
+    "fullName": "Маркос Льоренте",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 14.8,
+    "fp_last": 112.0
+  },
+  {
+    "playerId": 213683,
+    "fullName": "Молина",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.8,
+    "fp_last": 82.0
+  },
+  {
+    "playerId": 213672,
+    "fullName": "Костис",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213686,
+    "fullName": "Хименес",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213671,
+    "fullName": "Боньяр",
+    "clubName": "Атлетико",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213728,
+    "fullName": "Ямаль",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 10.5,
+    "popularity": 70.1,
+    "fp_last": 185.0
+  },
+  {
+    "playerId": 213729,
+    "fullName": "Рафинья",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 11.5,
+    "popularity": 38.3,
+    "fp_last": 219.0
+  },
+  {
+    "playerId": 213708,
+    "fullName": "Араухо",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 4.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213709,
+    "fullName": "Кубарси",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 13.8,
+    "fp_last": 99.0
+  },
+  {
+    "playerId": 213714,
+    "fullName": "Бальде",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 8.5,
+    "fp_last": 98.0
+  },
+  {
+    "playerId": 213719,
+    "fullName": "Эрик Гарсия",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.8,
+    "fp_last": 89.0
+  },
+  {
+    "playerId": 213716,
+    "fullName": "Жоан Гарсия",
+    "clubName": "Барселона",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 5.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213725,
+    "fullName": "Ферран Торрес",
+    "clubName": "Барселона",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 12.2,
+    "fp_last": 103.0
+  },
+  {
+    "playerId": 213723,
+    "fullName": "Педри",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 16.9,
+    "fp_last": 129.0
+  },
+  {
+    "playerId": 213720,
+    "fullName": "Гави",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 3.5,
+    "fp_last": 50.0
+  },
+  {
+    "playerId": 213721,
+    "fullName": "де Йонг",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 2.9,
+    "fp_last": 50.0
+  },
+  {
+    "playerId": 213718,
+    "fullName": "Кунде",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 17.3,
+    "fp_last": 102.0
+  },
+  {
+    "playerId": 213722,
+    "fullName": "Фермин Лопес",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 2.7,
+    "fp_last": 84.0
+  },
+  {
+    "playerId": 213726,
+    "fullName": "Ольмо",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 9.0,
+    "popularity": 2.3,
+    "fp_last": 106.0
+  },
+  {
+    "playerId": 213724,
+    "fullName": "Рэшфорд",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 2.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216525,
+    "fullName": "Торрентс",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213727,
+    "fullName": "Левандовски",
+    "clubName": "Барселона",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 10.0,
+    "popularity": 5.5,
+    "fp_last": 192.0
+  },
+  {
+    "playerId": 215658,
+    "fullName": "Кочен",
+    "clubName": "Барселона",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215659,
+    "fullName": "Форт",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 213701,
+    "fullName": "Пенья",
+    "clubName": "Барселона",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213717,
+    "fullName": "Касадо",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.2,
+    "fp_last": 66.0
+  },
+  {
+    "playerId": 213702,
+    "fullName": "Дани Родригес",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213715,
+    "fullName": "Бардагжи",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213713,
+    "fullName": "Шченсны",
+    "clubName": "Барселона",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.9,
+    "fp_last": 62.0
+  },
+  {
+    "playerId": 213712,
+    "fullName": "тер Стеген",
+    "clubName": "Барселона",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3,
+    "fp_last": 21.0
+  },
+  {
+    "playerId": 213711,
+    "fullName": "Иньиго Мартинес",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.1,
+    "fp_last": 89.0
+  },
+  {
+    "playerId": 213710,
+    "fullName": "Жерар Мартин",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3,
+    "fp_last": 48.0
+  },
+  {
+    "playerId": 213707,
+    "fullName": "Ромеу",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213706,
+    "fullName": "Кристенсен",
+    "clubName": "Барселона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 8.0
+  },
+  {
+    "playerId": 213705,
+    "fullName": "Берналь",
+    "clubName": "Барселона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 213704,
+    "fullName": "Тони Фернандес",
+    "clubName": "Барселона",
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
@@ -4550,43 +1190,763 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213677,
-    "fullName": "Сейду",
-    "clubName": "Атлетико",
+    "playerId": 213703,
+    "fullName": "Гилье Фернандес",
+    "clubName": "Барселона",
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.1,
+    "popularity": 0.0,
     "fp_last": 0.0
   },
   {
-    "playerId": 213676,
-    "fullName": "Монсеррате",
-    "clubName": "Атлетико",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213675,
-    "fullName": "Джанне",
-    "clubName": "Атлетико",
+    "playerId": 216526,
+    "fullName": "Дро Фернандес",
+    "clubName": "Барселона",
     "position": "FWD",
     "league": "La Liga",
     "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213748,
+    "fullName": "Руибаль",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 6.8,
+    "fp_last": 57.0
+  },
+  {
+    "playerId": 213753,
+    "fullName": "Рикельме",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 3.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213754,
+    "fullName": "Форнальс",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.5,
+    "fp_last": 67.0
+  },
+  {
+    "playerId": 213756,
+    "fullName": "Ло Чельсо",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 16.0,
+    "fp_last": 89.0
+  },
+  {
+    "playerId": 213747,
+    "fullName": "Серджи Альтимира",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.0,
+    "fp_last": 65.0
+  },
+  {
+    "playerId": 213745,
+    "fullName": "Рикардо Родригес",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.9,
+    "fp_last": 44.0
+  },
+  {
+    "playerId": 213733,
+    "fullName": "Бельерин",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.4,
+    "fp_last": 22.0
+  },
+  {
+    "playerId": 213737,
+    "fullName": "Бартра",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 13.6,
+    "fp_last": 70.0
+  },
+  {
+    "playerId": 213743,
+    "fullName": "Натан",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 3.6,
+    "fp_last": 59.0
+  },
+  {
+    "playerId": 213757,
+    "fullName": "Кучо Эрнандес",
+    "clubName": "Бетис",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 5.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213740,
+    "fullName": "Пау Лопес",
+    "clubName": "Бетис",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 3.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213751,
+    "fullName": "Бакамбу",
+    "clubName": "Бетис",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.4,
+    "fp_last": 42.0
+  },
+  {
+    "playerId": 213750,
+    "fullName": "Чими Авила",
+    "clubName": "Бетис",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 24.0
+  },
+  {
+    "playerId": 216527,
+    "fullName": "Гарсия",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 213744,
+    "fullName": "Петит",
+    "clubName": "Бетис",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213731,
+    "fullName": "Вьейтес",
+    "clubName": "Бетис",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 8.0
+  },
+  {
+    "playerId": 213746,
+    "fullName": "Марк Рока",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 43.0
+  },
+  {
+    "playerId": 213742,
+    "fullName": "Диего Льоренте",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 85.0
+  },
+  {
+    "playerId": 213741,
+    "fullName": "Лосада",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213749,
+    "fullName": "Фирпо",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 4.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213739,
+    "fullName": "Гомес",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213738,
+    "fullName": "Альваро Вальес",
+    "clubName": "Бетис",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213736,
+    "fullName": "Сенхаджи",
+    "clubName": "Бетис",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213735,
+    "fullName": "Перро",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 53.0
+  },
+  {
+    "playerId": 213755,
+    "fullName": "Эззальзули",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.6,
+    "fp_last": 76.0
+  },
+  {
+    "playerId": 213734,
+    "fullName": "Ортис",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 15.0
+  },
+  {
+    "playerId": 213732,
+    "fullName": "Нобель Менди",
+    "clubName": "Бетис",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213758,
+    "fullName": "Иско",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 4.3,
+    "fp_last": 115.0
+  },
+  {
+    "playerId": 215660,
+    "fullName": "Деосса",
+    "clubName": "Бетис",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213730,
+    "fullName": "Адриан",
+    "clubName": "Бетис",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 18.1,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 213780,
+    "fullName": "Диего Лопес",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 2.5,
+    "fp_last": 142.0
+  },
+  {
+    "playerId": 213781,
+    "fullName": "Раба",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213768,
+    "fullName": "Фулькье",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.0,
+    "fp_last": 57.0
+  },
+  {
+    "playerId": 213779,
+    "fullName": "Риоха",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.4,
+    "fp_last": 120.0
+  },
+  {
+    "playerId": 213782,
+    "fullName": "Дуро",
+    "clubName": "Валенсия",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 4.2,
+    "fp_last": 116.0
+  },
+  {
+    "playerId": 213766,
+    "fullName": "Копете",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213770,
+    "fullName": "Агирресабала",
+    "clubName": "Валенсия",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 4.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213778,
+    "fullName": "Пепелу",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.7,
+    "fp_last": 73.0
+  },
+  {
+    "playerId": 213777,
+    "fullName": "Герра",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.3,
+    "fp_last": 107.0
+  },
+  {
+    "playerId": 213774,
+    "fullName": "Таррега",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.9,
+    "fp_last": 93.0
+  },
+  {
+    "playerId": 215662,
+    "fullName": "Угринич",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213776,
+    "fullName": "Андре Алмейда",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 78.0
+  },
+  {
+    "playerId": 215661,
+    "fullName": "Сантамария",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213803,
+    "fullName": "Данджума",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213769,
+    "fullName": "Хесус Васкес",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 29.0
+  },
+  {
+    "playerId": 213771,
+    "fullName": "Гайя",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 5.9,
+    "fp_last": 62.0
+  },
+  {
+    "playerId": 213759,
+    "fullName": "Джемерт",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213773,
+    "fullName": "Мари",
+    "clubName": "Валенсия",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 213760,
+    "fullName": "Ирансо",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213767,
+    "fullName": "Тьерри Коррейя",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 25.0
+  },
+  {
+    "playerId": 213765,
+    "fullName": "Димитриевски",
+    "clubName": "Валенсия",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.9,
+    "fp_last": 11.0
+  },
+  {
+    "playerId": 213764,
+    "fullName": "Диакаби",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 30.0
+  },
+  {
+    "playerId": 213763,
+    "fullName": "Гильямон",
+    "clubName": "Валенсия",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2,
+    "fp_last": 14.0
+  },
+  {
+    "playerId": 213762,
+    "fullName": "Риверо",
+    "clubName": "Валенсия",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
     "popularity": 0.4,
     "fp_last": 0.0
   },
   {
-    "playerId": 213674,
-    "fullName": "Белаид",
-    "clubName": "Атлетико",
+    "playerId": 213761,
+    "fullName": "Озкаджар",
+    "clubName": "Валенсия",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213772,
+    "fullName": "Канос",
+    "clubName": "Валенсия",
     "position": "MID",
     "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 19.0
+  },
+  {
+    "playerId": 213800,
+    "fullName": "Гуйе",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 3.4,
+    "fp_last": 87.0
+  },
+  {
+    "playerId": 213792,
+    "fullName": "Жуниор",
+    "clubName": "Вильярреал",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 15.1,
+    "fp_last": 57.0
+  },
+  {
+    "playerId": 213788,
+    "fullName": "Моуриньо",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.5,
+    "popularity": 10.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213796,
+    "fullName": "Этта-Эйонг",
+    "clubName": "Вильярреал",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 12.8,
+    "fp_last": 9.0
+  },
+  {
+    "playerId": 213798,
+    "fullName": "Кардона",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 13.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213807,
+    "fullName": "Пино",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 7.3,
+    "fp_last": 97.0
+  },
+  {
+    "playerId": 213806,
+    "fullName": "Пепе",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 11.1,
+    "fp_last": 84.0
+  },
+  {
+    "playerId": 213794,
+    "fullName": "Рафа Марин",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 3.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213795,
+    "fullName": "Фойт",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 8.6,
+    "fp_last": 59.0
+  },
+  {
+    "playerId": 213802,
+    "fullName": "Комесанья",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.3,
+    "fp_last": 105.0
+  },
+  {
+    "playerId": 213799,
+    "fullName": "Бьюкенен",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.4,
+    "fp_last": 24.0
+  },
+  {
+    "playerId": 213805,
+    "fullName": "Молейро",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 1.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213804,
+    "fullName": "Парехо",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.9,
+    "fp_last": 89.0
+  },
+  {
+    "playerId": 213801,
+    "fullName": "Жерар Морено",
+    "clubName": "Вильярреал",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 11.5,
+    "fp_last": 43.0
+  },
+  {
+    "playerId": 215663,
+    "fullName": "Парти",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213790,
+    "fullName": "Педраса",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 24.0
+  },
+  {
+    "playerId": 213797,
+    "fullName": "Ахомаш",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 22.0
+  },
+  {
+    "playerId": 213784,
+    "fullName": "Адриа Альтимира",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4,
     "fp_last": 0.0
   },
   {
@@ -4600,6 +1960,56 @@
     "fp_last": 85.0
   },
   {
+    "playerId": 213791,
+    "fullName": "Денис Суарес",
+    "clubName": "Вильярреал",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.0,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 213789,
+    "fullName": "Пау Наварро",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 28.0
+  },
+  {
+    "playerId": 213787,
+    "fullName": "Конде",
+    "clubName": "Вильярреал",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213786,
+    "fullName": "Камбвала",
+    "clubName": "Вильярреал",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213785,
+    "fullName": "Кабанес",
+    "clubName": "Вильярреал",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
     "playerId": 213808,
     "fullName": "Айосе Перес",
     "clubName": "Вильярреал",
@@ -4610,224 +2020,204 @@
     "fp_last": 164.0
   },
   {
-    "playerId": 213988,
-    "fullName": "Карлос Фернандес",
-    "clubName": "Реал Сосьедад",
-    "position": "FWD",
+    "playerId": 213783,
+    "fullName": "Рубен Гомес",
+    "clubName": "Вильярреал",
+    "position": "GK",
     "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.1,
+    "price": 4.0,
+    "popularity": 0.6,
     "fp_last": 0.0
   },
   {
-    "playerId": 213920,
-    "fullName": "Трехо",
-    "clubName": "Райо Вальекано",
+    "playerId": 213826,
+    "fullName": "Хоэль Рока",
+    "clubName": "Жирона",
     "position": "MID",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 29.0
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
-    "playerId": 213941,
-    "fullName": "Рюдигер",
-    "clubName": "Реал Мадрид",
-    "position": "DEF",
+    "playerId": 213837,
+    "fullName": "Цыганков",
+    "clubName": "Жирона",
+    "position": "MID",
     "league": "La Liga",
-    "price": 6.0,
-    "popularity": 3.2,
+    "price": 7.0,
+    "popularity": 2.7,
     "fp_last": 90.0
   },
   {
-    "playerId": 213937,
-    "fullName": "Лунин",
-    "clubName": "Реал Мадрид",
-    "position": "GK",
+    "playerId": 213827,
+    "fullName": "Солис",
+    "clubName": "Жирона",
+    "position": "MID",
     "league": "La Liga",
-    "price": 5.5,
+    "price": 5.0,
     "popularity": 0.3,
-    "fp_last": 32.0
+    "fp_last": 25.0
   },
   {
-    "playerId": 213935,
-    "fullName": "Асенсио",
-    "clubName": "Реал Мадрид",
+    "playerId": 213836,
+    "fullName": "Янхель Эррера",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213823,
+    "fullName": "Крейчи",
+    "clubName": "Жирона",
     "position": "DEF",
     "league": "La Liga",
-    "price": 5.5,
-    "popularity": 1.1,
+    "price": 5.0,
+    "popularity": 2.0,
+    "fp_last": 57.0
+  },
+  {
+    "playerId": 213822,
+    "fullName": "Давид Лопес",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.4,
     "fp_last": 79.0
   },
   {
-    "playerId": 213934,
-    "fullName": "Рейньер",
-    "clubName": "Реал Мадрид",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213933,
-    "fullName": "Ферлан Менди",
-    "clubName": "Реал Мадрид",
+    "playerId": 213820,
+    "fullName": "Блинд",
+    "clubName": "Жирона",
     "position": "DEF",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 40.0
+    "popularity": 5.2,
+    "fp_last": 82.0
   },
   {
-    "playerId": 213932,
-    "fullName": "Алаба",
-    "clubName": "Реал Мадрид",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 1.0,
-    "fp_last": 11.0
-  },
-  {
-    "playerId": 213931,
-    "fullName": "Фран Гонсалес",
-    "clubName": "Реал Мадрид",
+    "playerId": 213810,
+    "fullName": "Крапивцов",
+    "clubName": "Жирона",
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 1.0
+    "popularity": 2.4,
+    "fp_last": 0.0
   },
   {
-    "playerId": 213923,
-    "fullName": "Камельо",
-    "clubName": "Райо Вальекано",
-    "position": "FWD",
+    "playerId": 213831,
+    "fullName": "Порту",
+    "clubName": "Жирона",
+    "position": "MID",
     "league": "La Liga",
     "price": 5.5,
-    "popularity": 0.3,
-    "fp_last": 51.0
-  },
-  {
-    "playerId": 213914,
-    "fullName": "Мумин",
-    "clubName": "Райо Вальекано",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 72.0
-  },
-  {
-    "playerId": 213946,
-    "fullName": "Камавинга",
-    "clubName": "Реал Мадрид",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.5,
-    "popularity": 0.5,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 213913,
-    "fullName": "Диего Мендес",
-    "clubName": "Райо Вальекано",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213912,
-    "fullName": "Луис Фелипе",
-    "clubName": "Райо Вальекано",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
     "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213911,
-    "fullName": "Балиу",
-    "clubName": "Райо Вальекано",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 46.0
-  },
-  {
-    "playerId": 213909,
-    "fullName": "Карденас",
-    "clubName": "Райо Вальекано",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 22.0
-  },
-  {
-    "playerId": 213908,
-    "fullName": "де лас Сиас",
-    "clubName": "Райо Вальекано",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213898,
-    "fullName": "Икер Муньос",
-    "clubName": "Осасуна",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 28.0
-  },
-  {
-    "playerId": 213895,
-    "fullName": "Барха",
-    "clubName": "Осасуна",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.5,
-    "fp_last": 15.0
-  },
-  {
-    "playerId": 213894,
-    "fullName": "Эррандо",
-    "clubName": "Осасуна",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
     "fp_last": 45.0
   },
   {
-    "playerId": 213943,
-    "fullName": "Фран Гарсия",
-    "clubName": "Реал Мадрид",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 1.2,
-    "fp_last": 92.0
-  },
-  {
-    "playerId": 213949,
-    "fullName": "Эндрик",
-    "clubName": "Реал Мадрид",
+    "playerId": 213825,
+    "fullName": "Миовски",
+    "clubName": "Жирона",
     "position": "FWD",
     "league": "La Liga",
-    "price": 7.0,
+    "price": 5.0,
+    "popularity": 1.6,
+    "fp_last": 39.0
+  },
+  {
+    "playerId": 213832,
+    "fullName": "Асприлья",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 2.0,
+    "fp_last": 63.0
+  },
+  {
+    "playerId": 213817,
+    "fullName": "Ринкон",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215665,
+    "fullName": "Рейс",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213833,
+    "fullName": "Лемар",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213829,
+    "fullName": "ван де Бек",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 213834,
+    "fullName": "Иван Мартин",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
     "popularity": 0.2,
-    "fp_last": 29.0
+    "fp_last": 71.0
+  },
+  {
+    "playerId": 213835,
+    "fullName": "Стуани",
+    "clubName": "Жирона",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 2.4,
+    "fp_last": 84.0
+  },
+  {
+    "playerId": 213830,
+    "fullName": "Мигель Гутьеррес",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 84.0
+  },
+  {
+    "playerId": 215664,
+    "fullName": "Кебе",
+    "clubName": "Жирона",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
     "playerId": 213809,
@@ -4837,226 +2227,6 @@
     "league": "La Liga",
     "price": 4.0,
     "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213973,
-    "fullName": "Коломбатто",
-    "clubName": "Реал Овьедо",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213987,
-    "fullName": "Пачеко",
-    "clubName": "Реал Сосьедад",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213986,
-    "fullName": "Марьескуррена",
-    "clubName": "Реал Сосьедад",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 17.0
-  },
-  {
-    "playerId": 213985,
-    "fullName": "Хон Мартин",
-    "clubName": "Реал Сосьедад",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 18.0
-  },
-  {
-    "playerId": 213984,
-    "fullName": "Марреро",
-    "clubName": "Реал Сосьедад",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 11.0
-  },
-  {
-    "playerId": 213983,
-    "fullName": "Дадье",
-    "clubName": "Реал Сосьедад",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213982,
-    "fullName": "Фрага",
-    "clubName": "Реал Сосьедад",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213981,
-    "fullName": "Одриосола",
-    "clubName": "Реал Сосьедад",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 2.5,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 213976,
-    "fullName": "Форес",
-    "clubName": "Реал Овьедо",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213971,
-    "fullName": "Брандон Домингес",
-    "clubName": "Реал Овьедо",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213953,
-    "fullName": "Родриго",
-    "clubName": "Реал Мадрид",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 8.5,
-    "popularity": 1.4,
-    "fp_last": 114.0
-  },
-  {
-    "playerId": 213966,
-    "fullName": "Костас",
-    "clubName": "Реал Овьедо",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213965,
-    "fullName": "Кардеро",
-    "clubName": "Реал Овьедо",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213963,
-    "fullName": "Яйо Гонсалес",
-    "clubName": "Реал Овьедо",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213960,
-    "fullName": "Нарваэс",
-    "clubName": "Реал Овьедо",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213959,
-    "fullName": "Молдован",
-    "clubName": "Реал Овьедо",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 5.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213958,
-    "fullName": "Лукас Аихадо",
-    "clubName": "Реал Овьедо",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213957,
-    "fullName": "Лемос",
-    "clubName": "Реал Овьедо",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213954,
-    "fullName": "Беллингем",
-    "clubName": "Реал Мадрид",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 9.5,
-    "popularity": 4.3,
-    "fp_last": 145.0
-  },
-  {
-    "playerId": 213620,
-    "fullName": "Хоседа Альварес",
-    "clubName": "Алавес",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 10.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213891,
-    "fullName": "Бретонес",
-    "clubName": "Осасуна",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 78.0
-  },
-  {
-    "playerId": 213890,
-    "fullName": "Бенито",
-    "clubName": "Осасуна",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 1.3,
     "fp_last": 0.0
   },
   {
@@ -5070,76 +2240,6 @@
     "fp_last": 51.0
   },
   {
-    "playerId": 213843,
-    "fullName": "Виктор Фернандес",
-    "clubName": "Леванте",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213840,
-    "fullName": "Примо",
-    "clubName": "Леванте",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213839,
-    "fullName": "Пастор",
-    "clubName": "Леванте",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213835,
-    "fullName": "Стуани",
-    "clubName": "Жирона",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 2.4,
-    "fp_last": 84.0
-  },
-  {
-    "playerId": 213834,
-    "fullName": "Иван Мартин",
-    "clubName": "Жирона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.2,
-    "fp_last": 71.0
-  },
-  {
-    "playerId": 213830,
-    "fullName": "Мигель Гутьеррес",
-    "clubName": "Жирона",
-    "position": "DEF",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 84.0
-  },
-  {
-    "playerId": 213829,
-    "fullName": "ван де Бек",
-    "clubName": "Жирона",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 61.0
-  },
-  {
     "playerId": 213824,
     "fullName": "Арнау Мартинес",
     "clubName": "Жирона",
@@ -5148,16 +2248,6 @@
     "price": 5.0,
     "popularity": 1.4,
     "fp_last": 81.0
-  },
-  {
-    "playerId": 213889,
-    "fullName": "Айтор Фернандес",
-    "clubName": "Осасуна",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 7.0
   },
   {
     "playerId": 213819,
@@ -5240,13 +2330,193 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213844,
-    "fullName": "Клементе",
+    "playerId": 216528,
+    "fullName": "Витцель",
+    "clubName": "Жирона",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213821,
+    "fullName": "Гассанига",
+    "clubName": "Жирона",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 4.9,
+    "fp_last": 119.0
+  },
+  {
+    "playerId": 213851,
+    "fullName": "Толян",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213857,
+    "fullName": "Ури Рей",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213858,
+    "fullName": "Бруги",
+    "clubName": "Леванте",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213856,
+    "fullName": "Иван Ромеро",
+    "clubName": "Леванте",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213859,
+    "fullName": "Пабло Мартинес",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213838,
+    "fullName": "Кабельо",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 7.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213849,
+    "fullName": "Пампин",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213861,
+    "fullName": "Карлос Альварес",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213860,
+    "fullName": "Моралес",
+    "clubName": "Леванте",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213852,
+    "fullName": "Эльхесабаль",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213850,
+    "fullName": "Ману Санчес",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213848,
+    "fullName": "Морено",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213846,
+    "fullName": "Серхио Лосано",
     "clubName": "Леванте",
     "position": "MID",
     "league": "La Liga",
     "price": 4.5,
-    "popularity": 0.3,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213845,
+    "fullName": "Куньят",
+    "clubName": "Леванте",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213842,
+    "fullName": "Виктор Гарсия",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213841,
+    "fullName": "Адри",
+    "clubName": "Леванте",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213839,
+    "fullName": "Пастор",
+    "clubName": "Леванте",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.5,
     "fp_last": 0.0
   },
   {
@@ -5280,14 +2550,164 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213888,
-    "fullName": "Валенсия",
-    "clubName": "Осасуна",
+    "playerId": 213855,
+    "fullName": "Оласагасти",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213844,
+    "fullName": "Клементе",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213843,
+    "fullName": "Виктор Фернандес",
+    "clubName": "Леванте",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213840,
+    "fullName": "Примо",
+    "clubName": "Леванте",
     "position": "GK",
     "league": "La Liga",
     "price": 4.0,
-    "popularity": 1.9,
+    "popularity": 0.7,
     "fp_last": 0.0
+  },
+  {
+    "playerId": 213862,
+    "fullName": "Койялипу",
+    "clubName": "Леванте",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213880,
+    "fullName": "Антонио Санчес",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 48.0
+  },
+  {
+    "playerId": 213877,
+    "fullName": "Мохика",
+    "clubName": "Мальорка",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.8,
+    "fp_last": 94.0
+  },
+  {
+    "playerId": 213886,
+    "fullName": "Дардер",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.6,
+    "fp_last": 113.0
+  },
+  {
+    "playerId": 213867,
+    "fullName": "Вальент",
+    "clubName": "Мальорка",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 93.0
+  },
+  {
+    "playerId": 213872,
+    "fullName": "Роман",
+    "clubName": "Мальорка",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.5,
+    "fp_last": 30.0
+  },
+  {
+    "playerId": 213879,
+    "fullName": "Раильо",
+    "clubName": "Мальорка",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.0,
+    "fp_last": 105.0
+  },
+  {
+    "playerId": 216529,
+    "fullName": "Фернандес",
+    "clubName": "Мальорка",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213866,
+    "fullName": "Тони Лато",
+    "clubName": "Мальорка",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.1,
+    "fp_last": 25.0
+  },
+  {
+    "playerId": 213883,
+    "fullName": "Дани Родригес",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.5,
+    "fp_last": 106.0
+  },
+  {
+    "playerId": 213881,
+    "fullName": "Асано",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 48.0
+  },
+  {
+    "playerId": 213874,
+    "fullName": "Маскарель",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 69.0
   },
   {
     "playerId": 213885,
@@ -5320,6 +2740,16 @@
     "fp_last": 86.0
   },
   {
+    "playerId": 213863,
+    "fullName": "Бергстрем",
+    "clubName": "Мальорка",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 4.5,
+    "fp_last": 0.0
+  },
+  {
     "playerId": 213878,
     "fullName": "Пратс",
     "clubName": "Мальорка",
@@ -5328,6 +2758,16 @@
     "price": 5.0,
     "popularity": 0.1,
     "fp_last": 34.0
+  },
+  {
+    "playerId": 213864,
+    "fullName": "Куэльяр",
+    "clubName": "Мальорка",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 213875,
@@ -5390,56 +2830,6 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213864,
-    "fullName": "Куэльяр",
-    "clubName": "Мальорка",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213863,
-    "fullName": "Бергстрем",
-    "clubName": "Мальорка",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 4.0,
-    "popularity": 4.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213862,
-    "fullName": "Койялипу",
-    "clubName": "Леванте",
-    "position": "FWD",
-    "league": "La Liga",
-    "price": 6.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213855,
-    "fullName": "Оласагасти",
-    "clubName": "Леванте",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216533,
-    "fullName": "Влаходимос",
-    "clubName": "Севилья",
-    "position": "GK",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
     "playerId": 213871,
     "fullName": "Морей",
     "clubName": "Мальорка",
@@ -5448,26 +2838,6 @@
     "price": 4.5,
     "popularity": 0.2,
     "fp_last": 24.0
-  },
-  {
-    "playerId": 213974,
-    "fullName": "Рейна",
-    "clubName": "Реал Овьедо",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213876,
-    "fullName": "Морланес",
-    "clubName": "Мальорка",
-    "position": "MID",
-    "league": "La Liga",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 40.0
   },
   {
     "playerId": 213887,
@@ -5480,33 +2850,2643 @@
     "fp_last": 88.0
   },
   {
-    "playerId": 213821,
-    "fullName": "Гассанига",
-    "clubName": "Жирона",
+    "playerId": 213876,
+    "fullName": "Морланес",
+    "clubName": "Мальорка",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 40.0
+  },
+  {
+    "playerId": 213892,
+    "fullName": "Розье",
+    "clubName": "Осасуна",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213907,
+    "fullName": "Будимир",
+    "clubName": "Осасуна",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 8.0,
+    "fp_last": 190.0
+  },
+  {
+    "playerId": 213904,
+    "fullName": "Торро",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.3,
+    "fp_last": 109.0
+  },
+  {
+    "playerId": 213906,
+    "fullName": "Орос",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 0.7,
+    "fp_last": 126.0
+  },
+  {
+    "playerId": 213896,
+    "fullName": "Бойомо",
+    "clubName": "Осасуна",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.5,
+    "fp_last": 105.0
+  },
+  {
+    "playerId": 213897,
+    "fullName": "Катена",
+    "clubName": "Осасуна",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.6,
+    "fp_last": 93.0
+  },
+  {
+    "playerId": 213901,
+    "fullName": "Монкайола",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 59.0
+  },
+  {
+    "playerId": 213899,
+    "fullName": "Серхио Эррера",
+    "clubName": "Осасуна",
     "position": "GK",
     "league": "La Liga",
     "price": 5.0,
-    "popularity": 4.9,
-    "fp_last": 119.0
+    "popularity": 1.6,
+    "fp_last": 118.0
   },
   {
-    "playerId": 214535,
-    "fullName": "Семеньо",
-    "clubName": "Борнмут",
+    "playerId": 213905,
+    "fullName": "Рубен Гарсия",
+    "clubName": "Осасуна",
     "position": "MID",
-    "league": "EPL",
-    "price": 8.0,
-    "popularity": 8.2,
-    "fp_last": 175.0
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.4,
+    "fp_last": 116.0
   },
   {
-    "playerId": 214915,
-    "fullName": "Бэллард",
-    "clubName": "Сандерленд",
+    "playerId": 213900,
+    "fullName": "Мойсес Гомес",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 34.0
+  },
+  {
+    "playerId": 213903,
+    "fullName": "Рауль Гарсия",
+    "clubName": "Осасуна",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 213902,
+    "fullName": "Виктор Муньос",
+    "clubName": "Осасуна",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213888,
+    "fullName": "Валенсия",
+    "clubName": "Осасуна",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213889,
+    "fullName": "Айтор Фернандес",
+    "clubName": "Осасуна",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 7.0
+  },
+  {
+    "playerId": 213895,
+    "fullName": "Барха",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 15.0
+  },
+  {
+    "playerId": 213894,
+    "fullName": "Эррандо",
+    "clubName": "Осасуна",
     "position": "DEF",
-    "league": "EPL",
+    "league": "La Liga",
     "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 45.0
+  },
+  {
+    "playerId": 213893,
+    "fullName": "Хуан Крус",
+    "clubName": "Осасуна",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 59.0
+  },
+  {
+    "playerId": 213891,
+    "fullName": "Бретонес",
+    "clubName": "Осасуна",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 78.0
+  },
+  {
+    "playerId": 213890,
+    "fullName": "Бенито",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213898,
+    "fullName": "Икер Муньос",
+    "clubName": "Осасуна",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 28.0
+  },
+  {
+    "playerId": 213928,
+    "fullName": "Де Фрутос",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 6.1,
+    "fp_last": 112.0
+  },
+  {
+    "playerId": 213929,
+    "fullName": "Паласон",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.8,
+    "fp_last": 103.0
+  },
+  {
+    "playerId": 213930,
+    "fullName": "Альваро Гарсия",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 0.8,
+    "fp_last": 117.0
+  },
+  {
+    "playerId": 213926,
+    "fullName": "Унаи Лопес",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.6,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 213927,
+    "fullName": "Сисс",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.1,
+    "fp_last": 82.0
+  },
+  {
+    "playerId": 213925,
+    "fullName": "Рациу",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.4,
+    "fp_last": 110.0
+  },
+  {
+    "playerId": 213924,
+    "fullName": "Лежен",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.5,
+    "fp_last": 111.0
+  },
+  {
+    "playerId": 213915,
+    "fullName": "Чаваррия",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2,
+    "fp_last": 85.0
+  },
+  {
+    "playerId": 213922,
+    "fullName": "Диас",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3,
+    "fp_last": 53.0
+  },
+  {
+    "playerId": 213921,
+    "fullName": "Баталья",
+    "clubName": "Райо Вальекано",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.6,
+    "fp_last": 109.0
+  },
+  {
+    "playerId": 213919,
+    "fullName": "Оскар Валентин",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 213918,
+    "fullName": "Нтека",
+    "clubName": "Райо Вальекано",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 49.0
+  },
+  {
+    "playerId": 213917,
+    "fullName": "Гумбау",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 28.0
+  },
+  {
+    "playerId": 213916,
+    "fullName": "Эспино",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 22.0
+  },
+  {
+    "playerId": 213910,
+    "fullName": "Пелайо Фернандес",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.8,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 213908,
+    "fullName": "де лас Сиас",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213920,
+    "fullName": "Трехо",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 29.0
+  },
+  {
+    "playerId": 213923,
+    "fullName": "Камельо",
+    "clubName": "Райо Вальекано",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3,
+    "fp_last": 51.0
+  },
+  {
+    "playerId": 213914,
+    "fullName": "Мумин",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 72.0
+  },
+  {
+    "playerId": 213913,
+    "fullName": "Диего Мендес",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213912,
+    "fullName": "Луис Фелипе",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213911,
+    "fullName": "Балиу",
+    "clubName": "Райо Вальекано",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 46.0
+  },
+  {
+    "playerId": 213909,
+    "fullName": "Карденас",
+    "clubName": "Райо Вальекано",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 22.0
+  },
+  {
+    "playerId": 213775,
+    "fullName": "Франсиско Перес",
+    "clubName": "Райо Вальекано",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213938,
+    "fullName": "Милитао",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 4.4,
+    "fp_last": 43.0
+  },
+  {
+    "playerId": 213939,
+    "fullName": "Альваро Каррерас",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 4.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213956,
+    "fullName": "Мбаппе",
+    "clubName": "Реал Мадрид",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 11.5,
+    "popularity": 69.7,
+    "fp_last": 218.0
+  },
+  {
+    "playerId": 213945,
+    "fullName": "Александер-Арнолд",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 30.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213944,
+    "fullName": "Хейсен",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 14.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213940,
+    "fullName": "Куртуа",
+    "clubName": "Реал Мадрид",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 14.6,
+    "fp_last": 111.0
+  },
+  {
+    "playerId": 213952,
+    "fullName": "Гюлер",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 13.7,
+    "fp_last": 78.0
+  },
+  {
+    "playerId": 213950,
+    "fullName": "Вальверде",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 13.7,
+    "fp_last": 151.0
+  },
+  {
+    "playerId": 213947,
+    "fullName": "Тчуамени",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 2.4,
+    "fp_last": 94.0
+  },
+  {
+    "playerId": 213948,
+    "fullName": "Браим Диас",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 1.8,
+    "fp_last": 80.0
+  },
+  {
+    "playerId": 213955,
+    "fullName": "Винисиус Жуниор",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 10.0,
+    "popularity": 12.0,
+    "fp_last": 146.0
+  },
+  {
+    "playerId": 213936,
+    "fullName": "Карвахаль",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.9,
+    "fp_last": 34.0
+  },
+  {
+    "playerId": 213942,
+    "fullName": "Себальос",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.2,
+    "fp_last": 41.0
+  },
+  {
+    "playerId": 213951,
+    "fullName": "Гонсало Гарсия",
+    "clubName": "Реал Мадрид",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 8.0,
+    "popularity": 3.0,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 216530,
+    "fullName": "Диего Агуадо",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213954,
+    "fullName": "Беллингем",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 9.5,
+    "popularity": 4.3,
+    "fp_last": 145.0
+  },
+  {
+    "playerId": 213953,
+    "fullName": "Родриго",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 8.5,
+    "popularity": 1.4,
+    "fp_last": 114.0
+  },
+  {
+    "playerId": 216531,
+    "fullName": "Мартин",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213931,
+    "fullName": "Фран Гонсалес",
+    "clubName": "Реал Мадрид",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 213949,
+    "fullName": "Эндрик",
+    "clubName": "Реал Мадрид",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 0.2,
+    "fp_last": 29.0
+  },
+  {
+    "playerId": 213946,
+    "fullName": "Камавинга",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.5,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 213932,
+    "fullName": "Алаба",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.0,
+    "fp_last": 11.0
+  },
+  {
+    "playerId": 213943,
+    "fullName": "Фран Гарсия",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.2,
+    "fp_last": 92.0
+  },
+  {
+    "playerId": 213941,
+    "fullName": "Рюдигер",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 3.2,
+    "fp_last": 90.0
+  },
+  {
+    "playerId": 213937,
+    "fullName": "Лунин",
+    "clubName": "Реал Мадрид",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.3,
+    "fp_last": 32.0
+  },
+  {
+    "playerId": 213935,
+    "fullName": "Асенсио",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.1,
+    "fp_last": 79.0
+  },
+  {
+    "playerId": 213934,
+    "fullName": "Рейньер",
+    "clubName": "Реал Мадрид",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213933,
+    "fullName": "Ферлан Менди",
+    "clubName": "Реал Мадрид",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 40.0
+  },
+  {
+    "playerId": 216532,
+    "fullName": "Яньес",
+    "clubName": "Реал Мадрид",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213980,
+    "fullName": "Шаира",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213961,
+    "fullName": "Альхассан",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213975,
+    "fullName": "Сибо",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213969,
+    "fullName": "Эскандель",
+    "clubName": "Реал Овьедо",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213962,
+    "fullName": "Начо Видаль",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213978,
+    "fullName": "Илич",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213979,
+    "fullName": "Рондон",
+    "clubName": "Реал Овьедо",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213964,
+    "fullName": "Кальво",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213977,
+    "fullName": "Хассан",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213967,
+    "fullName": "Луэнго",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213968,
+    "fullName": "Борха Санчес",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213970,
+    "fullName": "Виньяс",
+    "clubName": "Реал Овьедо",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213972,
+    "fullName": "Касорла",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 3.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213960,
+    "fullName": "Нарваэс",
+    "clubName": "Реал Овьедо",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213959,
+    "fullName": "Молдован",
+    "clubName": "Реал Овьедо",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 5.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213976,
+    "fullName": "Форес",
+    "clubName": "Реал Овьедо",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213971,
+    "fullName": "Брандон Домингес",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213973,
+    "fullName": "Коломбатто",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213958,
+    "fullName": "Лукас Аихадо",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213966,
+    "fullName": "Костас",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213965,
+    "fullName": "Кардеро",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213963,
+    "fullName": "Яйо Гонсалес",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213957,
+    "fullName": "Лемос",
+    "clubName": "Реал Овьедо",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213974,
+    "fullName": "Рейна",
+    "clubName": "Реал Овьедо",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214009,
+    "fullName": "Кубо",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 6.6,
+    "fp_last": 106.0
+  },
+  {
+    "playerId": 214008,
+    "fullName": "Браис Мендес",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 1.9,
+    "fp_last": 73.0
+  },
+  {
+    "playerId": 214010,
+    "fullName": "Ойарсабаль",
+    "clubName": "Реал Сосьедад",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 14.2,
+    "fp_last": 108.0
+  },
+  {
+    "playerId": 214001,
+    "fullName": "Барренечеа",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 2.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214000,
+    "fullName": "Пабло Марин",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213997,
+    "fullName": "Туррьентес",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 30.0
+  },
+  {
+    "playerId": 213994,
+    "fullName": "Айен Муньос",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 36.0
+  },
+  {
+    "playerId": 215666,
+    "fullName": "Чалета-Цар",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214003,
+    "fullName": "Ремиро",
+    "clubName": "Реал Сосьедад",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 2.5,
+    "fp_last": 132.0
+  },
+  {
+    "playerId": 213998,
+    "fullName": "Арамбуру",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 2.5,
+    "fp_last": 90.0
+  },
+  {
+    "playerId": 213995,
+    "fullName": "Субельдия",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 2.2,
+    "fp_last": 65.0
+  },
+  {
+    "playerId": 214007,
+    "fullName": "Оускарссон",
+    "clubName": "Реал Сосьедад",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.8,
+    "fp_last": 42.0
+  },
+  {
+    "playerId": 214005,
+    "fullName": "Серхио Гомес",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 3.9,
+    "fp_last": 129.0
+  },
+  {
+    "playerId": 215667,
+    "fullName": "Гедеш",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213990,
+    "fullName": "Элустондо",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 37.0
+  },
+  {
+    "playerId": 213991,
+    "fullName": "Урко Гонсалес",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213993,
+    "fullName": "Каррикабуру",
+    "clubName": "Реал Сосьедад",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214006,
+    "fullName": "Сучич",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.4,
+    "fp_last": 70.0
+  },
+  {
+    "playerId": 213983,
+    "fullName": "Дадье",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213984,
+    "fullName": "Марреро",
+    "clubName": "Реал Сосьедад",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 11.0
+  },
+  {
+    "playerId": 213985,
+    "fullName": "Хон Мартин",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 18.0
+  },
+  {
+    "playerId": 213986,
+    "fullName": "Марьескуррена",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 17.0
+  },
+  {
+    "playerId": 213987,
+    "fullName": "Пачеко",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214004,
+    "fullName": "Садик",
+    "clubName": "Реал Сосьедад",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213988,
+    "fullName": "Карлос Фернандес",
+    "clubName": "Реал Сосьедад",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213996,
+    "fullName": "Траоре",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.6,
+    "fp_last": 35.0
+  },
+  {
+    "playerId": 213989,
+    "fullName": "Хави Лопес",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 214002,
+    "fullName": "Беккер",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.3,
+    "fp_last": 42.0
+  },
+  {
+    "playerId": 213999,
+    "fullName": "Горрочатеги",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213992,
+    "fullName": "Захарян",
+    "clubName": "Реал Сосьедад",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 2.3,
+    "fp_last": 8.0
+  },
+  {
+    "playerId": 213982,
+    "fullName": "Фрага",
+    "clubName": "Реал Сосьедад",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213981,
+    "fullName": "Одриосола",
+    "clubName": "Реал Сосьедад",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 2.5,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 214038,
+    "fullName": "Лукебакио",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 5.4,
+    "fp_last": 159.0
+  },
+  {
+    "playerId": 214027,
+    "fullName": "Агуме",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 84.0
+  },
+  {
+    "playerId": 214032,
+    "fullName": "Хуанлу Санчес",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 83.0
+  },
+  {
+    "playerId": 214033,
+    "fullName": "Адамс",
+    "clubName": "Севилья",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.0,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 214031,
+    "fullName": "Соу",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 79.0
+  },
+  {
+    "playerId": 214024,
+    "fullName": "Салас",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214020,
+    "fullName": "Идумбо-Музамбо",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 25.0
+  },
+  {
+    "playerId": 214021,
+    "fullName": "Кармона",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 78.0
+  },
+  {
+    "playerId": 214019,
+    "fullName": "Гудель",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.8,
+    "fp_last": 79.0
+  },
+  {
+    "playerId": 214036,
+    "fullName": "Эджуке",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.5,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 214022,
+    "fullName": "Нюланд",
+    "clubName": "Севилья",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.0,
+    "fp_last": 97.0
+  },
+  {
+    "playerId": 214035,
+    "fullName": "Исаак Ромеро",
+    "clubName": "Севилья",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.0,
+    "fp_last": 72.0
+  },
+  {
+    "playerId": 214012,
+    "fullName": "Маркао Тейшейра",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.0,
+    "fp_last": 10.0
+  },
+  {
+    "playerId": 214026,
+    "fullName": "Янузай",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214030,
+    "fullName": "Пеке",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 45.0
+  },
+  {
+    "playerId": 214034,
+    "fullName": "Альфон Гонсалес",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214037,
+    "fullName": "Варгас",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.3,
+    "fp_last": 34.0
+  },
+  {
+    "playerId": 214011,
+    "fullName": "Альберто Флорес",
+    "clubName": "Севилья",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214029,
+    "fullName": "Ихеаначо",
+    "clubName": "Севилья",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.8,
+    "fp_last": 13.0
+  },
+  {
+    "playerId": 214028,
+    "fullName": "Жордан",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214025,
+    "fullName": "Суасо",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214018,
+    "fullName": "Педроса",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 83.0
+  },
+  {
+    "playerId": 214017,
+    "fullName": "Буэно",
+    "clubName": "Севилья",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 16.0
+  },
+  {
+    "playerId": 214016,
+    "fullName": "Баде",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 79.0
+  },
+  {
+    "playerId": 214015,
+    "fullName": "Альваро Фернандес",
+    "clubName": "Севилья",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 20.0
+  },
+  {
+    "playerId": 214014,
+    "fullName": "Ньянзу",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 18.0
+  },
+  {
+    "playerId": 214013,
+    "fullName": "Рамон Мартинес",
+    "clubName": "Севилья",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 12.0
+  },
+  {
+    "playerId": 216533,
+    "fullName": "Влаходимос",
+    "clubName": "Севилья",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214058,
+    "fullName": "Аспас",
+    "clubName": "Сельта",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 14.3,
+    "fp_last": 102.0
+  },
+  {
+    "playerId": 214054,
+    "fullName": "Мориба",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 1.7,
+    "fp_last": 70.0
+  },
+  {
+    "playerId": 214061,
+    "fullName": "Жуджла",
+    "clubName": "Сельта",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 7.0,
+    "popularity": 3.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214053,
+    "fullName": "Мингеса",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 21.9,
+    "fp_last": 114.0
+  },
+  {
+    "playerId": 214056,
+    "fullName": "Бельтран",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.8,
+    "fp_last": 89.0
+  },
+  {
+    "playerId": 214050,
+    "fullName": "Сотело",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 40.0
+  },
+  {
+    "playerId": 214042,
+    "fullName": "Ристич",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.0,
+    "fp_last": 23.0
+  },
+  {
+    "playerId": 213752,
+    "fullName": "Борха Иглесиас",
+    "clubName": "Сельта",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 3.0,
+    "fp_last": 115.0
+  },
+  {
+    "playerId": 214047,
+    "fullName": "Раду",
+    "clubName": "Сельта",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.0,
     "popularity": 6.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214059,
+    "fullName": "Сарагоса",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 4.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214057,
+    "fullName": "Дуран",
+    "clubName": "Сельта",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.8,
+    "fp_last": 71.0
+  },
+  {
+    "playerId": 214051,
+    "fullName": "Хави Родригес",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 3.3,
+    "fp_last": 86.0
+  },
+  {
+    "playerId": 214052,
+    "fullName": "Алонсо",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 9.5,
+    "fp_last": 78.0
+  },
+  {
+    "playerId": 214060,
+    "fullName": "Сведберг",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 0.7,
+    "fp_last": 83.0
+  },
+  {
+    "playerId": 214040,
+    "fullName": "Марк Видаль",
+    "clubName": "Сельта",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214041,
+    "fullName": "Карлос Домингес",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.9,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 214044,
+    "fullName": "Вильяр",
+    "clubName": "Сельта",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 13.0
+  },
+  {
+    "playerId": 214055,
+    "fullName": "Уго Альварес",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 1.5,
+    "fp_last": 74.0
+  },
+  {
+    "playerId": 214045,
+    "fullName": "Каррейра",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.0,
+    "fp_last": 59.0
+  },
+  {
+    "playerId": 214039,
+    "fullName": "Айду",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 6.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214049,
+    "fullName": "Серви",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 8.0
+  },
+  {
+    "playerId": 214048,
+    "fullName": "Дамиан Родригес",
+    "clubName": "Сельта",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 29.0
+  },
+  {
+    "playerId": 214046,
+    "fullName": "Старфельт",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.2,
+    "fp_last": 66.0
+  },
+  {
+    "playerId": 214043,
+    "fullName": "Руэда",
+    "clubName": "Сельта",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214076,
+    "fullName": "Лисо",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 2.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214086,
+    "fullName": "Уче",
+    "clubName": "Хетафе",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 3.8,
+    "fp_last": 107.0
+  },
+  {
+    "playerId": 214062,
+    "fullName": "Бекуша",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 10.5,
+    "fp_last": 3.0
+  },
+  {
+    "playerId": 214083,
+    "fullName": "Сория",
+    "clubName": "Хетафе",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 4.8,
+    "fp_last": 129.0
+  },
+  {
+    "playerId": 214069,
+    "fullName": "Джене",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2,
+    "fp_last": 78.0
+  },
+  {
+    "playerId": 214071,
+    "fullName": "Хуан Иглесиас",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.9,
+    "fp_last": 86.0
+  },
+  {
+    "playerId": 214079,
+    "fullName": "Рико",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.9,
+    "fp_last": 92.0
+  },
+  {
+    "playerId": 214063,
+    "fullName": "Давинчи",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 8.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214077,
+    "fullName": "Марио Мартин",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214087,
+    "fullName": "Арамбарри",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214085,
+    "fullName": "Луис Милья",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.5,
+    "fp_last": 111.0
+  },
+  {
+    "playerId": 214080,
+    "fullName": "Сола",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214084,
+    "fullName": "Хави Муньос",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214082,
+    "fullName": "Санкрис",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214081,
+    "fullName": "Хуанми",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 214075,
+    "fullName": "да Коста",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 32.0
+  },
+  {
+    "playerId": 214078,
+    "fullName": "Неу",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214074,
+    "fullName": "Фемения",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214073,
+    "fullName": "Риско",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 214072,
+    "fullName": "Петер Федерико",
+    "clubName": "Хетафе",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 17.0
+  },
+  {
+    "playerId": 214070,
+    "fullName": "Дуарте",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 54.0
+  },
+  {
+    "playerId": 214068,
+    "fullName": "Альдерете",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2,
+    "fp_last": 92.0
+  },
+  {
+    "playerId": 214067,
+    "fullName": "Абкар",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214066,
+    "fullName": "Эрранс",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214065,
+    "fullName": "Трилья",
+    "clubName": "Хетафе",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214064,
+    "fullName": "Летачек",
+    "clubName": "Хетафе",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214088,
+    "fullName": "Майораль",
+    "clubName": "Хетафе",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.2,
+    "fp_last": 58.0
+  },
+  {
+    "playerId": 214106,
+    "fullName": "Валера",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214096,
+    "fullName": "Аффенгрубер",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214101,
+    "fullName": "Мендоса",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 4.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214110,
+    "fullName": "Фебас",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214108,
+    "fullName": "Мартим Нету",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214102,
+    "fullName": "Нуньес",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214097,
+    "fullName": "Бигас",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214105,
+    "fullName": "Хори",
+    "clubName": "Эльче",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214099,
+    "fullName": "Дитуро",
+    "clubName": "Эльче",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214103,
+    "fullName": "Петро",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214111,
+    "fullName": "Альваро Родригес",
+    "clubName": "Эльче",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214095,
+    "fullName": "Марк Агуадо",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 16.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214100,
+    "fullName": "Искьердо",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214109,
+    "fullName": "Мурад",
+    "clubName": "Эльче",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214023,
+    "fullName": "Рафа Мир",
+    "clubName": "Эльче",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214091,
+    "fullName": "Дональд",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214089,
+    "fullName": "Барзич",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 12.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214104,
+    "fullName": "Рафаэль Нуньес",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214098,
+    "fullName": "Боаяр",
+    "clubName": "Эльче",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 9.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214094,
+    "fullName": "Хесус Лопес",
+    "clubName": "Эльче",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214107,
+    "fullName": "де Сантьяго",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214093,
+    "fullName": "Кастильо",
+    "clubName": "Эльче",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214092,
+    "fullName": "Итурбе",
+    "clubName": "Эльче",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 2.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214090,
+    "fullName": "Диаби",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214112,
+    "fullName": "Хосан",
+    "clubName": "Эльче",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215668,
+    "fullName": "Виктор Чуст",
+    "clubName": "Эльче",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214125,
+    "fullName": "Рубио",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214136,
+    "fullName": "Экспосито",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 42.0
+  },
+  {
+    "playerId": 214132,
+    "fullName": "Пере Милья",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 32.0
+  },
+  {
+    "playerId": 214129,
+    "fullName": "Эль-Хилали",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 87.0
+  },
+  {
+    "playerId": 214135,
+    "fullName": "Поль Лосано",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214124,
+    "fullName": "Карлос Ромеро",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 89.0
+  },
+  {
+    "playerId": 214141,
+    "fullName": "Пуадо",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 7.5,
+    "popularity": 2.3,
+    "fp_last": 163.0
+  },
+  {
+    "playerId": 214122,
+    "fullName": "Дмитрович",
+    "clubName": "Эспаньол",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 3.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214139,
+    "fullName": "Роберто Фернандес",
+    "clubName": "Эспаньол",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.4,
+    "fp_last": 67.0
+  },
+  {
+    "playerId": 214131,
+    "fullName": "Кабрера",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 1.3,
+    "fp_last": 106.0
+  },
+  {
+    "playerId": 214140,
+    "fullName": "Кике Гарсия",
+    "clubName": "Эспаньол",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 6.5,
+    "popularity": 1.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214138,
+    "fullName": "Терратс",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214137,
+    "fullName": "Долан",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 6.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214134,
+    "fullName": "Каррерас",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 89.0
+  },
+  {
+    "playerId": 214123,
+    "fullName": "Калеро",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 35.0
+  },
+  {
+    "playerId": 214133,
+    "fullName": "Антониу Рока",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 35.0
+  },
+  {
+    "playerId": 214113,
+    "fullName": "Инохо",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214130,
+    "fullName": "Хави Эрнандес",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 1.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214128,
+    "fullName": "Маркос Фернандес",
+    "clubName": "Эспаньол",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214114,
+    "fullName": "Рамон",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214126,
+    "fullName": "Саласар",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214121,
+    "fullName": "Гастон Вальес",
+    "clubName": "Эспаньол",
+    "position": "FWD",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 3.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214120,
+    "fullName": "Бауса",
+    "clubName": "Эспаньол",
+    "position": "MID",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 2.5,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 214119,
+    "fullName": "Фортуньо",
+    "clubName": "Эспаньол",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214118,
+    "fullName": "Форнс",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214117,
+    "fullName": "Уго Перес",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214116,
+    "fullName": "Тристан",
+    "clubName": "Эспаньол",
+    "position": "GK",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214115,
+    "fullName": "Рубен Санчес",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.0,
+    "popularity": 1.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214127,
+    "fullName": "Салинас",
+    "clubName": "Эспаньол",
+    "position": "DEF",
+    "league": "La Liga",
+    "price": 4.5,
+    "popularity": 0.1,
     "fp_last": 0.0
   },
   {
@@ -5520,426 +5500,6 @@
     "fp_last": 38.0
   },
   {
-    "playerId": 214795,
-    "fullName": "Рейндерс",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 20.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214735,
-    "fullName": "Салах",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 12.5,
-    "popularity": 27.7,
-    "fp_last": 318.0
-  },
-  {
-    "playerId": 214974,
-    "fullName": "Ришарлисон",
-    "clubName": "Тоттенхэм",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 13.3,
-    "fp_last": 36.0
-  },
-  {
-    "playerId": 214865,
-    "fullName": "Вуд",
-    "clubName": "Ноттингем Форест",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 8.0,
-    "popularity": 10.4,
-    "fp_last": 173.0
-  },
-  {
-    "playerId": 214977,
-    "fullName": "Кудус",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 16.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214802,
-    "fullName": "Холанд",
-    "clubName": "Манчестер Сити",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 12.0,
-    "popularity": 36.6,
-    "fp_last": 180.0
-  },
-  {
-    "playerId": 214732,
-    "fullName": "Гакпо",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 8.5,
-    "popularity": 8.9,
-    "fp_last": 127.0
-  },
-  {
-    "playerId": 214733,
-    "fullName": "Экитике",
-    "clubName": "Ливерпуль",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 8.5,
-    "popularity": 29.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214782,
-    "fullName": "Льюис",
-    "clubName": "Манчестер Сити",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 3.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214785,
-    "fullName": "Бобб",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 1.2,
-    "fp_last": 3.0
-  },
-  {
-    "playerId": 214861,
-    "fullName": "Эллиот Андерсон",
-    "clubName": "Ноттингем Форест",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 2.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214862,
-    "fullName": "Ндойе",
-    "clubName": "Ноттингем Форест",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 1.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214968,
-    "fullName": "Пап Матар Сарр",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 8.6,
-    "fp_last": 73.0
-  },
-  {
-    "playerId": 214976,
-    "fullName": "Бреннан Джонсон",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 2.6,
-    "fp_last": 133.0
-  },
-  {
-    "playerId": 214748,
-    "fullName": "Гудмундссон",
-    "clubName": "Лидс",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214560,
-    "fullName": "Мэттью О`Райли",
-    "clubName": "Брайтон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 2.4,
-    "fp_last": 49.0
-  },
-  {
-    "playerId": 214760,
-    "fullName": "Штах",
-    "clubName": "Лидс",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215024,
-    "fullName": "Чалоба",
-    "clubName": "Челси",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 2.3,
-    "fp_last": 82.0
-  },
-  {
-    "playerId": 214922,
-    "fullName": "Руфс",
-    "clubName": "Сандерленд",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 4.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215030,
-    "fullName": "Кукурелья",
-    "clubName": "Челси",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 18.0,
-    "fp_last": 116.0
-  },
-  {
-    "playerId": 215029,
-    "fullName": "Санчес",
-    "clubName": "Челси",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 7.4,
-    "fp_last": 115.0
-  },
-  {
-    "playerId": 214888,
-    "fullName": "Шер",
-    "clubName": "Ньюкасл",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 108.0
-  },
-  {
-    "playerId": 214886,
-    "fullName": "Триппьер",
-    "clubName": "Ньюкасл",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 3.8,
-    "fp_last": 64.0
-  },
-  {
-    "playerId": 214885,
-    "fullName": "Поуп",
-    "clubName": "Ньюкасл",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 4.0,
-    "fp_last": 100.0
-  },
-  {
-    "playerId": 214456,
-    "fullName": "Динь",
-    "clubName": "Астон Вилла",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 3.1,
-    "fp_last": 79.0
-  },
-  {
-    "playerId": 214599,
-    "fullName": "Игор Тиаго",
-    "clubName": "Брентфорд",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 1.7,
-    "fp_last": 9.0
-  },
-  {
-    "playerId": 214791,
-    "fullName": "Рубен Диаш",
-    "clubName": "Манчестер Сити",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 6.6,
-    "fp_last": 85.0
-  },
-  {
-    "playerId": 214925,
-    "fullName": "Хьюм",
-    "clubName": "Сандерленд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215026,
-    "fullName": "Рис Джеймс",
-    "clubName": "Челси",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 6.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214744,
-    "fullName": "Богл",
-    "clubName": "Лидс",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214964,
-    "fullName": "ван де Вен",
-    "clubName": "Тоттенхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 13.5,
-    "fp_last": 30.0
-  },
-  {
-    "playerId": 214883,
-    "fullName": "Берн",
-    "clubName": "Ньюкасл",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 2.0,
-    "fp_last": 110.0
-  },
-  {
-    "playerId": 214965,
-    "fullName": "Викарио",
-    "clubName": "Тоттенхэм",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 10.6,
-    "fp_last": 64.0
-  },
-  {
-    "playerId": 214967,
-    "fullName": "Ромеро",
-    "clubName": "Тоттенхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 6.0,
-    "fp_last": 43.0
-  },
-  {
-    "playerId": 214973,
-    "fullName": "Порро",
-    "clubName": "Тоттенхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 15.1,
-    "fp_last": 92.0
-  },
-  {
-    "playerId": 214777,
-    "fullName": "Стоунз",
-    "clubName": "Манчестер Сити",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 2.3,
-    "fp_last": 27.0
-  },
-  {
-    "playerId": 214684,
-    "fullName": "Митчелл",
-    "clubName": "Кристал Пэлас",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 120.0
-  },
-  {
-    "playerId": 214784,
-    "fullName": "Аит-Нури",
-    "clubName": "Манчестер Сити",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 11.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214778,
-    "fullName": "Траффорд",
-    "clubName": "Манчестер Сити",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 4.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214999,
-    "fullName": "Харри Уилсон",
-    "clubName": "Фулхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 1.3,
-    "fp_last": 72.0
-  },
-  {
-    "playerId": 214906,
-    "fullName": "Рейнилду",
-    "clubName": "Сандерленд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 11.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214889,
-    "fullName": "Ливраменто",
-    "clubName": "Ньюкасл",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 2.9,
-    "fp_last": 99.0
-  },
-  {
     "playerId": 214421,
     "fullName": "Райя",
     "clubName": "Арсенал",
@@ -5948,26 +5508,6 @@
     "price": 6.0,
     "popularity": 13.6,
     "fp_last": 132.0
-  },
-  {
-    "playerId": 214424,
-    "fullName": "Бен Уайт",
-    "clubName": "Арсенал",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.8,
-    "fp_last": 50.0
-  },
-  {
-    "playerId": 215006,
-    "fullName": "Ачимпонг",
-    "clubName": "Челси",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 4.1,
-    "fp_last": 4.0
   },
   {
     "playerId": 214430,
@@ -5980,6 +5520,16 @@
     "fp_last": 133.0
   },
   {
+    "playerId": 214424,
+    "fullName": "Бен Уайт",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.8,
+    "fp_last": 50.0
+  },
+  {
     "playerId": 214422,
     "fullName": "Салиба",
     "clubName": "Арсенал",
@@ -5988,146 +5538,6 @@
     "price": 6.0,
     "popularity": 16.5,
     "fp_last": 117.0
-  },
-  {
-    "playerId": 214753,
-    "fullName": "Стрейк",
-    "clubName": "Лидс",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214443,
-    "fullName": "Бизот",
-    "clubName": "Астон Вилла",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 4.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214692,
-    "fullName": "Дин Хендерсон",
-    "clubName": "Кристал Пэлас",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 7.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214752,
-    "fullName": "Родон",
-    "clubName": "Лидс",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214683,
-    "fullName": "Лакруа",
-    "clubName": "Кристал Пэлас",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.3,
-    "fp_last": 102.0
-  },
-  {
-    "playerId": 214751,
-    "fullName": "Лукас Перри",
-    "clubName": "Лидс",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 3.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214447,
-    "fullName": "Мингз",
-    "clubName": "Астон Вилла",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.9,
-    "fp_last": 39.0
-  },
-  {
-    "playerId": 214723,
-    "fullName": "Керкез",
-    "clubName": "Ливерпуль",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 5.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214936,
-    "fullName": "Аденгра",
-    "clubName": "Сандерленд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 1.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214935,
-    "fullName": "Тальби",
-    "clubName": "Сандерленд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214725,
-    "fullName": "Кьеза",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.6,
-    "fp_last": 7.0
-  },
-  {
-    "playerId": 214961,
-    "fullName": "Спенс",
-    "clubName": "Тоттенхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 3.0,
-    "fp_last": 47.0
-  },
-  {
-    "playerId": 214726,
-    "fullName": "Фримпонг",
-    "clubName": "Ливерпуль",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 32.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214681,
-    "fullName": "Гехи",
-    "clubName": "Кристал Пэлас",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 8.2,
-    "fp_last": 111.0
   },
   {
     "playerId": 214435,
@@ -6150,246 +5560,6 @@
     "fp_last": 107.0
   },
   {
-    "playerId": 214799,
-    "fullName": "Шерки",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
-    "league": "EPL",
-    "price": 8.0,
-    "popularity": 9.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214594,
-    "fullName": "Ярмолюк",
-    "clubName": "Брентфорд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.5,
-    "fp_last": 49.0
-  },
-  {
-    "playerId": 214568,
-    "fullName": "Рюттер",
-    "clubName": "Брайтон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 4.6,
-    "fp_last": 88.0
-  },
-  {
-    "playerId": 214676,
-    "fullName": "Крис Ричардс",
-    "clubName": "Кристал Пэлас",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 2.5,
-    "fp_last": 65.0
-  },
-  {
-    "playerId": 214460,
-    "fullName": "Амаду Онана",
-    "clubName": "Астон Вилла",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 1.3,
-    "fp_last": 67.0
-  },
-  {
-    "playerId": 214453,
-    "fullName": "Кэш",
-    "clubName": "Астон Вилла",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.6,
-    "fp_last": 75.0
-  },
-  {
-    "playerId": 214531,
-    "fullName": "Тавернье",
-    "clubName": "Борнмут",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.6,
-    "fp_last": 88.0
-  },
-  {
-    "playerId": 214933,
-    "fullName": "Майенда",
-    "clubName": "Сандерленд",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 2.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214892,
-    "fullName": "Тонали",
-    "clubName": "Ньюкасл",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 2.9,
-    "fp_last": 120.0
-  },
-  {
-    "playerId": 214524,
-    "fullName": "Брукс",
-    "clubName": "Борнмут",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 47.0
-  },
-  {
-    "playerId": 214564,
-    "fullName": "Балеба",
-    "clubName": "Брайтон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 3.0,
-    "fp_last": 95.0
-  },
-  {
-    "playerId": 214763,
-    "fullName": "Нмеча",
-    "clubName": "Лидс",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 1.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214864,
-    "fullName": "Гиббс-Уайт",
-    "clubName": "Ноттингем Форест",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 4.0,
-    "fp_last": 142.0
-  },
-  {
-    "playerId": 214556,
-    "fullName": "Айяри",
-    "clubName": "Брайтон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.6,
-    "fp_last": 80.0
-  },
-  {
-    "playerId": 214790,
-    "fullName": "Нико Гонсалес",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.5,
-    "fp_last": 33.0
-  },
-  {
-    "playerId": 214937,
-    "fullName": "Изидор",
-    "clubName": "Сандерленд",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214457,
-    "fullName": "Камара",
-    "clubName": "Астон Вилла",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.6,
-    "fp_last": 66.0
-  },
-  {
-    "playerId": 214891,
-    "fullName": "Бруно Гимараэс",
-    "clubName": "Ньюкасл",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 4.6,
-    "fp_last": 146.0
-  },
-  {
-    "playerId": 214463,
-    "fullName": "Макгинн",
-    "clubName": "Астон Вилла",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 1.3,
-    "fp_last": 90.0
-  },
-  {
-    "playerId": 215063,
-    "fullName": "Ндиай",
-    "clubName": "Эвертон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 1.5,
-    "fp_last": 107.0
-  },
-  {
-    "playerId": 214691,
-    "fullName": "Уортон",
-    "clubName": "Кристал Пэлас",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 1.1,
-    "fp_last": 46.0
-  },
-  {
-    "playerId": 214466,
-    "fullName": "Роджерс",
-    "clubName": "Астон Вилла",
-    "position": "MID",
-    "league": "EPL",
-    "price": 8.0,
-    "popularity": 2.5,
-    "fp_last": 164.0
-  },
-  {
-    "playerId": 214694,
-    "fullName": "Муньос",
-    "clubName": "Кристал Пэлас",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 2.8,
-    "fp_last": 130.0
-  },
-  {
-    "playerId": 214931,
-    "fullName": "Диарра",
-    "clubName": "Сандерленд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
     "playerId": 214428,
     "fullName": "Субименди",
     "clubName": "Арсенал",
@@ -6397,136 +5567,6 @@
     "league": "EPL",
     "price": 6.5,
     "popularity": 4.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214697,
-    "fullName": "Исмаила Сарр",
-    "clubName": "Кристал Пэлас",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 1.7,
-    "fp_last": 129.0
-  },
-  {
-    "playerId": 214730,
-    "fullName": "Мак Аллистер",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 4.8,
-    "fp_last": 130.0
-  },
-  {
-    "playerId": 214897,
-    "fullName": "Гордон",
-    "clubName": "Ньюкасл",
-    "position": "MID",
-    "league": "EPL",
-    "price": 8.5,
-    "popularity": 2.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214635,
-    "fullName": "Боуэн",
-    "clubName": "Вест Хэм",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 8.5,
-    "popularity": 5.9,
-    "fp_last": 191.0
-  },
-  {
-    "playerId": 214837,
-    "fullName": "Бруну Фернандеш",
-    "clubName": "Манчестер Юнайтед",
-    "position": "MID",
-    "league": "EPL",
-    "price": 10.0,
-    "popularity": 11.0,
-    "fp_last": 168.0
-  },
-  {
-    "playerId": 215038,
-    "fullName": "Нету",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 5.4,
-    "fp_last": 110.0
-  },
-  {
-    "playerId": 215041,
-    "fullName": "Палмер",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 11.0,
-    "popularity": 34.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214719,
-    "fullName": "Эндо",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 21.0
-  },
-  {
-    "playerId": 214985,
-    "fullName": "Джошуа Кинг",
-    "clubName": "Фулхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 2.9,
-    "fp_last": 10.0
-  },
-  {
-    "playerId": 214582,
-    "fullName": "Оньека",
-    "clubName": "Брентфорд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 214836,
-    "fullName": "Мбемо",
-    "clubName": "Манчестер Юнайтед",
-    "position": "MID",
-    "league": "EPL",
-    "price": 8.5,
-    "popularity": 5.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214437,
-    "fullName": "Сака",
-    "clubName": "Арсенал",
-    "position": "MID",
-    "league": "EPL",
-    "price": 10.5,
-    "popularity": 10.6,
-    "fp_last": 115.0
-  },
-  {
-    "playerId": 214525,
-    "fullName": "Хамед Траоре",
-    "clubName": "Борнмут",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.2,
     "fp_last": 0.0
   },
   {
@@ -6540,164 +5580,324 @@
     "fp_last": 129.0
   },
   {
-    "playerId": 214731,
-    "fullName": "Собослаи",
-    "clubName": "Ливерпуль",
+    "playerId": 214437,
+    "fullName": "Сака",
+    "clubName": "Арсенал",
     "position": "MID",
     "league": "EPL",
-    "price": 7.0,
-    "popularity": 3.3,
-    "fp_last": 134.0
+    "price": 10.5,
+    "popularity": 10.6,
+    "fp_last": 115.0
   },
   {
-    "playerId": 214896,
-    "fullName": "Эланга",
-    "clubName": "Ньюкасл",
+    "playerId": 214436,
+    "fullName": "Дьокереш",
+    "clubName": "Арсенал",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 9.5,
+    "popularity": 24.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214434,
+    "fullName": "Хавертц",
+    "clubName": "Арсенал",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 2.0,
+    "fp_last": 101.0
+  },
+  {
+    "playerId": 214431,
+    "fullName": "Мадуэке",
+    "clubName": "Арсенал",
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 3.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214558,
-    "fullName": "Виффер",
-    "clubName": "Брайтон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 214567,
-    "fullName": "Минте",
-    "clubName": "Брайтон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 1.7,
-    "fp_last": 94.0
-  },
-  {
-    "playerId": 215060,
-    "fullName": "Гуйе",
-    "clubName": "Эвертон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.6,
-    "fp_last": 109.0
-  },
-  {
-    "playerId": 215000,
-    "fullName": "Родриго Муниз",
-    "clubName": "Фулхэм",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.9,
-    "fp_last": 72.0
-  },
-  {
-    "playerId": 214698,
-    "fullName": "Эзе",
-    "clubName": "Кристал Пэлас",
-    "position": "MID",
-    "league": "EPL",
-    "price": 8.5,
-    "popularity": 4.9,
-    "fp_last": 148.0
-  },
-  {
-    "playerId": 214734,
-    "fullName": "Виртц",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 9.0,
-    "popularity": 30.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214634,
-    "fullName": "Лукас Пакета",
-    "clubName": "Вест Хэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 3.7,
-    "fp_last": 88.0
-  },
-  {
-    "playerId": 214893,
-    "fullName": "Харви Барнс",
-    "clubName": "Ньюкасл",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214958,
-    "fullName": "Арчи Грэй",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
     "popularity": 0.5,
     "fp_last": 0.0
   },
   {
-    "playerId": 214853,
-    "fullName": "Айна",
-    "clubName": "Ноттингем Форест",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 4.6,
-    "fp_last": 113.0
-  },
-  {
-    "playerId": 214758,
-    "fullName": "Танака",
-    "clubName": "Лидс",
+    "playerId": 214429,
+    "fullName": "Мерино",
+    "clubName": "Арсенал",
     "position": "MID",
     "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.4,
+    "price": 7.0,
+    "popularity": 1.1,
+    "fp_last": 95.0
+  },
+  {
+    "playerId": 214415,
+    "fullName": "Аррисабалага",
+    "clubName": "Арсенал",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.8,
     "fp_last": 0.0
   },
   {
-    "playerId": 214923,
-    "fullName": "Садики",
-    "clubName": "Сандерленд",
+    "playerId": 214427,
+    "fullName": "Нергор",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214407,
+    "fullName": "Рохас Федорущенко",
+    "clubName": "Арсенал",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214408,
+    "fullName": "Сетфорд",
+    "clubName": "Арсенал",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214432,
+    "fullName": "Троссард",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 0.6,
+    "fp_last": 146.0
+  },
+  {
+    "playerId": 214409,
+    "fullName": "Хейн",
+    "clubName": "Арсенал",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214410,
+    "fullName": "Кабиа",
+    "clubName": "Арсенал",
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 1.3,
+    "popularity": 0.1,
     "fp_last": 0.0
   },
   {
-    "playerId": 214658,
-    "fullName": "Мунеци",
-    "clubName": "Вулверхэмптон",
+    "playerId": 214426,
+    "fullName": "Нванери",
+    "clubName": "Арсенал",
     "position": "MID",
     "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.1,
-    "fp_last": 52.0
+    "price": 6.5,
+    "popularity": 0.3,
+    "fp_last": 63.0
   },
   {
-    "playerId": 214494,
-    "fullName": "Каллен",
-    "clubName": "Бернли",
+    "playerId": 214414,
+    "fullName": "Нелсон",
+    "clubName": "Арсенал",
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
     "popularity": 0.1,
     "fp_last": 0.0
+  },
+  {
+    "playerId": 214425,
+    "fullName": "Габриэл Жезус",
+    "clubName": "Арсенал",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.1,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 214411,
+    "fullName": "Локонга",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214423,
+    "fullName": "Тимбер",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.9,
+    "fp_last": 105.0
+  },
+  {
+    "playerId": 214412,
+    "fullName": "Зинченко",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 38.0
+  },
+  {
+    "playerId": 214406,
+    "fullName": "Николс",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214413,
+    "fullName": "Кристиан Москера",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214419,
+    "fullName": "Фабиу Виейра",
+    "clubName": "Арсенал",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214418,
+    "fullName": "Льюис-Скелли",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 4.2,
+    "fp_last": 44.0
+  },
+  {
+    "playerId": 214417,
+    "fullName": "Кивер",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 41.0
+  },
+  {
+    "playerId": 214405,
+    "fullName": "Кацурри",
+    "clubName": "Арсенал",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214443,
+    "fullName": "Бизот",
+    "clubName": "Астон Вилла",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 4.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214456,
+    "fullName": "Динь",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 3.1,
+    "fp_last": 79.0
+  },
+  {
+    "playerId": 214453,
+    "fullName": "Кэш",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.6,
+    "fp_last": 75.0
+  },
+  {
+    "playerId": 214447,
+    "fullName": "Мингз",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.9,
+    "fp_last": 39.0
+  },
+  {
+    "playerId": 214460,
+    "fullName": "Амаду Онана",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.3,
+    "fp_last": 67.0
+  },
+  {
+    "playerId": 214466,
+    "fullName": "Роджерс",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 2.5,
+    "fp_last": 164.0
+  },
+  {
+    "playerId": 214463,
+    "fullName": "Макгинн",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 1.3,
+    "fp_last": 90.0
+  },
+  {
+    "playerId": 214457,
+    "fullName": "Камара",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.6,
+    "fp_last": 66.0
   },
   {
     "playerId": 214467,
@@ -6720,306 +5920,6 @@
     "fp_last": 133.0
   },
   {
-    "playerId": 215035,
-    "fullName": "Кайседо",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 4.9,
-    "fp_last": 125.0
-  },
-  {
-    "playerId": 214857,
-    "fullName": "Мурилло",
-    "clubName": "Ноттингем Форест",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 6.3,
-    "fp_last": 112.0
-  },
-  {
-    "playerId": 214793,
-    "fullName": "Бернарду Силва",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 3.0,
-    "fp_last": 125.0
-  },
-  {
-    "playerId": 214598,
-    "fullName": "Карвалью",
-    "clubName": "Брентфорд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.2,
-    "fp_last": 34.0
-  },
-  {
-    "playerId": 214927,
-    "fullName": "Джака",
-    "clubName": "Сандерленд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 10.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214517,
-    "fullName": "Адамс",
-    "clubName": "Борнмут",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.8,
-    "fp_last": 72.0
-  },
-  {
-    "playerId": 214655,
-    "fullName": "Андре",
-    "clubName": "Вулверхэмптон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 73.0
-  },
-  {
-    "playerId": 214626,
-    "fullName": "Родригес",
-    "clubName": "Вест Хэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 39.0
-  },
-  {
-    "playerId": 214628,
-    "fullName": "Уан-Биссака",
-    "clubName": "Вест Хэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 5.3,
-    "fp_last": 102.0
-  },
-  {
-    "playerId": 214894,
-    "fullName": "Жоэлинтон",
-    "clubName": "Ньюкасл",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 1.3,
-    "fp_last": 104.0
-  },
-  {
-    "playerId": 214992,
-    "fullName": "Лено",
-    "clubName": "Фулхэм",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 2.2,
-    "fp_last": 107.0
-  },
-  {
-    "playerId": 214552,
-    "fullName": "Данк",
-    "clubName": "Брайтон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.5,
-    "fp_last": 43.0
-  },
-  {
-    "playerId": 214633,
-    "fullName": "Фюллькруг",
-    "clubName": "Вест Хэм",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 4.2,
-    "fp_last": 40.0
-  },
-  {
-    "playerId": 214559,
-    "fullName": "де Кейпер",
-    "clubName": "Брайтон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 5.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214765,
-    "fullName": "Дэниэл Джеймс",
-    "clubName": "Лидс",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 1.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214696,
-    "fullName": "Матета",
-    "clubName": "Кристал Пэлас",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 8.9,
-    "fp_last": 142.0
-  },
-  {
-    "playerId": 214661,
-    "fullName": "Жоао Гомес",
-    "clubName": "Вулверхэмптон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.3,
-    "fp_last": 101.0
-  },
-  {
-    "playerId": 214693,
-    "fullName": "Хьюз",
-    "clubName": "Кристал Пэлас",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.3,
-    "fp_last": 64.0
-  },
-  {
-    "playerId": 214766,
-    "fullName": "Ньонто",
-    "clubName": "Лидс",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214981,
-    "fullName": "Куэнка",
-    "clubName": "Фулхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 1.5,
-    "fp_last": 9.0
-  },
-  {
-    "playerId": 214742,
-    "fullName": "Ампаду",
-    "clubName": "Лидс",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 8.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214767,
-    "fullName": "Пиру",
-    "clubName": "Лидс",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 2.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214963,
-    "fullName": "Бергвалль",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.3,
-    "fp_last": 47.0
-  },
-  {
-    "playerId": 214835,
-    "fullName": "Матеус Кунья",
-    "clubName": "Манчестер Юнайтед",
-    "position": "MID",
-    "league": "EPL",
-    "price": 8.0,
-    "popularity": 6.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215048,
-    "fullName": "О'Брайен",
-    "clubName": "Эвертон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 3.2,
-    "fp_last": 60.0
-  },
-  {
-    "playerId": 214816,
-    "fullName": "де Лигт",
-    "clubName": "Манчестер Юнайтед",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.8,
-    "fp_last": 65.0
-  },
-  {
-    "playerId": 214549,
-    "fullName": "ван Хекке",
-    "clubName": "Брайтон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 2.7,
-    "fp_last": 80.0
-  },
-  {
-    "playerId": 215047,
-    "fullName": "Кин",
-    "clubName": "Эвертон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.0,
-    "fp_last": 44.0
-  },
-  {
-    "playerId": 215052,
-    "fullName": "Ироэгбунам",
-    "clubName": "Эвертон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 25.0
-  },
-  {
-    "playerId": 214798,
-    "fullName": "Доку",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 2.7,
-    "fp_last": 91.0
-  },
-  {
     "playerId": 214452,
     "fullName": "Конса",
     "clubName": "Астон Вилла",
@@ -7030,33 +5930,213 @@
     "fp_last": 93.0
   },
   {
-    "playerId": 215055,
-    "fullName": "Гарнер",
-    "clubName": "Эвертон",
+    "playerId": 214464,
+    "fullName": "Мален",
+    "clubName": "Астон Вилла",
     "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 1.3,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 214455,
+    "fullName": "Пау Торрес",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.1,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 214462,
+    "fullName": "Бэйли",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.5,
+    "fp_last": 49.0
+  },
+  {
+    "playerId": 214459,
+    "fullName": "Буэндиа",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.5,
+    "fp_last": 11.0
+  },
+  {
+    "playerId": 214458,
+    "fullName": "Эмилиано Мартинес",
+    "clubName": "Астон Вилла",
+    "position": "GK",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 53.0
+    "popularity": 2.3,
+    "fp_last": 106.0
   },
   {
-    "playerId": 215059,
-    "fullName": "Бету",
-    "clubName": "Эвертон",
+    "playerId": 214438,
+    "fullName": "Гарсия",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 9.0
+  },
+  {
+    "playerId": 214454,
+    "fullName": "Матсен",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.1,
+    "fp_last": 57.0
+  },
+  {
+    "playerId": 214439,
+    "fullName": "Госи",
+    "clubName": "Астон Вилла",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214451,
+    "fullName": "Илинг-Джуниор",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214450,
+    "fullName": "Дендонкер",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214449,
+    "fullName": "Баркли",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 41.0
+  },
+  {
+    "playerId": 214448,
+    "fullName": "Морено",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214446,
+    "fullName": "Доббин",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214445,
+    "fullName": "Джимо-Алоба",
+    "clubName": "Астон Вилла",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214444,
+    "fullName": "Богарде",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 214442,
+    "fullName": "Райт",
+    "clubName": "Астон Вилла",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214441,
+    "fullName": "Трэвис Паттерсон",
+    "clubName": "Астон Вилла",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214440,
+    "fullName": "Филип Маршалл",
+    "clubName": "Астон Вилла",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215651,
+    "fullName": "Гессан",
+    "clubName": "Астон Вилла",
     "position": "FWD",
     "league": "EPL",
-    "price": 6.0,
-    "popularity": 2.0,
-    "fp_last": 82.0
+    "price": 6.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
   },
   {
-    "playerId": 215061,
-    "fullName": "Дьюзбери-Холл",
-    "clubName": "Эвертон",
+    "playerId": 214494,
+    "fullName": "Каллен",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214504,
+    "fullName": "Энтони",
+    "clubName": "Бернли",
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.9,
+    "popularity": 0.4,
     "fp_last": 0.0
   },
   {
@@ -7070,76 +6150,6 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 214818,
-    "fullName": "Йоро",
-    "clubName": "Манчестер Юнайтед",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 3.3,
-    "fp_last": 22.0
-  },
-  {
-    "playerId": 214822,
-    "fullName": "Шоу",
-    "clubName": "Манчестер Юнайтед",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.8,
-    "fp_last": 7.0
-  },
-  {
-    "playerId": 214863,
-    "fullName": "Хадсон-Одои",
-    "clubName": "Ноттингем Форест",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 1.2,
-    "fp_last": 103.0
-  },
-  {
-    "playerId": 214995,
-    "fullName": "Лукич",
-    "clubName": "Фулхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 65.0
-  },
-  {
-    "playerId": 214994,
-    "fullName": "Тете",
-    "clubName": "Фулхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.5,
-    "fp_last": 49.0
-  },
-  {
-    "playerId": 214504,
-    "fullName": "Энтони",
-    "clubName": "Бернли",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215039,
-    "fullName": "Энцо Фернандес",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 5.4,
-    "fp_last": 0.0
-  },
-  {
     "playerId": 214497,
     "fullName": "Межбри",
     "clubName": "Бернли",
@@ -7150,26 +6160,6 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 215040,
-    "fullName": "Жоао Педро",
-    "clubName": "Челси",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 8.0,
-    "popularity": 32.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214855,
-    "fullName": "Зельс",
-    "clubName": "Ноттингем Форест",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 11.0,
-    "fp_last": 136.0
-  },
-  {
     "playerId": 214873,
     "fullName": "Дубравка",
     "clubName": "Бернли",
@@ -7177,6 +6167,16 @@
     "league": "EPL",
     "price": 4.5,
     "popularity": 3.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214486,
+    "fullName": "Уокер",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 3.0,
     "fp_last": 0.0
   },
   {
@@ -7190,846 +6190,6 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 214608,
-    "fullName": "Агерд",
-    "clubName": "Вест Хэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214623,
-    "fullName": "Диуф",
-    "clubName": "Вест Хэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 3.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214630,
-    "fullName": "Уорд-Проуз",
-    "clubName": "Вест Хэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 1.0,
-    "fp_last": 57.0
-  },
-  {
-    "playerId": 214551,
-    "fullName": "Вербрюгген",
-    "clubName": "Брайтон",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 6.6,
-    "fp_last": 97.0
-  },
-  {
-    "playerId": 214803,
-    "fullName": "Байындыр",
-    "clubName": "Манчестер Юнайтед",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 14.9,
-    "fp_last": 8.0
-  },
-  {
-    "playerId": 214852,
-    "fullName": "Сангаре",
-    "clubName": "Ноттингем Форест",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 21.0
-  },
-  {
-    "playerId": 214657,
-    "fullName": "Белльгард",
-    "clubName": "Вулверхэмптон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.2,
-    "fp_last": 86.0
-  },
-  {
-    "playerId": 214851,
-    "fullName": "Йейтс",
-    "clubName": "Ноттингем Форест",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 74.0
-  },
-  {
-    "playerId": 214663,
-    "fullName": "Ларсен",
-    "clubName": "Вулверхэмптон",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 1.9,
-    "fp_last": 139.0
-  },
-  {
-    "playerId": 214601,
-    "fullName": "Шаде",
-    "clubName": "Брентфорд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 0.3,
-    "fp_last": 140.0
-  },
-  {
-    "playerId": 215054,
-    "fullName": "Алькарас",
-    "clubName": "Эвертон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 41.0
-  },
-  {
-    "playerId": 215056,
-    "fullName": "Пикфорд",
-    "clubName": "Эвертон",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 8.9,
-    "fp_last": 143.0
-  },
-  {
-    "playerId": 214436,
-    "fullName": "Дьокереш",
-    "clubName": "Арсенал",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 9.5,
-    "popularity": 24.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214907,
-    "fullName": "Селт",
-    "clubName": "Сандерленд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 1.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214724,
-    "fullName": "Конате",
-    "clubName": "Ливерпуль",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 1.7,
-    "fp_last": 102.0
-  },
-  {
-    "playerId": 214721,
-    "fullName": "ван Дейк",
-    "clubName": "Ливерпуль",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 16.7,
-    "fp_last": 135.0
-  },
-  {
-    "playerId": 214828,
-    "fullName": "Каземиро",
-    "clubName": "Манчестер Юнайтед",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 1.0,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 214830,
-    "fullName": "Маунт",
-    "clubName": "Манчестер Юнайтед",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.8,
-    "fp_last": 25.0
-  },
-  {
-    "playerId": 214856,
-    "fullName": "Миленкович",
-    "clubName": "Ноттингем Форест",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 9.4,
-    "fp_last": 143.0
-  },
-  {
-    "playerId": 214486,
-    "fullName": "Уокер",
-    "clubName": "Бернли",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 3.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215002,
-    "fullName": "Ивоби",
-    "clubName": "Фулхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 0.7,
-    "fp_last": 154.0
-  },
-  {
-    "playerId": 214570,
-    "fullName": "Митома",
-    "clubName": "Брайтон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 4.5,
-    "fp_last": 144.0
-  },
-  {
-    "playerId": 215004,
-    "fullName": "Хименес",
-    "clubName": "Фулхэм",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 1.8,
-    "fp_last": 132.0
-  },
-  {
-    "playerId": 214988,
-    "fullName": "Басси",
-    "clubName": "Фулхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 75.0
-  },
-  {
-    "playerId": 214593,
-    "fullName": "Джордан Хендерсон",
-    "clubName": "Брентфорд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214987,
-    "fullName": "Андерсен",
-    "clubName": "Фулхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.2,
-    "fp_last": 51.0
-  },
-  {
-    "playerId": 214534,
-    "fullName": "Эванилсон",
-    "clubName": "Борнмут",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 2.1,
-    "fp_last": 113.0
-  },
-  {
-    "playerId": 214522,
-    "fullName": "Скотт",
-    "clubName": "Борнмут",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 26.0
-  },
-  {
-    "playerId": 214589,
-    "fullName": "Йенсен",
-    "clubName": "Брентфорд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 39.0
-  },
-  {
-    "playerId": 214520,
-    "fullName": "Петрович",
-    "clubName": "Борнмут",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 3.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214577,
-    "fullName": "ван ден Берг",
-    "clubName": "Брентфорд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 65.0
-  },
-  {
-    "playerId": 214662,
-    "fullName": "Хван Хи Чхан",
-    "clubName": "Вулверхэмптон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.3,
-    "fp_last": 33.0
-  },
-  {
-    "playerId": 214859,
-    "fullName": "Игор Жезус",
-    "clubName": "Ноттингем Форест",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214660,
-    "fullName": "Арьяс",
-    "clubName": "Вулверхэмптон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214980,
-    "fullName": "Соланке",
-    "clubName": "Тоттенхэм",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 8.0,
-    "popularity": 1.6,
-    "fp_last": 115.0
-  },
-  {
-    "playerId": 214595,
-    "fullName": "Льюис-Поттер",
-    "clubName": "Брентфорд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 116.0
-  },
-  {
-    "playerId": 214596,
-    "fullName": "Миламбо",
-    "clubName": "Брентфорд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214579,
-    "fullName": "Кайоде",
-    "clubName": "Брентфорд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.0,
-    "fp_last": 26.0
-  },
-  {
-    "playerId": 214654,
-    "fullName": "Фер Лопес",
-    "clubName": "Вулверхэмптон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214652,
-    "fullName": "Хувер",
-    "clubName": "Вулверхэмптон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214722,
-    "fullName": "Кертис Джонс",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214523,
-    "fullName": "Трюффер",
-    "clubName": "Борнмут",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214649,
-    "fullName": "Меллер Вольф",
-    "clubName": "Вулверхэмптон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214881,
-    "fullName": "Осула",
-    "clubName": "Ньюкасл",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.5,
-    "fp_last": 18.0
-  },
-  {
-    "playerId": 214647,
-    "fullName": "Доэрти",
-    "clubName": "Вулверхэмптон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 73.0
-  },
-  {
-    "playerId": 214880,
-    "fullName": "Майли",
-    "clubName": "Ньюкасл",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 21.0
-  },
-  {
-    "playerId": 214475,
-    "fullName": "Сонне",
-    "clubName": "Бернли",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215003,
-    "fullName": "Смит-Роу",
-    "clubName": "Фулхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 0.4,
-    "fp_last": 100.0
-  },
-  {
-    "playerId": 214932,
-    "fullName": "Ле Фе",
-    "clubName": "Сандерленд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215058,
-    "fullName": "Барри",
-    "clubName": "Эвертон",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 1.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214690,
-    "fullName": "Лерма",
-    "clubName": "Кристал Пэлас",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 74.0
-  },
-  {
-    "playerId": 214565,
-    "fullName": "Груда",
-    "clubName": "Брайтон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.1,
-    "fp_last": 44.0
-  },
-  {
-    "playerId": 214431,
-    "fullName": "Мадуэке",
-    "clubName": "Арсенал",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215652,
-    "fullName": "Шешко",
-    "clubName": "Манчестер Юнайтед",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 8.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214429,
-    "fullName": "Мерино",
-    "clubName": "Арсенал",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 1.1,
-    "fp_last": 95.0
-  },
-  {
-    "playerId": 214817,
-    "fullName": "Диогу Далот",
-    "clubName": "Манчестер Юнайтед",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.7,
-    "fp_last": 83.0
-  },
-  {
-    "playerId": 214682,
-    "fullName": "Девенни",
-    "clubName": "Кристал Пэлас",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 31.0
-  },
-  {
-    "playerId": 216508,
-    "fullName": "Уинтерберн",
-    "clubName": "Борнмут",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 3.0
-  },
-  {
-    "playerId": 214823,
-    "fullName": "Доргу",
-    "clubName": "Манчестер Юнайтед",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 2.7,
-    "fp_last": 18.0
-  },
-  {
-    "playerId": 214860,
-    "fullName": "Силва",
-    "clubName": "Ноттингем Форест",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.3,
-    "fp_last": 51.0
-  },
-  {
-    "playerId": 214819,
-    "fullName": "Магуайр",
-    "clubName": "Манчестер Юнайтед",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.9,
-    "fp_last": 45.0
-  },
-  {
-    "playerId": 214569,
-    "fullName": "Уэлбек",
-    "clubName": "Брайтон",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 2.0,
-    "fp_last": 112.0
-  },
-  {
-    "playerId": 214787,
-    "fullName": "Грилиш",
-    "clubName": "Эвертон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 4.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216510,
-    "fullName": "Хермансен",
-    "clubName": "Вест Хэм",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214773,
-    "fullName": "Хусанов",
-    "clubName": "Манчестер Сити",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.3,
-    "fp_last": 16.0
-  },
-  {
-    "playerId": 214464,
-    "fullName": "Мален",
-    "clubName": "Астон Вилла",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 1.3,
-    "fp_last": 31.0
-  },
-  {
-    "playerId": 214930,
-    "fullName": "Ригг",
-    "clubName": "Сандерленд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215001,
-    "fullName": "Адама Траоре",
-    "clubName": "Фулхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.4,
-    "fp_last": 89.0
-  },
-  {
-    "playerId": 214643,
-    "fullName": "Родригу Гомеш",
-    "clubName": "Вулверхэмптон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 41.0
-  },
-  {
-    "playerId": 214644,
-    "fullName": "Тоте Гомеш",
-    "clubName": "Вулверхэмптон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 71.0
-  },
-  {
-    "playerId": 214591,
-    "fullName": "Коллинз",
-    "clubName": "Брентфорд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.8,
-    "fp_last": 108.0
-  },
-  {
-    "playerId": 214617,
-    "fullName": "Тодибо",
-    "clubName": "Вест Хэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.2,
-    "fp_last": 53.0
-  },
-  {
-    "playerId": 214762,
-    "fullName": "Лонгстафф",
-    "clubName": "Лидс",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214972,
-    "fullName": "Одобер",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.2,
-    "fp_last": 34.0
-  },
-  {
-    "playerId": 214764,
-    "fullName": "Харрисон",
-    "clubName": "Лидс",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214500,
-    "fullName": "Тшауна",
-    "clubName": "Бернли",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214590,
-    "fullName": "Келлехер",
-    "clubName": "Брентфорд",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 4.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214962,
-    "fullName": "Бентанкур",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 1.6,
-    "fp_last": 55.0
-  },
-  {
-    "playerId": 214609,
-    "fullName": "Ирвинг",
-    "clubName": "Вест Хэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 9.0
-  },
-  {
-    "playerId": 214502,
-    "fullName": "Эдвардс",
-    "clubName": "Бернли",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214761,
-    "fullName": "Ааронсон",
-    "clubName": "Лидс",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214503,
-    "fullName": "Флемминг",
-    "clubName": "Бернли",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214554,
-    "fullName": "Милнер",
-    "clubName": "Брайтон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 214966,
-    "fullName": "Пальинья",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
     "playerId": 215022,
     "fullName": "Угочукву",
     "clubName": "Бернли",
@@ -8040,53 +6200,23 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 214858,
-    "fullName": "Неко Уильямс",
-    "clubName": "Ноттингем Форест",
+    "playerId": 214487,
+    "fullName": "Хартман",
+    "clubName": "Бернли",
     "position": "DEF",
     "league": "EPL",
-    "price": 5.5,
-    "popularity": 1.9,
-    "fp_last": 101.0
-  },
-  {
-    "playerId": 215021,
-    "fullName": "Сантос",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
+    "price": 4.5,
+    "popularity": 0.3,
     "fp_last": 0.0
   },
   {
-    "playerId": 214512,
-    "fullName": "Хилл",
-    "clubName": "Борнмут",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 2.2,
-    "fp_last": 18.0
-  },
-  {
-    "playerId": 215018,
-    "fullName": "Гюсто",
-    "clubName": "Челси",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 2.5,
-    "fp_last": 58.0
-  },
-  {
-    "playerId": 214514,
-    "fullName": "Крупи",
-    "clubName": "Борнмут",
+    "playerId": 214493,
+    "fullName": "Бруун Ларсен",
+    "clubName": "Бернли",
     "position": "MID",
     "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.5,
+    "price": 5.0,
+    "popularity": 0.3,
     "fp_last": 0.0
   },
   {
@@ -8100,144 +6230,44 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 214834,
-    "fullName": "Диалло",
-    "clubName": "Манчестер Юнайтед",
+    "playerId": 214500,
+    "fullName": "Тшауна",
+    "clubName": "Бернли",
     "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 2.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214587,
-    "fullName": "Хенри",
-    "clubName": "Брентфорд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 4.0
-  },
-  {
-    "playerId": 214789,
-    "fullName": "Матеуш Нунеш",
-    "clubName": "Манчестер Сити",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 1.3,
-    "fp_last": 88.0
-  },
-  {
-    "playerId": 214720,
-    "fullName": "Алиссон",
-    "clubName": "Ливерпуль",
-    "position": "GK",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 11.3,
-    "fp_last": 103.0
-  },
-  {
-    "playerId": 214825,
-    "fullName": "Угарте",
-    "clubName": "Манчестер Юнайтед",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 58.0
-  },
-  {
-    "playerId": 215037,
-    "fullName": "Гиттенс",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215034,
-    "fullName": "Делап",
-    "clubName": "Челси",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 3.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214637,
-    "fullName": "Уго Буэно",
-    "clubName": "Вулверхэмптон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214712,
-    "fullName": "Джо Гомес",
-    "clubName": "Ливерпуль",
-    "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 14.0
+    "popularity": 0.1,
+    "fp_last": 0.0
   },
   {
-    "playerId": 214487,
-    "fullName": "Хартман",
+    "playerId": 214475,
+    "fullName": "Сонне",
     "clubName": "Бернли",
     "position": "DEF",
     "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
+    "price": 4.0,
+    "popularity": 0.8,
     "fp_last": 0.0
   },
   {
-    "playerId": 214800,
-    "fullName": "Мармуш",
-    "clubName": "Манчестер Сити",
+    "playerId": 214502,
+    "fullName": "Эдвардс",
+    "clubName": "Бернли",
     "position": "MID",
     "league": "EPL",
-    "price": 9.0,
-    "popularity": 6.4,
-    "fp_last": 79.0
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
   },
   {
-    "playerId": 214632,
-    "fullName": "Соучек",
-    "clubName": "Вест Хэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.9,
-    "fp_last": 130.0
-  },
-  {
-    "playerId": 214629,
-    "fullName": "Каллум Уилсон",
-    "clubName": "Вест Хэм",
+    "playerId": 214503,
+    "fullName": "Флемминг",
+    "clubName": "Бернли",
     "position": "FWD",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 1.4,
+    "popularity": 0.1,
     "fp_last": 0.0
-  },
-  {
-    "playerId": 214516,
-    "fullName": "Смит",
-    "clubName": "Борнмут",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 57.0
   },
   {
     "playerId": 214489,
@@ -8250,503 +6280,43 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 214990,
-    "fullName": "Кастань",
-    "clubName": "Фулхэм",
-    "position": "DEF",
+    "playerId": 214491,
+    "fullName": "Эшли Барнс",
+    "clubName": "Бернли",
+    "position": "FWD",
     "league": "EPL",
     "price": 5.0,
     "popularity": 0.4,
-    "fp_last": 46.0
+    "fp_last": 0.0
   },
   {
-    "playerId": 214493,
-    "fullName": "Бруун Ларсен",
+    "playerId": 214498,
+    "fullName": "Ндайишимийе",
     "clubName": "Бернли",
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214756,
-    "fullName": "Груев",
-    "clubName": "Лидс",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
     "popularity": 0.1,
     "fp_last": 0.0
   },
   {
-    "playerId": 214895,
-    "fullName": "Джейкоб Мерфи",
-    "clubName": "Ньюкасл",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 0.8,
-    "fp_last": 154.0
-  },
-  {
-    "playerId": 214975,
-    "fullName": "Тель",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 0.5,
-    "fp_last": 45.0
-  },
-  {
-    "playerId": 214434,
-    "fullName": "Хавертц",
-    "clubName": "Арсенал",
+    "playerId": 214499,
+    "fullName": "Обафеми",
+    "clubName": "Бернли",
     "position": "FWD",
     "league": "EPL",
-    "price": 8.0,
-    "popularity": 2.0,
-    "fp_last": 101.0
-  },
-  {
-    "playerId": 214838,
-    "fullName": "Карлос Мигел",
-    "clubName": "Ноттингем Форест",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.4,
+    "price": 5.0,
+    "popularity": 0.3,
     "fp_last": 0.0
   },
   {
-    "playerId": 214839,
-    "fullName": "Карму",
-    "clubName": "Ноттингем Форест",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214890,
-    "fullName": "Уиллок",
-    "clubName": "Ньюкасл",
+    "playerId": 214495,
+    "fullName": "Колиошо",
+    "clubName": "Бернли",
     "position": "MID",
     "league": "EPL",
-    "price": 6.0,
+    "price": 5.0,
     "popularity": 0.0,
-    "fp_last": 46.0
-  },
-  {
-    "playerId": 214841,
-    "fullName": "Боли",
-    "clubName": "Ноттингем Форест",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 214840,
-    "fullName": "Тернер",
-    "clubName": "Ноттингем Форест",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214870,
-    "fullName": "Алекс Мерфи",
-    "clubName": "Ньюкасл",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214842,
-    "fullName": "Боулер",
-    "clubName": "Ноттингем Форест",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214869,
-    "fullName": "Ласселс",
-    "clubName": "Ньюкасл",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214872,
-    "fullName": "Эшби",
-    "clubName": "Ньюкасл",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214874,
-    "fullName": "Кордеро",
-    "clubName": "Ньюкасл",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214875,
-    "fullName": "Нив",
-    "clubName": "Ньюкасл",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214876,
-    "fullName": "Таргетт",
-    "clubName": "Ньюкасл",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 214854,
-    "fullName": "Домингес",
-    "clubName": "Ноттингем Форест",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 61.0
-  },
-  {
-    "playerId": 214877,
-    "fullName": "Джо Уайт",
-    "clubName": "Ньюкасл",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214878,
-    "fullName": "Хернес",
-    "clubName": "Ньюкасл",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214879,
-    "fullName": "Хэйден",
-    "clubName": "Ньюкасл",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214871,
-    "fullName": "Радди",
-    "clubName": "Ньюкасл",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214850,
-    "fullName": "Эммануэль Деннис",
-    "clubName": "Ноттингем Форест",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214868,
-    "fullName": "Крафт",
-    "clubName": "Ньюкасл",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 17.0
-  },
-  {
-    "playerId": 214843,
-    "fullName": "Жаир Кунья",
-    "clubName": "Ноттингем Форест",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214882,
-    "fullName": "Рэмсдейл",
-    "clubName": "Ньюкасл",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214849,
-    "fullName": "да Силва Морейра",
-    "clubName": "Ноттингем Форест",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 214848,
-    "fullName": "Авонийи",
-    "clubName": "Ноттингем Форест",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.3,
-    "fp_last": 32.0
-  },
-  {
-    "playerId": 214847,
-    "fullName": "Стаменич",
-    "clubName": "Ноттингем Форест",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214884,
-    "fullName": "Ботман",
-    "clubName": "Ньюкасл",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 1.1,
-    "fp_last": 18.0
-  },
-  {
-    "playerId": 214846,
-    "fullName": "Омар Ричардс",
-    "clubName": "Ноттингем Форест",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214887,
-    "fullName": "Льюис Холл",
-    "clubName": "Ньюкасл",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.5,
-    "fp_last": 82.0
-  },
-  {
-    "playerId": 214845,
-    "fullName": "О`Брайен",
-    "clubName": "Ноттингем Форест",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214867,
-    "fullName": "Гиллеспи",
-    "clubName": "Ньюкасл",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214844,
-    "fullName": "Морато",
-    "clubName": "Ноттингем Форест",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 34.0
-  },
-  {
-    "playerId": 214866,
-    "fullName": "Влаходимос",
-    "clubName": "Ньюкасл",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 1.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214405,
-    "fullName": "Кацурри",
-    "clubName": "Арсенал",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214898,
-    "fullName": "Исак",
-    "clubName": "Ньюкасл",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 10.5,
-    "popularity": 3.1,
-    "fp_last": 192.0
-  },
-  {
-    "playerId": 215015,
-    "fullName": "Адарабиойо",
-    "clubName": "Челси",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.3,
-    "fp_last": 64.0
-  },
-  {
-    "playerId": 215033,
-    "fullName": "Стерлинг",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215032,
-    "fullName": "Джексон",
-    "clubName": "Челси",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215031,
-    "fullName": "Эстевао",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215028,
-    "fullName": "Лавия",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.3,
-    "fp_last": 26.0
-  },
-  {
-    "playerId": 215027,
-    "fullName": "Колуилл",
-    "clubName": "Челси",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 103.0
-  },
-  {
-    "playerId": 215025,
-    "fullName": "Чуквуэмека",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215023,
-    "fullName": "Фофана",
-    "clubName": "Челси",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215020,
-    "fullName": "Йоргенсен",
-    "clubName": "Челси",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215019,
-    "fullName": "Джордж",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 15.0
-  },
-  {
-    "playerId": 215017,
-    "fullName": "Гиу",
-    "clubName": "Сандерленд",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 3.4,
     "fp_last": 0.0
   },
   {
@@ -8760,89 +6330,39 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 215014,
-    "fullName": "Эссугу",
-    "clubName": "Челси",
+    "playerId": 214492,
+    "fullName": "Бенсон",
+    "clubName": "Бернли",
     "position": "MID",
     "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215042,
-    "fullName": "Азну",
-    "clubName": "Эвертон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 12.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215013,
-    "fullName": "Чилуэлл",
-    "clubName": "Челси",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215012,
-    "fullName": "Келлимен",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
+    "price": 5.0,
     "popularity": 0.0,
     "fp_last": 0.0
   },
   {
-    "playerId": 215011,
-    "fullName": "Дисаси",
-    "clubName": "Челси",
+    "playerId": 214468,
+    "fullName": "Байер",
+    "clubName": "Бернли",
     "position": "DEF",
     "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.4,
+    "price": 4.0,
+    "popularity": 1.2,
     "fp_last": 0.0
   },
   {
-    "playerId": 215010,
-    "fullName": "Бадьяшиль",
-    "clubName": "Челси",
-    "position": "DEF",
+    "playerId": 214490,
+    "fullName": "Амдуни",
+    "clubName": "Бернли",
+    "position": "FWD",
     "league": "EPL",
-    "price": 4.5,
+    "price": 5.0,
     "popularity": 0.1,
-    "fp_last": 7.0
-  },
-  {
-    "playerId": 215009,
-    "fullName": "Слонина",
-    "clubName": "Челси",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.3,
     "fp_last": 0.0
   },
   {
-    "playerId": 215008,
-    "fullName": "Мамаду Сарр",
-    "clubName": "Челси",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215007,
-    "fullName": "Гилкрист",
-    "clubName": "Челси",
+    "playerId": 214477,
+    "fullName": "Уоррелл",
+    "clubName": "Бернли",
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
@@ -8850,194 +6370,304 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 215005,
-    "fullName": "Ансельмино",
-    "clubName": "Челси",
-    "position": "DEF",
+    "playerId": 214470,
+    "fullName": "Грин",
+    "clubName": "Бернли",
+    "position": "GK",
     "league": "EPL",
     "price": 4.0,
     "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 214998,
-    "fullName": "Сессеньон",
-    "clubName": "Фулхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.1,
-    "fp_last": 48.0
-  },
-  {
-    "playerId": 214997,
-    "fullName": "Перейра",
-    "clubName": "Фулхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.3,
-    "fp_last": 78.0
-  },
-  {
-    "playerId": 214996,
-    "fullName": "Робинсон",
-    "clubName": "Фулхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 98.0
-  },
-  {
-    "playerId": 215036,
-    "fullName": "Нкунку",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 0.4,
-    "fp_last": 57.0
-  },
-  {
-    "playerId": 215043,
-    "fullName": "Коулмэн",
-    "clubName": "Эвертон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 1.2,
-    "fp_last": 5.0
-  },
-  {
-    "playerId": 214991,
-    "fullName": "Кэрни",
-    "clubName": "Фулхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 33.0
-  },
-  {
-    "playerId": 216509,
-    "fullName": "Артур",
-    "clubName": "Брентфорд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 1.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216521,
-    "fullName": "Хит",
-    "clubName": "Эвертон",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216520,
-    "fullName": "Оньянго",
-    "clubName": "Эвертон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216519,
-    "fullName": "Уолш",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216518,
-    "fullName": "Сэмюэл Рак-Сакьи",
-    "clubName": "Челси",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216517,
-    "fullName": "Антви",
-    "clubName": "Челси",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216516,
-    "fullName": "Масуаку",
-    "clubName": "Сандерленд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216515,
-    "fullName": "Куол",
-    "clubName": "Ньюкасл",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216514,
-    "fullName": "Шахар",
-    "clubName": "Ньюкасл",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216513,
-    "fullName": "Ганн",
-    "clubName": "Ноттингем Форест",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216512,
-    "fullName": "Мердок",
-    "clubName": "Манчестер Юнайтед",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216511,
-    "fullName": "Амасс",
-    "clubName": "Манчестер Юнайтед",
+    "playerId": 214471,
+    "fullName": "Делькруа",
+    "clubName": "Бернли",
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
     "popularity": 0.5,
-    "fp_last": 4.0
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214472,
+    "fullName": "Доджсон",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214473,
+    "fullName": "Пирес",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214474,
+    "fullName": "Самбо",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214476,
+    "fullName": "Туанзебе",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214478,
+    "fullName": "Хамфрис",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214469,
+    "fullName": "Гладки",
+    "clubName": "Бернли",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214480,
+    "fullName": "Адевуми",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 2.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214481,
+    "fullName": "Аджей",
+    "clubName": "Бернли",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214482,
+    "fullName": "Банел",
+    "clubName": "Бернли",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214483,
+    "fullName": "Вайсс",
+    "clubName": "Бернли",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214484,
+    "fullName": "Коннор Робертс",
+    "clubName": "Бернли",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214485,
+    "fullName": "Аарон Рэмзи",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214488,
+    "fullName": "Чурлинов",
+    "clubName": "Бернли",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214535,
+    "fullName": "Семеньо",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 8.2,
+    "fp_last": 175.0
+  },
+  {
+    "playerId": 214531,
+    "fullName": "Тавернье",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.6,
+    "fp_last": 88.0
+  },
+  {
+    "playerId": 214524,
+    "fullName": "Брукс",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 47.0
+  },
+  {
+    "playerId": 214525,
+    "fullName": "Хамед Траоре",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214517,
+    "fullName": "Адамс",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.8,
+    "fp_last": 72.0
+  },
+  {
+    "playerId": 214522,
+    "fullName": "Скотт",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 26.0
+  },
+  {
+    "playerId": 214534,
+    "fullName": "Эванилсон",
+    "clubName": "Борнмут",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 2.1,
+    "fp_last": 113.0
+  },
+  {
+    "playerId": 214520,
+    "fullName": "Петрович",
+    "clubName": "Борнмут",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 3.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214516,
+    "fullName": "Смит",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 57.0
+  },
+  {
+    "playerId": 214523,
+    "fullName": "Трюффер",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216508,
+    "fullName": "Уинтерберн",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 3.0
+  },
+  {
+    "playerId": 214512,
+    "fullName": "Хилл",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 2.2,
+    "fp_last": 18.0
+  },
+  {
+    "playerId": 214514,
+    "fullName": "Крупи",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214515,
+    "fullName": "Силкотт-Дьюберри",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214529,
+    "fullName": "Кук",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.1,
+    "fp_last": 106.0
   },
   {
     "playerId": 216507,
@@ -9047,16 +6677,6 @@
     "league": "EPL",
     "price": 4.5,
     "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215044,
-    "fullName": "Тайрер",
-    "clubName": "Эвертон",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.3,
     "fp_last": 0.0
   },
   {
@@ -9080,704 +6700,354 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 215653,
-    "fullName": "Хато",
-    "clubName": "Челси",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215651,
-    "fullName": "Гессан",
-    "clubName": "Астон Вилла",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215062,
-    "fullName": "Макнил",
-    "clubName": "Эвертон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 0.1,
-    "fp_last": 88.0
-  },
-  {
-    "playerId": 215057,
-    "fullName": "Тарковски",
-    "clubName": "Эвертон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 2.6,
-    "fp_last": 97.0
-  },
-  {
-    "playerId": 215053,
-    "fullName": "Миколенко",
-    "clubName": "Эвертон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.3,
-    "fp_last": 109.0
-  },
-  {
-    "playerId": 215051,
-    "fullName": "Брэнтуэйт",
-    "clubName": "Эвертон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.2,
-    "fp_last": 85.0
-  },
-  {
-    "playerId": 215050,
-    "fullName": "Шермити",
-    "clubName": "Эвертон",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.9,
-    "fp_last": 3.0
-  },
-  {
-    "playerId": 215049,
-    "fullName": "Натан Паттерсон",
-    "clubName": "Эвертон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 14.0
-  },
-  {
-    "playerId": 215046,
-    "fullName": "Армстронг",
-    "clubName": "Эвертон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215045,
-    "fullName": "Трэверс",
-    "clubName": "Эвертон",
+    "playerId": 214507,
+    "fullName": "Маккенна",
+    "clubName": "Борнмут",
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 0.5,
+    "popularity": 0.2,
     "fp_last": 0.0
   },
   {
-    "playerId": 214993,
-    "fullName": "Рид",
-    "clubName": "Фулхэм",
+    "playerId": 214508,
+    "fullName": "Мифем",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214533,
+    "fullName": "Клюйверт",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 0.6,
+    "fp_last": 151.0
+  },
+  {
+    "playerId": 214509,
+    "fullName": "Нето",
+    "clubName": "Борнмут",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214530,
+    "fullName": "Синистерра",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.1,
+    "fp_last": 21.0
+  },
+  {
+    "playerId": 214527,
+    "fullName": "Февр",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214528,
+    "fullName": "Кристи",
+    "clubName": "Борнмут",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 82.0
+  },
+  {
+    "playerId": 214526,
+    "fullName": "Унал",
+    "clubName": "Борнмут",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 28.0
+  },
+  {
+    "playerId": 214510,
+    "fullName": "Полсен",
+    "clubName": "Борнмут",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214511,
+    "fullName": "Солер",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214506,
+    "fullName": "Уилл Деннис",
+    "clubName": "Борнмут",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214521,
+    "fullName": "Сенеси",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.6,
+    "fp_last": 28.0
+  },
+  {
+    "playerId": 214513,
+    "fullName": "Араухо",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 12.0
+  },
+  {
+    "playerId": 214519,
+    "fullName": "Забарный",
+    "clubName": "Борнмут",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.0,
+    "fp_last": 86.0
+  },
+  {
+    "playerId": 214518,
+    "fullName": "Биллинг",
+    "clubName": "Борнмут",
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1,
+    "popularity": 0.3,
     "fp_last": 10.0
   },
   {
-    "playerId": 214989,
-    "fullName": "Берге",
-    "clubName": "Фулхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 67.0
-  },
-  {
-    "playerId": 214899,
-    "fullName": "Алесе",
-    "clubName": "Сандерленд",
+    "playerId": 214505,
+    "fullName": "Акинмбони",
+    "clubName": "Борнмут",
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
-    "popularity": 1.2,
+    "popularity": 4.8,
     "fp_last": 0.0
   },
   {
-    "playerId": 214914,
-    "fullName": "Браун",
-    "clubName": "Сандерленд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214934,
-    "fullName": "Патрик Робертс",
-    "clubName": "Сандерленд",
+    "playerId": 214560,
+    "fullName": "Мэттью О`Райли",
+    "clubName": "Брайтон",
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
+    "popularity": 2.4,
+    "fp_last": 49.0
   },
   {
-    "playerId": 214929,
-    "fullName": "Нил",
-    "clubName": "Сандерленд",
+    "playerId": 214568,
+    "fullName": "Рюттер",
+    "clubName": "Брайтон",
     "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 4.6,
+    "fp_last": 88.0
+  },
+  {
+    "playerId": 214564,
+    "fullName": "Балеба",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 3.0,
+    "fp_last": 95.0
+  },
+  {
+    "playerId": 214556,
+    "fullName": "Айяри",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.6,
+    "fp_last": 80.0
+  },
+  {
+    "playerId": 214567,
+    "fullName": "Минте",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 1.7,
+    "fp_last": 94.0
+  },
+  {
+    "playerId": 214558,
+    "fullName": "Виффер",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 214552,
+    "fullName": "Данк",
+    "clubName": "Брайтон",
+    "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
+    "popularity": 1.5,
+    "fp_last": 43.0
   },
   {
-    "playerId": 214928,
-    "fullName": "Мандл",
-    "clubName": "Сандерленд",
-    "position": "MID",
+    "playerId": 214549,
+    "fullName": "ван Хекке",
+    "clubName": "Брайтон",
+    "position": "DEF",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
+    "popularity": 2.7,
+    "fp_last": 80.0
   },
   {
-    "playerId": 214926,
-    "fullName": "Эква",
-    "clubName": "Сандерленд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214924,
-    "fullName": "Серкин",
-    "clubName": "Сандерленд",
+    "playerId": 214559,
+    "fullName": "де Кейпер",
+    "clubName": "Брайтон",
     "position": "DEF",
     "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
+    "price": 5.5,
+    "popularity": 5.5,
     "fp_last": 0.0
   },
   {
-    "playerId": 214921,
-    "fullName": "Русин",
-    "clubName": "Сандерленд",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214920,
-    "fullName": "Поведа",
-    "clubName": "Сандерленд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214919,
-    "fullName": "О`Нин",
-    "clubName": "Сандерленд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214918,
-    "fullName": "Матете",
-    "clubName": "Сандерленд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214917,
-    "fullName": "Луиш Семеду",
-    "clubName": "Сандерленд",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214916,
-    "fullName": "Харрисон Джонс",
-    "clubName": "Сандерленд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214913,
-    "fullName": "Ба",
-    "clubName": "Сандерленд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214939,
-    "fullName": "Кассанова",
-    "clubName": "Тоттенхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214912,
-    "fullName": "Алексич",
-    "clubName": "Сандерленд",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214911,
-    "fullName": "Абдуллахи",
-    "clubName": "Сандерленд",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 6.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214910,
-    "fullName": "Хьельде",
-    "clubName": "Сандерленд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214909,
-    "fullName": "Хаггинс",
-    "clubName": "Сандерленд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214908,
-    "fullName": "Триантис",
-    "clubName": "Сандерленд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214905,
-    "fullName": "Пэттерсон",
-    "clubName": "Сандерленд",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 1.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214904,
-    "fullName": "Пембеле",
-    "clubName": "Сандерленд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214903,
-    "fullName": "Нуке",
-    "clubName": "Сандерленд",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214902,
-    "fullName": "Саймон Мур",
-    "clubName": "Сандерленд",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214901,
-    "fullName": "Зак Джонсон",
-    "clubName": "Сандерленд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214900,
-    "fullName": "Джозеф Андерсон",
-    "clubName": "Сандерленд",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 4.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214938,
-    "fullName": "Вушкович",
-    "clubName": "Тоттенхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214940,
-    "fullName": "Остин",
-    "clubName": "Тоттенхэм",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 214986,
-    "fullName": "Харрис",
-    "clubName": "Фулхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214956,
-    "fullName": "Эшкрофт",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214984,
-    "fullName": "Диоп",
-    "clubName": "Фулхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 33.0
-  },
-  {
-    "playerId": 214983,
-    "fullName": "Годо",
-    "clubName": "Фулхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 214982,
-    "fullName": "Лекомт",
-    "clubName": "Фулхэм",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214979,
-    "fullName": "Мэддисон",
-    "clubName": "Тоттенхэм",
+    "playerId": 214570,
+    "fullName": "Митома",
+    "clubName": "Брайтон",
     "position": "MID",
     "league": "EPL",
     "price": 7.5,
-    "popularity": 0.0,
-    "fp_last": 116.0
+    "popularity": 4.5,
+    "fp_last": 144.0
   },
   {
-    "playerId": 214978,
-    "fullName": "Кулусевски",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
+    "playerId": 214551,
+    "fullName": "Вербрюгген",
+    "clubName": "Брайтон",
+    "position": "GK",
     "league": "EPL",
-    "price": 7.5,
-    "popularity": 0.1,
-    "fp_last": 130.0
+    "price": 5.0,
+    "popularity": 6.6,
+    "fp_last": 97.0
   },
   {
-    "playerId": 214971,
-    "fullName": "Хиль",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214970,
-    "fullName": "Удоджи",
-    "clubName": "Тоттенхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 45.0
-  },
-  {
-    "playerId": 214969,
-    "fullName": "Соломон",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214960,
-    "fullName": "Мин Хек",
-    "clubName": "Тоттенхэм",
+    "playerId": 214554,
+    "fullName": "Милнер",
+    "clubName": "Брайтон",
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214959,
-    "fullName": "Данзо",
-    "clubName": "Тоттенхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.9,
-    "fp_last": 16.0
-  },
-  {
-    "playerId": 214957,
-    "fullName": "Биссума",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.9,
-    "fp_last": 50.0
-  },
-  {
-    "playerId": 214954,
-    "fullName": "Уильямс-Барнетт",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214941,
-    "fullName": "Такаи",
-    "clubName": "Тоттенхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214953,
-    "fullName": "Скарлетт",
-    "clubName": "Тоттенхэм",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
     "popularity": 0.4,
     "fp_last": 6.0
   },
   {
-    "playerId": 214952,
-    "fullName": "Рассел-Дэнни",
-    "clubName": "Тоттенхэм",
+    "playerId": 214565,
+    "fullName": "Груда",
+    "clubName": "Брайтон",
     "position": "MID",
     "league": "EPL",
-    "price": 4.5,
+    "price": 6.0,
     "popularity": 0.1,
-    "fp_last": 0.0
+    "fp_last": 44.0
   },
   {
-    "playerId": 214951,
-    "fullName": "Олусеси",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214950,
-    "fullName": "Майки Мур",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214949,
-    "fullName": "Лэнкшир",
-    "clubName": "Тоттенхэм",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 214948,
-    "fullName": "Кьерематен",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214947,
-    "fullName": "Кински",
-    "clubName": "Тоттенхэм",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 17.0
-  },
-  {
-    "playerId": 214946,
-    "fullName": "Дэвис",
-    "clubName": "Тоттенхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214945,
-    "fullName": "Дрэгушин",
-    "clubName": "Тоттенхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 24.0
-  },
-  {
-    "playerId": 214944,
-    "fullName": "Донли",
-    "clubName": "Тоттенхэм",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214943,
-    "fullName": "Дивайн",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214942,
-    "fullName": "Эбботт",
-    "clubName": "Тоттенхэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214955,
-    "fullName": "Тайрис Холл",
-    "clubName": "Тоттенхэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214745,
-    "fullName": "Гелхардт",
-    "clubName": "Лидс",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 2.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214833,
-    "fullName": "Хейлунд",
-    "clubName": "Манчестер Юнайтед",
+    "playerId": 214569,
+    "fullName": "Уэлбек",
+    "clubName": "Брайтон",
     "position": "FWD",
     "league": "EPL",
     "price": 7.0,
-    "popularity": 0.6,
-    "fp_last": 76.0
+    "popularity": 2.0,
+    "fp_last": 112.0
+  },
+  {
+    "playerId": 214561,
+    "fullName": "Хиншелвуд",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 90.0
+  },
+  {
+    "playerId": 214563,
+    "fullName": "Энсисо",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214566,
+    "fullName": "Марч",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 7.0
+  },
+  {
+    "playerId": 214557,
+    "fullName": "Буонанотте",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214562,
+    "fullName": "Цимас",
+    "clubName": "Брайтон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
   },
   {
     "playerId": 214536,
@@ -9788,6 +7058,36 @@
     "price": 4.0,
     "popularity": 1.2,
     "fp_last": 18.0
+  },
+  {
+    "playerId": 214555,
+    "fullName": "Сима",
+    "clubName": "Брайтон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214537,
+    "fullName": "Макгилл",
+    "clubName": "Брайтон",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214550,
+    "fullName": "Велтман",
+    "clubName": "Брайтон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.8,
+    "fp_last": 52.0
   },
   {
     "playerId": 214548,
@@ -9900,26 +7200,6 @@
     "fp_last": 8.0
   },
   {
-    "playerId": 214537,
-    "fullName": "Макгилл",
-    "clubName": "Брайтон",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214533,
-    "fullName": "Клюйверт",
-    "clubName": "Борнмут",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 0.6,
-    "fp_last": 151.0
-  },
-  {
     "playerId": 214553,
     "fullName": "Костулас",
     "clubName": "Брайтон",
@@ -9930,254 +7210,144 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 214532,
-    "fullName": "Уаттара",
+    "playerId": 214599,
+    "fullName": "Игор Тиаго",
+    "clubName": "Брентфорд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 1.7,
+    "fp_last": 9.0
+  },
+  {
+    "playerId": 214594,
+    "fullName": "Ярмолюк",
     "clubName": "Брентфорд",
     "position": "MID",
     "league": "EPL",
-    "price": 7.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214530,
-    "fullName": "Синистерра",
-    "clubName": "Борнмут",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.1,
-    "fp_last": 21.0
-  },
-  {
-    "playerId": 214529,
-    "fullName": "Кук",
-    "clubName": "Борнмут",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.1,
-    "fp_last": 106.0
-  },
-  {
-    "playerId": 214528,
-    "fullName": "Кристи",
-    "clubName": "Борнмут",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 82.0
-  },
-  {
-    "playerId": 214527,
-    "fullName": "Февр",
-    "clubName": "Борнмут",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214526,
-    "fullName": "Унал",
-    "clubName": "Борнмут",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 28.0
-  },
-  {
-    "playerId": 214521,
-    "fullName": "Сенеси",
-    "clubName": "Борнмут",
-    "position": "DEF",
-    "league": "EPL",
     "price": 5.0,
-    "popularity": 0.6,
-    "fp_last": 28.0
+    "popularity": 0.5,
+    "fp_last": 49.0
   },
   {
-    "playerId": 214519,
-    "fullName": "Забарный",
-    "clubName": "Борнмут",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.0,
-    "fp_last": 86.0
-  },
-  {
-    "playerId": 214518,
-    "fullName": "Биллинг",
-    "clubName": "Борнмут",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 10.0
-  },
-  {
-    "playerId": 214515,
-    "fullName": "Силкотт-Дьюберри",
-    "clubName": "Борнмут",
+    "playerId": 214582,
+    "fullName": "Оньека",
+    "clubName": "Брентфорд",
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1,
+    "popularity": 0.4,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 214598,
+    "fullName": "Карвалью",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.2,
+    "fp_last": 34.0
+  },
+  {
+    "playerId": 214601,
+    "fullName": "Шаде",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 0.3,
+    "fp_last": 140.0
+  },
+  {
+    "playerId": 214593,
+    "fullName": "Джордан Хендерсон",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.9,
     "fp_last": 0.0
   },
   {
-    "playerId": 214513,
-    "fullName": "Араухо",
-    "clubName": "Борнмут",
+    "playerId": 214577,
+    "fullName": "ван ден Берг",
+    "clubName": "Брентфорд",
     "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 12.0
-  },
-  {
-    "playerId": 214511,
-    "fullName": "Солер",
-    "clubName": "Борнмут",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214510,
-    "fullName": "Полсен",
-    "clubName": "Борнмут",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214550,
-    "fullName": "Велтман",
-    "clubName": "Брайтон",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
     "popularity": 0.8,
-    "fp_last": 52.0
+    "fp_last": 65.0
   },
   {
-    "playerId": 214555,
-    "fullName": "Сима",
-    "clubName": "Брайтон",
+    "playerId": 214589,
+    "fullName": "Йенсен",
+    "clubName": "Брентфорд",
     "position": "MID",
     "league": "EPL",
     "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
+    "popularity": 0.2,
+    "fp_last": 39.0
   },
   {
-    "playerId": 214508,
-    "fullName": "Мифем",
-    "clubName": "Борнмут",
+    "playerId": 214587,
+    "fullName": "Хенри",
+    "clubName": "Брентфорд",
     "position": "DEF",
     "league": "EPL",
-    "price": 4.0,
+    "price": 4.5,
     "popularity": 0.2,
-    "fp_last": 0.0
+    "fp_last": 4.0
   },
   {
-    "playerId": 214584,
-    "fullName": "Пирт-Харрис",
+    "playerId": 214591,
+    "fullName": "Коллинз",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.8,
+    "fp_last": 108.0
+  },
+  {
+    "playerId": 214579,
+    "fullName": "Кайоде",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.0,
+    "fp_last": 26.0
+  },
+  {
+    "playerId": 214595,
+    "fullName": "Льюис-Поттер",
+    "clubName": "Брентфорд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 116.0
+  },
+  {
+    "playerId": 214596,
+    "fullName": "Миламбо",
     "clubName": "Брентфорд",
     "position": "MID",
     "league": "EPL",
-    "price": 4.5,
+    "price": 5.5,
     "popularity": 0.1,
     "fp_last": 0.0
   },
   {
-    "playerId": 214610,
-    "fullName": "Каммингс",
-    "clubName": "Вест Хэм",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214607,
-    "fullName": "Хедьи",
-    "clubName": "Вест Хэм",
+    "playerId": 214590,
+    "fullName": "Келлехер",
+    "clubName": "Брентфорд",
     "position": "GK",
     "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.5,
+    "price": 5.0,
+    "popularity": 4.6,
     "fp_last": 0.0
-  },
-  {
-    "playerId": 214606,
-    "fullName": "Фодерингэм",
-    "clubName": "Вест Хэм",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214605,
-    "fullName": "Скарлз",
-    "clubName": "Вест Хэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 27.0
-  },
-  {
-    "playerId": 214604,
-    "fullName": "Клейтон",
-    "clubName": "Вест Хэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214603,
-    "fullName": "Кейси",
-    "clubName": "Вест Хэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 214602,
-    "fullName": "Висса",
-    "clubName": "Брентфорд",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 8.0,
-    "popularity": 1.6,
-    "fp_last": 199.0
-  },
-  {
-    "playerId": 214600,
-    "fullName": "Дамсгор",
-    "clubName": "Брентфорд",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 0.5,
-    "fp_last": 129.0
   },
   {
     "playerId": 214597,
@@ -10190,6 +7360,16 @@
     "fp_last": 85.0
   },
   {
+    "playerId": 214600,
+    "fullName": "Дамсгор",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.5,
+    "fp_last": 129.0
+  },
+  {
     "playerId": 214592,
     "fullName": "Нунес",
     "clubName": "Брентфорд",
@@ -10200,6 +7380,26 @@
     "fp_last": 3.0
   },
   {
+    "playerId": 214602,
+    "fullName": "Висса",
+    "clubName": "Брентфорд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 1.6,
+    "fp_last": 199.0
+  },
+  {
+    "playerId": 214532,
+    "fullName": "Уаттара",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
     "playerId": 214588,
     "fullName": "Хики",
     "clubName": "Брентфорд",
@@ -10207,6 +7407,16 @@
     "league": "EPL",
     "price": 4.5,
     "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214571,
+    "fullName": "Балкомб",
+    "clubName": "Брентфорд",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 3.2,
     "fp_last": 0.0
   },
   {
@@ -10230,6 +7440,16 @@
     "fp_last": 36.0
   },
   {
+    "playerId": 214584,
+    "fullName": "Пирт-Харрис",
+    "clubName": "Брентфорд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
     "playerId": 214583,
     "fullName": "Пиннок",
     "clubName": "Брентфорд",
@@ -10238,16 +7458,6 @@
     "price": 4.5,
     "popularity": 0.1,
     "fp_last": 49.0
-  },
-  {
-    "playerId": 214557,
-    "fullName": "Буонанотте",
-    "clubName": "Брайтон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
   },
   {
     "playerId": 214581,
@@ -10330,639 +7540,9 @@
     "fp_last": 2.0
   },
   {
-    "playerId": 214571,
-    "fullName": "Балкомб",
+    "playerId": 216509,
+    "fullName": "Артур",
     "clubName": "Брентфорд",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 3.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214566,
-    "fullName": "Марч",
-    "clubName": "Брайтон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 7.0
-  },
-  {
-    "playerId": 214563,
-    "fullName": "Энсисо",
-    "clubName": "Брайтон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214562,
-    "fullName": "Цимас",
-    "clubName": "Брайтон",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214561,
-    "fullName": "Хиншелвуд",
-    "clubName": "Брайтон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 90.0
-  },
-  {
-    "playerId": 214509,
-    "fullName": "Нето",
-    "clubName": "Борнмут",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214507,
-    "fullName": "Маккенна",
-    "clubName": "Борнмут",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214612,
-    "fullName": "Келли",
-    "clubName": "Вест Хэм",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214426,
-    "fullName": "Нванери",
-    "clubName": "Арсенал",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.3,
-    "fp_last": 63.0
-  },
-  {
-    "playerId": 214449,
-    "fullName": "Баркли",
-    "clubName": "Астон Вилла",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 41.0
-  },
-  {
-    "playerId": 214448,
-    "fullName": "Морено",
-    "clubName": "Астон Вилла",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214446,
-    "fullName": "Доббин",
-    "clubName": "Астон Вилла",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214445,
-    "fullName": "Джимо-Алоба",
-    "clubName": "Астон Вилла",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214444,
-    "fullName": "Богарде",
-    "clubName": "Астон Вилла",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 214442,
-    "fullName": "Райт",
-    "clubName": "Астон Вилла",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214441,
-    "fullName": "Трэвис Паттерсон",
-    "clubName": "Астон Вилла",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214440,
-    "fullName": "Филип Маршалл",
-    "clubName": "Астон Вилла",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214439,
-    "fullName": "Госи",
-    "clubName": "Астон Вилла",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214438,
-    "fullName": "Гарсия",
-    "clubName": "Астон Вилла",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 9.0
-  },
-  {
-    "playerId": 214432,
-    "fullName": "Троссард",
-    "clubName": "Арсенал",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.5,
-    "popularity": 0.6,
-    "fp_last": 146.0
-  },
-  {
-    "playerId": 214427,
-    "fullName": "Нергор",
-    "clubName": "Арсенал",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214425,
-    "fullName": "Габриэл Жезус",
-    "clubName": "Арсенал",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.1,
-    "fp_last": 33.0
-  },
-  {
-    "playerId": 214451,
-    "fullName": "Илинг-Джуниор",
-    "clubName": "Астон Вилла",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214423,
-    "fullName": "Тимбер",
-    "clubName": "Арсенал",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.9,
-    "fp_last": 105.0
-  },
-  {
-    "playerId": 214419,
-    "fullName": "Фабиу Виейра",
-    "clubName": "Арсенал",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214418,
-    "fullName": "Льюис-Скелли",
-    "clubName": "Арсенал",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 4.2,
-    "fp_last": 44.0
-  },
-  {
-    "playerId": 214417,
-    "fullName": "Кивер",
-    "clubName": "Арсенал",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 41.0
-  },
-  {
-    "playerId": 214415,
-    "fullName": "Аррисабалага",
-    "clubName": "Арсенал",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214414,
-    "fullName": "Нелсон",
-    "clubName": "Арсенал",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214413,
-    "fullName": "Кристиан Москера",
-    "clubName": "Арсенал",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214412,
-    "fullName": "Зинченко",
-    "clubName": "Арсенал",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 38.0
-  },
-  {
-    "playerId": 214411,
-    "fullName": "Локонга",
-    "clubName": "Арсенал",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214410,
-    "fullName": "Кабиа",
-    "clubName": "Арсенал",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214409,
-    "fullName": "Хейн",
-    "clubName": "Арсенал",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214408,
-    "fullName": "Сетфорд",
-    "clubName": "Арсенал",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214407,
-    "fullName": "Рохас Федорущенко",
-    "clubName": "Арсенал",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214450,
-    "fullName": "Дендонкер",
-    "clubName": "Астон Вилла",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214454,
-    "fullName": "Матсен",
-    "clubName": "Астон Вилла",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.1,
-    "fp_last": 57.0
-  },
-  {
-    "playerId": 214506,
-    "fullName": "Уилл Деннис",
-    "clubName": "Борнмут",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214480,
-    "fullName": "Адевуми",
-    "clubName": "Бернли",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 2.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214505,
-    "fullName": "Акинмбони",
-    "clubName": "Борнмут",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 4.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214499,
-    "fullName": "Обафеми",
-    "clubName": "Бернли",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214498,
-    "fullName": "Ндайишимийе",
-    "clubName": "Бернли",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214495,
-    "fullName": "Колиошо",
-    "clubName": "Бернли",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214492,
-    "fullName": "Бенсон",
-    "clubName": "Бернли",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214491,
-    "fullName": "Эшли Барнс",
-    "clubName": "Бернли",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214490,
-    "fullName": "Амдуни",
-    "clubName": "Бернли",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214488,
-    "fullName": "Чурлинов",
-    "clubName": "Бернли",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214485,
-    "fullName": "Аарон Рэмзи",
-    "clubName": "Бернли",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214484,
-    "fullName": "Коннор Робертс",
-    "clubName": "Бернли",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214483,
-    "fullName": "Вайсс",
-    "clubName": "Бернли",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214482,
-    "fullName": "Банел",
-    "clubName": "Бернли",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214481,
-    "fullName": "Аджей",
-    "clubName": "Бернли",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214478,
-    "fullName": "Хамфрис",
-    "clubName": "Бернли",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214455,
-    "fullName": "Пау Торрес",
-    "clubName": "Астон Вилла",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 214477,
-    "fullName": "Уоррелл",
-    "clubName": "Бернли",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214476,
-    "fullName": "Туанзебе",
-    "clubName": "Бернли",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214474,
-    "fullName": "Самбо",
-    "clubName": "Бернли",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214473,
-    "fullName": "Пирес",
-    "clubName": "Бернли",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214472,
-    "fullName": "Доджсон",
-    "clubName": "Бернли",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214471,
-    "fullName": "Делькруа",
-    "clubName": "Бернли",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214470,
-    "fullName": "Грин",
-    "clubName": "Бернли",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214469,
-    "fullName": "Гладки",
-    "clubName": "Бернли",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214468,
-    "fullName": "Байер",
-    "clubName": "Бернли",
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
@@ -10970,53 +7550,263 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 214462,
-    "fullName": "Бэйли",
-    "clubName": "Астон Вилла",
-    "position": "MID",
+    "playerId": 214635,
+    "fullName": "Боуэн",
+    "clubName": "Вест Хэм",
+    "position": "FWD",
     "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.5,
-    "fp_last": 49.0
+    "price": 8.5,
+    "popularity": 5.9,
+    "fp_last": 191.0
   },
   {
-    "playerId": 214461,
-    "fullName": "Джейкоб Рэмзи",
-    "clubName": "Ньюкасл",
+    "playerId": 214634,
+    "fullName": "Лукас Пакета",
+    "clubName": "Вест Хэм",
     "position": "MID",
     "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.4,
+    "price": 7.0,
+    "popularity": 3.7,
+    "fp_last": 88.0
+  },
+  {
+    "playerId": 214628,
+    "fullName": "Уан-Биссака",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 5.3,
+    "fp_last": 102.0
+  },
+  {
+    "playerId": 214633,
+    "fullName": "Фюллькруг",
+    "clubName": "Вест Хэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 4.2,
+    "fp_last": 40.0
+  },
+  {
+    "playerId": 214626,
+    "fullName": "Родригес",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 39.0
+  },
+  {
+    "playerId": 214623,
+    "fullName": "Диуф",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 3.8,
     "fp_last": 0.0
   },
   {
-    "playerId": 214459,
-    "fullName": "Буэндиа",
-    "clubName": "Астон Вилла",
+    "playerId": 214630,
+    "fullName": "Уорд-Проуз",
+    "clubName": "Вест Хэм",
     "position": "MID",
     "league": "EPL",
     "price": 6.0,
-    "popularity": 0.5,
-    "fp_last": 11.0
+    "popularity": 1.0,
+    "fp_last": 57.0
   },
   {
-    "playerId": 214458,
-    "fullName": "Эмилиано Мартинес",
-    "clubName": "Астон Вилла",
+    "playerId": 214608,
+    "fullName": "Агерд",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214632,
+    "fullName": "Соучек",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.9,
+    "fp_last": 130.0
+  },
+  {
+    "playerId": 214629,
+    "fullName": "Каллум Уилсон",
+    "clubName": "Вест Хэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214609,
+    "fullName": "Ирвинг",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 9.0
+  },
+  {
+    "playerId": 214617,
+    "fullName": "Тодибо",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.2,
+    "fp_last": 53.0
+  },
+  {
+    "playerId": 216510,
+    "fullName": "Хермансен",
+    "clubName": "Вест Хэм",
     "position": "GK",
     "league": "EPL",
-    "price": 5.5,
-    "popularity": 2.3,
-    "fp_last": 106.0
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
-    "playerId": 214611,
-    "fullName": "Канте",
+    "playerId": 214631,
+    "fullName": "Саммервилл",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.0,
+    "fp_last": 32.0
+  },
+  {
+    "playerId": 214622,
+    "fullName": "Гильерме",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 12.0
+  },
+  {
+    "playerId": 214627,
+    "fullName": "Альварес",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214625,
+    "fullName": "Корне",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214624,
+    "fullName": "Килмен",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 77.0
+  },
+  {
+    "playerId": 214603,
+    "fullName": "Кейси",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 214621,
+    "fullName": "Ареоля",
+    "clubName": "Вест Хэм",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.1,
+    "fp_last": 70.0
+  },
+  {
+    "playerId": 214604,
+    "fullName": "Клейтон",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214619,
+    "fullName": "Эмерсон",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 72.0
+  },
+  {
+    "playerId": 214618,
+    "fullName": "Уокер-Питерс",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214616,
+    "fullName": "Поттс",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214615,
+    "fullName": "Орфорд",
     "clubName": "Вест Хэм",
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
     "popularity": 0.1,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 214614,
+    "fullName": "Каллум Маршалл",
+    "clubName": "Вест Хэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.8,
     "fp_last": 0.0
   },
   {
@@ -11030,79 +7820,39 @@
     "fp_last": 42.0
   },
   {
-    "playerId": 214832,
-    "fullName": "Гарначо",
-    "clubName": "Манчестер Юнайтед",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 0.4,
-    "fp_last": 107.0
-  },
-  {
-    "playerId": 214747,
-    "fullName": "Харри Грэй",
-    "clubName": "Лидс",
+    "playerId": 214612,
+    "fullName": "Келли",
+    "clubName": "Вест Хэм",
     "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214774,
-    "fullName": "Аке",
-    "clubName": "Манчестер Сити",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.9,
-    "fp_last": 25.0
-  },
-  {
-    "playerId": 214772,
-    "fullName": "Рейс",
-    "clubName": "Манчестер Сити",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 214771,
-    "fullName": "Нюпан",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
     "league": "EPL",
     "price": 4.5,
     "popularity": 0.2,
     "fp_last": 0.0
   },
   {
-    "playerId": 214770,
-    "fullName": "Уилсон-Эсбранд",
-    "clubName": "Манчестер Сити",
-    "position": "DEF",
+    "playerId": 214611,
+    "fullName": "Канте",
+    "clubName": "Вест Хэм",
+    "position": "MID",
     "league": "EPL",
-    "price": 4.0,
+    "price": 4.5,
     "popularity": 0.1,
     "fp_last": 0.0
   },
   {
-    "playerId": 214769,
-    "fullName": "Каборе",
-    "clubName": "Манчестер Сити",
-    "position": "DEF",
+    "playerId": 214610,
+    "fullName": "Каммингс",
+    "clubName": "Вест Хэм",
+    "position": "FWD",
     "league": "EPL",
-    "price": 4.0,
+    "price": 4.5,
     "popularity": 0.3,
     "fp_last": 0.0
   },
   {
-    "playerId": 214768,
-    "fullName": "Беттинелли",
-    "clubName": "Манчестер Сити",
+    "playerId": 214607,
+    "fullName": "Хедьи",
+    "clubName": "Вест Хэм",
     "position": "GK",
     "league": "EPL",
     "price": 4.0,
@@ -11110,604 +7860,174 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 214759,
-    "fullName": "Матео Фернандес",
-    "clubName": "Лидс",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214757,
-    "fullName": "Рамазани",
-    "clubName": "Лидс",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214755,
-    "fullName": "Бэмфорд",
-    "clubName": "Лидс",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 1.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214754,
-    "fullName": "Чамберс",
-    "clubName": "Лидс",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214750,
-    "fullName": "Крю",
-    "clubName": "Лидс",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214749,
-    "fullName": "Джаби",
-    "clubName": "Лидс",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214746,
-    "fullName": "Гринвуд",
-    "clubName": "Лидс",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214776,
-    "fullName": "Ортега",
-    "clubName": "Манчестер Сити",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 35.0
-  },
-  {
-    "playerId": 214406,
-    "fullName": "Николс",
-    "clubName": "Арсенал",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214743,
-    "fullName": "Бийол",
-    "clubName": "Лидс",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214741,
-    "fullName": "Шмидт",
-    "clubName": "Лидс",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214740,
-    "fullName": "Мелье",
-    "clubName": "Лидс",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 2.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214739,
-    "fullName": "Кэрнс",
-    "clubName": "Лидс",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214738,
-    "fullName": "Дарлоу",
-    "clubName": "Лидс",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 5.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214737,
-    "fullName": "Борнаув",
-    "clubName": "Лидс",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 1.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214736,
-    "fullName": "Байрэм",
-    "clubName": "Лидс",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 2.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214729,
-    "fullName": "Нуньес",
-    "clubName": "Ливерпуль",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 1.1,
-    "fp_last": 61.0
-  },
-  {
-    "playerId": 214728,
-    "fullName": "Гравенберх",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.8,
-    "fp_last": 118.0
-  },
-  {
-    "playerId": 214727,
-    "fullName": "Эллиот",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.2,
-    "fp_last": 31.0
-  },
-  {
-    "playerId": 214718,
-    "fullName": "Робертсон",
-    "clubName": "Ливерпуль",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.9,
-    "fp_last": 90.0
-  },
-  {
-    "playerId": 214717,
-    "fullName": "Мамардашвили",
-    "clubName": "Ливерпуль",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214775,
-    "fullName": "Нико О`Райли",
-    "clubName": "Манчестер Сити",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 31.0
-  },
-  {
-    "playerId": 214779,
-    "fullName": "Филлипс",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214715,
-    "fullName": "Цимикас",
-    "clubName": "Ливерпуль",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 45.0
-  },
-  {
-    "playerId": 214809,
-    "fullName": "Хитон",
-    "clubName": "Манчестер Юнайтед",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214831,
-    "fullName": "Санчо",
-    "clubName": "Манчестер Юнайтед",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214829,
-    "fullName": "Майну",
-    "clubName": "Манчестер Юнайтед",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 50.0
-  },
-  {
-    "playerId": 214827,
-    "fullName": "Зиркзе",
-    "clubName": "Манчестер Юнайтед",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 1.0,
-    "fp_last": 61.0
-  },
-  {
-    "playerId": 214826,
-    "fullName": "Антони",
-    "clubName": "Манчестер Юнайтед",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.4,
-    "fp_last": 8.0
-  },
-  {
-    "playerId": 214824,
-    "fullName": "Андре Онана",
-    "clubName": "Манчестер Юнайтед",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 1.0,
-    "fp_last": 112.0
-  },
-  {
-    "playerId": 214821,
-    "fullName": "Лисандро Мартинес",
-    "clubName": "Манчестер Юнайтед",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 63.0
-  },
-  {
-    "playerId": 214820,
-    "fullName": "Мазрауи",
-    "clubName": "Манчестер Юнайтед",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 83.0
-  },
-  {
-    "playerId": 214815,
-    "fullName": "Флетчер",
-    "clubName": "Манчестер Юнайтед",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214814,
-    "fullName": "Уитли",
-    "clubName": "Манчестер Юнайтед",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214813,
-    "fullName": "Оби-Мартин",
-    "clubName": "Манчестер Юнайтед",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214812,
-    "fullName": "Мантато",
-    "clubName": "Манчестер Юнайтед",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214811,
-    "fullName": "Коне",
-    "clubName": "Манчестер Юнайтед",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214810,
-    "fullName": "Коллиер",
-    "clubName": "Манчестер Юнайтед",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 214808,
-    "fullName": "Хевен",
-    "clubName": "Манчестер Юнайтед",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.9,
-    "fp_last": 8.0
-  },
-  {
-    "playerId": 214780,
-    "fullName": "Эчеверри",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 214807,
-    "fullName": "Фредриксон",
-    "clubName": "Манчестер Юнайтед",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214806,
-    "fullName": "Ми",
-    "clubName": "Манчестер Юнайтед",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214805,
-    "fullName": "Маласиа",
-    "clubName": "Манчестер Юнайтед",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 214804,
-    "fullName": "Леон",
-    "clubName": "Манчестер Юнайтед",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214801,
-    "fullName": "Фоден",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
-    "league": "EPL",
-    "price": 9.0,
-    "popularity": 2.0,
-    "fp_last": 102.0
-  },
-  {
-    "playerId": 214797,
-    "fullName": "Савио",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 0.4,
-    "fp_last": 93.0
-  },
-  {
-    "playerId": 214796,
-    "fullName": "Родри Эрнандес",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 0.4,
-    "fp_last": 3.0
-  },
-  {
-    "playerId": 214794,
-    "fullName": "Гюндоган",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
-    "league": "EPL",
-    "price": 7.0,
-    "popularity": 0.4,
-    "fp_last": 102.0
-  },
-  {
-    "playerId": 214792,
-    "fullName": "Эдерсон",
-    "clubName": "Манчестер Сити",
-    "position": "GK",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 2.4,
-    "fp_last": 102.0
-  },
-  {
-    "playerId": 214788,
-    "fullName": "Ковачич",
-    "clubName": "Манчестер Сити",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.1,
-    "fp_last": 106.0
-  },
-  {
-    "playerId": 214786,
-    "fullName": "Гвардиол",
-    "clubName": "Манчестер Сити",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 11.2,
-    "fp_last": 138.0
-  },
-  {
-    "playerId": 214783,
-    "fullName": "Макати",
-    "clubName": "Ноттингем Форест",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214781,
-    "fullName": "Аканджи",
-    "clubName": "Манчестер Сити",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 60.0
-  },
-  {
-    "playerId": 214716,
-    "fullName": "Брэдли",
-    "clubName": "Ливерпуль",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 38.0
-  },
-  {
-    "playerId": 214714,
-    "fullName": "Нгумоа",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214614,
-    "fullName": "Каллум Маршалл",
+    "playerId": 214606,
+    "fullName": "Фодерингэм",
     "clubName": "Вест Хэм",
-    "position": "FWD",
+    "position": "GK",
     "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.8,
+    "price": 4.0,
+    "popularity": 0.4,
     "fp_last": 0.0
   },
   {
-    "playerId": 214640,
-    "fullName": "Ерсон Москера",
+    "playerId": 214605,
+    "fullName": "Скарлз",
+    "clubName": "Вест Хэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 27.0
+  },
+  {
+    "playerId": 214620,
+    "fullName": "Эрти",
+    "clubName": "Вест Хэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214655,
+    "fullName": "Андре",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 73.0
+  },
+  {
+    "playerId": 214658,
+    "fullName": "Мунеци",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.1,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 214661,
+    "fullName": "Жоао Гомес",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.3,
+    "fp_last": 101.0
+  },
+  {
+    "playerId": 214663,
+    "fullName": "Ларсен",
+    "clubName": "Вулверхэмптон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 1.9,
+    "fp_last": 139.0
+  },
+  {
+    "playerId": 214657,
+    "fullName": "Белльгард",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.2,
+    "fp_last": 86.0
+  },
+  {
+    "playerId": 214654,
+    "fullName": "Фер Лопес",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214662,
+    "fullName": "Хван Хи Чхан",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.3,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 214660,
+    "fullName": "Арьяс",
+    "clubName": "Вулверхэмптон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214643,
+    "fullName": "Родригу Гомеш",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 41.0
+  },
+  {
+    "playerId": 214644,
+    "fullName": "Тоте Гомеш",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 71.0
+  },
+  {
+    "playerId": 214647,
+    "fullName": "Доэрти",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 73.0
+  },
+  {
+    "playerId": 214649,
+    "fullName": "Меллер Вольф",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214637,
+    "fullName": "Уго Буэно",
     "clubName": "Вулверхэмптон",
     "position": "DEF",
     "league": "EPL",
     "price": 4.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214652,
+    "fullName": "Хувер",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
     "popularity": 0.2,
     "fp_last": 0.0
-  },
-  {
-    "playerId": 214666,
-    "fullName": "Мэттьюз",
-    "clubName": "Кристал Пэлас",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214665,
-    "fullName": "Кпорха",
-    "clubName": "Кристал Пэлас",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 214664,
-    "fullName": "Клайн",
-    "clubName": "Кристал Пэлас",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 18.0
   },
   {
     "playerId": 214659,
@@ -11730,6 +8050,16 @@
     "fp_last": 0.0
   },
   {
+    "playerId": 214636,
+    "fullName": "Бентли",
+    "clubName": "Вулверхэмптон",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 3.1,
+    "fp_last": 8.0
+  },
+  {
     "playerId": 214653,
     "fullName": "Чирева",
     "clubName": "Вулверхэмптон",
@@ -11748,16 +8078,6 @@
     "price": 4.5,
     "popularity": 0.6,
     "fp_last": 0.0
-  },
-  {
-    "playerId": 214650,
-    "fullName": "Бубакар Траоре",
-    "clubName": "Вулверхэмптон",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 1.0
   },
   {
     "playerId": 214648,
@@ -11810,6 +8130,16 @@
     "fp_last": 44.0
   },
   {
+    "playerId": 214640,
+    "fullName": "Ерсон Москера",
+    "clubName": "Вулверхэмптон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
     "playerId": 214639,
     "fullName": "Лима",
     "clubName": "Вулверхэмптон",
@@ -11820,343 +8150,153 @@
     "fp_last": 2.0
   },
   {
-    "playerId": 214668,
-    "fullName": "Агбиноне",
-    "clubName": "Кристал Пэлас",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 3.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214638,
-    "fullName": "Том Кинг",
-    "clubName": "Эвертон",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214636,
-    "fullName": "Бентли",
+    "playerId": 214650,
+    "fullName": "Бубакар Траоре",
     "clubName": "Вулверхэмптон",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 3.1,
-    "fp_last": 8.0
-  },
-  {
-    "playerId": 214631,
-    "fullName": "Саммервилл",
-    "clubName": "Вест Хэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 32.0
-  },
-  {
-    "playerId": 214627,
-    "fullName": "Альварес",
-    "clubName": "Вест Хэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214625,
-    "fullName": "Корне",
-    "clubName": "Вест Хэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214624,
-    "fullName": "Килмен",
-    "clubName": "Вест Хэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.5,
-    "fp_last": 77.0
-  },
-  {
-    "playerId": 214622,
-    "fullName": "Гильерме",
-    "clubName": "Вест Хэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 12.0
-  },
-  {
-    "playerId": 214621,
-    "fullName": "Ареоля",
-    "clubName": "Вест Хэм",
-    "position": "GK",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 70.0
-  },
-  {
-    "playerId": 214620,
-    "fullName": "Эрти",
-    "clubName": "Вест Хэм",
     "position": "MID",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214619,
-    "fullName": "Эмерсон",
-    "clubName": "Вест Хэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 72.0
-  },
-  {
-    "playerId": 214618,
-    "fullName": "Уокер-Питерс",
-    "clubName": "Вест Хэм",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214616,
-    "fullName": "Поттс",
-    "clubName": "Вест Хэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 1.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214615,
-    "fullName": "Орфорд",
-    "clubName": "Вест Хэм",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 214667,
-    "fullName": "Холдинг",
-    "clubName": "Кристал Пэлас",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214669,
-    "fullName": "Ахамада",
-    "clubName": "Кристал Пэлас",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214713,
-    "fullName": "Доук",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214695,
-    "fullName": "Нкетиа",
-    "clubName": "Кристал Пэлас",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 6.0,
-    "popularity": 0.3,
-    "fp_last": 50.0
-  },
-  {
-    "playerId": 214711,
-    "fullName": "Байчетич",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214710,
-    "fullName": "Стивенсон",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214709,
-    "fullName": "Пиллинг",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214708,
-    "fullName": "Ньони",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214707,
-    "fullName": "Моррисон",
-    "clubName": "Ливерпуль",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214706,
-    "fullName": "Кумас",
-    "clubName": "Ливерпуль",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214705,
-    "fullName": "Дэннс",
-    "clubName": "Ливерпуль",
-    "position": "FWD",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
+    "popularity": 0.4,
     "fp_last": 1.0
   },
   {
-    "playerId": 214704,
-    "fullName": "Рис Уильямс",
-    "clubName": "Ливерпуль",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214703,
-    "fullName": "Кэлвин Рэмзи",
-    "clubName": "Ливерпуль",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214702,
-    "fullName": "Печи",
-    "clubName": "Ливерпуль",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214701,
-    "fullName": "Налло",
-    "clubName": "Ливерпуль",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214700,
-    "fullName": "Мабайя",
-    "clubName": "Ливерпуль",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214699,
-    "fullName": "Вудмен",
-    "clubName": "Ливерпуль",
-    "position": "GK",
-    "league": "EPL",
-    "price": 4.0,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214689,
-    "fullName": "Камада",
+    "playerId": 214684,
+    "fullName": "Митчелл",
     "clubName": "Кристал Пэлас",
-    "position": "MID",
+    "position": "DEF",
     "league": "EPL",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 52.0
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 120.0
   },
   {
-    "playerId": 214670,
-    "fullName": "Бенитес",
+    "playerId": 214681,
+    "fullName": "Гехи",
     "clubName": "Кристал Пэлас",
-    "position": "GK",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 8.2,
+    "fp_last": 111.0
+  },
+  {
+    "playerId": 214676,
+    "fullName": "Крис Ричардс",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
     "league": "EPL",
     "price": 4.5,
-    "popularity": 0.3,
+    "popularity": 2.5,
+    "fp_last": 65.0
+  },
+  {
+    "playerId": 214692,
+    "fullName": "Дин Хендерсон",
+    "clubName": "Кристал Пэлас",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 7.4,
     "fp_last": 0.0
   },
   {
-    "playerId": 214688,
-    "fullName": "Дукуре",
+    "playerId": 214683,
+    "fullName": "Лакруа",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.3,
+    "fp_last": 102.0
+  },
+  {
+    "playerId": 214697,
+    "fullName": "Исмаила Сарр",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 1.7,
+    "fp_last": 129.0
+  },
+  {
+    "playerId": 214694,
+    "fullName": "Муньос",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 2.8,
+    "fp_last": 130.0
+  },
+  {
+    "playerId": 214691,
+    "fullName": "Уортон",
     "clubName": "Кристал Пэлас",
     "position": "MID",
     "league": "EPL",
     "price": 5.5,
-    "popularity": 0.0,
+    "popularity": 1.1,
+    "fp_last": 46.0
+  },
+  {
+    "playerId": 214698,
+    "fullName": "Эзе",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.5,
+    "popularity": 4.9,
+    "fp_last": 148.0
+  },
+  {
+    "playerId": 214693,
+    "fullName": "Хьюз",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.3,
+    "fp_last": 64.0
+  },
+  {
+    "playerId": 214696,
+    "fullName": "Матета",
+    "clubName": "Кристал Пэлас",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 8.9,
+    "fp_last": 142.0
+  },
+  {
+    "playerId": 214682,
+    "fullName": "Девенни",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 214690,
+    "fullName": "Лерма",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 74.0
+  },
+  {
+    "playerId": 214673,
+    "fullName": "Озо",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
     "fp_last": 0.0
   },
   {
@@ -12170,6 +8310,76 @@
     "fp_last": 10.0
   },
   {
+    "playerId": 214666,
+    "fullName": "Мэттьюз",
+    "clubName": "Кристал Пэлас",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214695,
+    "fullName": "Нкетиа",
+    "clubName": "Кристал Пэлас",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.3,
+    "fp_last": 50.0
+  },
+  {
+    "playerId": 214667,
+    "fullName": "Холдинг",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214668,
+    "fullName": "Агбиноне",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 3.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214669,
+    "fullName": "Ахамада",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214689,
+    "fullName": "Камада",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 214688,
+    "fullName": "Дукуре",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
     "playerId": 214686,
     "fullName": "Эдуар",
     "clubName": "Кристал Пэлас",
@@ -12177,6 +8387,16 @@
     "league": "EPL",
     "price": 5.0,
     "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214674,
+    "fullName": "Пьеррик",
+    "clubName": "Кристал Пэлас",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
     "fp_last": 0.0
   },
   {
@@ -12188,6 +8408,36 @@
     "price": 5.0,
     "popularity": 0.1,
     "fp_last": 0.0
+  },
+  {
+    "playerId": 214670,
+    "fullName": "Бенитес",
+    "clubName": "Кристал Пэлас",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214671,
+    "fullName": "Марш",
+    "clubName": "Кристал Пэлас",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214665,
+    "fullName": "Кпорха",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 1.0
   },
   {
     "playerId": 214680,
@@ -12230,36 +8480,6 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 214675,
-    "fullName": "Риад",
-    "clubName": "Кристал Пэлас",
-    "position": "DEF",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 214674,
-    "fullName": "Пьеррик",
-    "clubName": "Кристал Пэлас",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 214673,
-    "fullName": "Озо",
-    "clubName": "Кристал Пэлас",
-    "position": "MID",
-    "league": "EPL",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
     "playerId": 214672,
     "fullName": "Матеус Франса",
     "clubName": "Кристал Пэлас",
@@ -12270,13 +8490,2073 @@
     "fp_last": 9.0
   },
   {
-    "playerId": 214671,
-    "fullName": "Марш",
+    "playerId": 214675,
+    "fullName": "Риад",
     "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 214664,
+    "fullName": "Клайн",
+    "clubName": "Кристал Пэлас",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 18.0
+  },
+  {
+    "playerId": 214735,
+    "fullName": "Салах",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 12.5,
+    "popularity": 27.7,
+    "fp_last": 318.0
+  },
+  {
+    "playerId": 214732,
+    "fullName": "Гакпо",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.5,
+    "popularity": 8.9,
+    "fp_last": 127.0
+  },
+  {
+    "playerId": 214733,
+    "fullName": "Экитике",
+    "clubName": "Ливерпуль",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 8.5,
+    "popularity": 29.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214723,
+    "fullName": "Керкез",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 5.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214726,
+    "fullName": "Фримпонг",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 32.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214725,
+    "fullName": "Кьеза",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.6,
+    "fp_last": 7.0
+  },
+  {
+    "playerId": 214730,
+    "fullName": "Мак Аллистер",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 4.8,
+    "fp_last": 130.0
+  },
+  {
+    "playerId": 214734,
+    "fullName": "Виртц",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 9.0,
+    "popularity": 30.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214731,
+    "fullName": "Собослаи",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 3.3,
+    "fp_last": 134.0
+  },
+  {
+    "playerId": 214719,
+    "fullName": "Эндо",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 21.0
+  },
+  {
+    "playerId": 214721,
+    "fullName": "ван Дейк",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 16.7,
+    "fp_last": 135.0
+  },
+  {
+    "playerId": 214724,
+    "fullName": "Конате",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.7,
+    "fp_last": 102.0
+  },
+  {
+    "playerId": 214722,
+    "fullName": "Кертис Джонс",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214720,
+    "fullName": "Алиссон",
+    "clubName": "Ливерпуль",
+    "position": "GK",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 11.3,
+    "fp_last": 103.0
+  },
+  {
+    "playerId": 214712,
+    "fullName": "Джо Гомес",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 14.0
+  },
+  {
+    "playerId": 214728,
+    "fullName": "Гравенберх",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.8,
+    "fp_last": 118.0
+  },
+  {
+    "playerId": 214729,
+    "fullName": "Нуньес",
+    "clubName": "Ливерпуль",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 1.1,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 214727,
+    "fullName": "Эллиот",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.2,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 214699,
+    "fullName": "Вудмен",
+    "clubName": "Ливерпуль",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214718,
+    "fullName": "Робертсон",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.9,
+    "fp_last": 90.0
+  },
+  {
+    "playerId": 214707,
+    "fullName": "Моррисон",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214701,
+    "fullName": "Налло",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214702,
+    "fullName": "Печи",
+    "clubName": "Ливерпуль",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214703,
+    "fullName": "Кэлвин Рэмзи",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214704,
+    "fullName": "Рис Уильямс",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214705,
+    "fullName": "Дэннс",
+    "clubName": "Ливерпуль",
     "position": "FWD",
     "league": "EPL",
     "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 214706,
+    "fullName": "Кумас",
+    "clubName": "Ливерпуль",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214708,
+    "fullName": "Ньони",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214700,
+    "fullName": "Мабайя",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214709,
+    "fullName": "Пиллинг",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214710,
+    "fullName": "Стивенсон",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214711,
+    "fullName": "Байчетич",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214713,
+    "fullName": "Доук",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214714,
+    "fullName": "Нгумоа",
+    "clubName": "Ливерпуль",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214715,
+    "fullName": "Цимикас",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
     "popularity": 0.3,
+    "fp_last": 45.0
+  },
+  {
+    "playerId": 214716,
+    "fullName": "Брэдли",
+    "clubName": "Ливерпуль",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 38.0
+  },
+  {
+    "playerId": 214717,
+    "fullName": "Мамардашвили",
+    "clubName": "Ливерпуль",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214748,
+    "fullName": "Гудмундссон",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214760,
+    "fullName": "Штах",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214753,
+    "fullName": "Стрейк",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214744,
+    "fullName": "Богл",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214752,
+    "fullName": "Родон",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214751,
+    "fullName": "Лукас Перри",
+    "clubName": "Лидс",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 3.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214763,
+    "fullName": "Нмеча",
+    "clubName": "Лидс",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214758,
+    "fullName": "Танака",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214766,
+    "fullName": "Ньонто",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214765,
+    "fullName": "Дэниэл Джеймс",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214767,
+    "fullName": "Пиру",
+    "clubName": "Лидс",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 2.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214742,
+    "fullName": "Ампаду",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 8.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214764,
+    "fullName": "Харрисон",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214762,
+    "fullName": "Лонгстафф",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214761,
+    "fullName": "Ааронсон",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214756,
+    "fullName": "Груев",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214747,
+    "fullName": "Харри Грэй",
+    "clubName": "Лидс",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214738,
+    "fullName": "Дарлоу",
+    "clubName": "Лидс",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 5.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214739,
+    "fullName": "Кэрнс",
+    "clubName": "Лидс",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214740,
+    "fullName": "Мелье",
+    "clubName": "Лидс",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 2.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214741,
+    "fullName": "Шмидт",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214759,
+    "fullName": "Матео Фернандес",
+    "clubName": "Лидс",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214757,
+    "fullName": "Рамазани",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214746,
+    "fullName": "Гринвуд",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214755,
+    "fullName": "Бэмфорд",
+    "clubName": "Лидс",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214754,
+    "fullName": "Чамберс",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214743,
+    "fullName": "Бийол",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214737,
+    "fullName": "Борнаув",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214745,
+    "fullName": "Гелхардт",
+    "clubName": "Лидс",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 2.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214750,
+    "fullName": "Крю",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214749,
+    "fullName": "Джаби",
+    "clubName": "Лидс",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214736,
+    "fullName": "Байрэм",
+    "clubName": "Лидс",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 2.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214795,
+    "fullName": "Рейндерс",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 20.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214802,
+    "fullName": "Холанд",
+    "clubName": "Манчестер Сити",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 12.0,
+    "popularity": 36.6,
+    "fp_last": 180.0
+  },
+  {
+    "playerId": 214782,
+    "fullName": "Льюис",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 3.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214785,
+    "fullName": "Бобб",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.2,
+    "fp_last": 3.0
+  },
+  {
+    "playerId": 214784,
+    "fullName": "Аит-Нури",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 11.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214777,
+    "fullName": "Стоунз",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.3,
+    "fp_last": 27.0
+  },
+  {
+    "playerId": 214778,
+    "fullName": "Траффорд",
+    "clubName": "Манчестер Сити",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 4.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214791,
+    "fullName": "Рубен Диаш",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 6.6,
+    "fp_last": 85.0
+  },
+  {
+    "playerId": 214799,
+    "fullName": "Шерки",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 9.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214790,
+    "fullName": "Нико Гонсалес",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.5,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 214793,
+    "fullName": "Бернарду Силва",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 3.0,
+    "fp_last": 125.0
+  },
+  {
+    "playerId": 214798,
+    "fullName": "Доку",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 2.7,
+    "fp_last": 91.0
+  },
+  {
+    "playerId": 214789,
+    "fullName": "Матеуш Нунеш",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.3,
+    "fp_last": 88.0
+  },
+  {
+    "playerId": 214800,
+    "fullName": "Мармуш",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 9.0,
+    "popularity": 6.4,
+    "fp_last": 79.0
+  },
+  {
+    "playerId": 214773,
+    "fullName": "Хусанов",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.3,
+    "fp_last": 16.0
+  },
+  {
+    "playerId": 214772,
+    "fullName": "Рейс",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 214794,
+    "fullName": "Гюндоган",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.4,
+    "fp_last": 102.0
+  },
+  {
+    "playerId": 214770,
+    "fullName": "Уилсон-Эсбранд",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214796,
+    "fullName": "Родри Эрнандес",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.4,
+    "fp_last": 3.0
+  },
+  {
+    "playerId": 214801,
+    "fullName": "Фоден",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 9.0,
+    "popularity": 2.0,
+    "fp_last": 102.0
+  },
+  {
+    "playerId": 214797,
+    "fullName": "Савио",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.4,
+    "fp_last": 93.0
+  },
+  {
+    "playerId": 214788,
+    "fullName": "Ковачич",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.1,
+    "fp_last": 106.0
+  },
+  {
+    "playerId": 214792,
+    "fullName": "Эдерсон",
+    "clubName": "Манчестер Сити",
+    "position": "GK",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 2.4,
+    "fp_last": 102.0
+  },
+  {
+    "playerId": 214786,
+    "fullName": "Гвардиол",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 11.2,
+    "fp_last": 138.0
+  },
+  {
+    "playerId": 214769,
+    "fullName": "Каборе",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214771,
+    "fullName": "Нюпан",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214781,
+    "fullName": "Аканджи",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 60.0
+  },
+  {
+    "playerId": 214780,
+    "fullName": "Эчеверри",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 214779,
+    "fullName": "Филлипс",
+    "clubName": "Манчестер Сити",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214776,
+    "fullName": "Ортега",
+    "clubName": "Манчестер Сити",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 35.0
+  },
+  {
+    "playerId": 214775,
+    "fullName": "Нико О`Райли",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 214774,
+    "fullName": "Аке",
+    "clubName": "Манчестер Сити",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.9,
+    "fp_last": 25.0
+  },
+  {
+    "playerId": 214768,
+    "fullName": "Беттинелли",
+    "clubName": "Манчестер Сити",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214837,
+    "fullName": "Бруну Фернандеш",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 10.0,
+    "popularity": 11.0,
+    "fp_last": 168.0
+  },
+  {
+    "playerId": 214836,
+    "fullName": "Мбемо",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.5,
+    "popularity": 5.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214822,
+    "fullName": "Шоу",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.8,
+    "fp_last": 7.0
+  },
+  {
+    "playerId": 214816,
+    "fullName": "де Лигт",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.8,
+    "fp_last": 65.0
+  },
+  {
+    "playerId": 214835,
+    "fullName": "Матеус Кунья",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 6.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214818,
+    "fullName": "Йоро",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 3.3,
+    "fp_last": 22.0
+  },
+  {
+    "playerId": 214830,
+    "fullName": "Маунт",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.8,
+    "fp_last": 25.0
+  },
+  {
+    "playerId": 214828,
+    "fullName": "Каземиро",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.0,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 214803,
+    "fullName": "Байындыр",
+    "clubName": "Манчестер Юнайтед",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 14.9,
+    "fp_last": 8.0
+  },
+  {
+    "playerId": 215652,
+    "fullName": "Шешко",
+    "clubName": "Манчестер Юнайтед",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 8.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214817,
+    "fullName": "Диогу Далот",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.7,
+    "fp_last": 83.0
+  },
+  {
+    "playerId": 214819,
+    "fullName": "Магуайр",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.9,
+    "fp_last": 45.0
+  },
+  {
+    "playerId": 214834,
+    "fullName": "Диалло",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 2.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214823,
+    "fullName": "Доргу",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 2.7,
+    "fp_last": 18.0
+  },
+  {
+    "playerId": 214825,
+    "fullName": "Угарте",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 58.0
+  },
+  {
+    "playerId": 214812,
+    "fullName": "Мантато",
+    "clubName": "Манчестер Юнайтед",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214829,
+    "fullName": "Майну",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 50.0
+  },
+  {
+    "playerId": 216511,
+    "fullName": "Амасс",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 4.0
+  },
+  {
+    "playerId": 214805,
+    "fullName": "Маласиа",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 214806,
+    "fullName": "Ми",
+    "clubName": "Манчестер Юнайтед",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214807,
+    "fullName": "Фредриксон",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214833,
+    "fullName": "Хейлунд",
+    "clubName": "Манчестер Юнайтед",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.6,
+    "fp_last": 76.0
+  },
+  {
+    "playerId": 214832,
+    "fullName": "Гарначо",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.4,
+    "fp_last": 107.0
+  },
+  {
+    "playerId": 214831,
+    "fullName": "Санчо",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214808,
+    "fullName": "Хевен",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.9,
+    "fp_last": 8.0
+  },
+  {
+    "playerId": 214826,
+    "fullName": "Антони",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.4,
+    "fp_last": 8.0
+  },
+  {
+    "playerId": 214809,
+    "fullName": "Хитон",
+    "clubName": "Манчестер Юнайтед",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214827,
+    "fullName": "Зиркзе",
+    "clubName": "Манчестер Юнайтед",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.0,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 214813,
+    "fullName": "Оби-Мартин",
+    "clubName": "Манчестер Юнайтед",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214824,
+    "fullName": "Андре Онана",
+    "clubName": "Манчестер Юнайтед",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.0,
+    "fp_last": 112.0
+  },
+  {
+    "playerId": 214804,
+    "fullName": "Леон",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214821,
+    "fullName": "Лисандро Мартинес",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 63.0
+  },
+  {
+    "playerId": 214820,
+    "fullName": "Мазрауи",
+    "clubName": "Манчестер Юнайтед",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 83.0
+  },
+  {
+    "playerId": 214810,
+    "fullName": "Коллиер",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 214811,
+    "fullName": "Коне",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214815,
+    "fullName": "Флетчер",
+    "clubName": "Манчестер Юнайтед",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214814,
+    "fullName": "Уитли",
+    "clubName": "Манчестер Юнайтед",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216512,
+    "fullName": "Мердок",
+    "clubName": "Манчестер Юнайтед",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214865,
+    "fullName": "Вуд",
+    "clubName": "Ноттингем Форест",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 10.4,
+    "fp_last": 173.0
+  },
+  {
+    "playerId": 214862,
+    "fullName": "Ндойе",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 1.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214861,
+    "fullName": "Эллиот Андерсон",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 2.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214864,
+    "fullName": "Гиббс-Уайт",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 4.0,
+    "fp_last": 142.0
+  },
+  {
+    "playerId": 214853,
+    "fullName": "Айна",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 4.6,
+    "fp_last": 113.0
+  },
+  {
+    "playerId": 214857,
+    "fullName": "Мурилло",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 6.3,
+    "fp_last": 112.0
+  },
+  {
+    "playerId": 214863,
+    "fullName": "Хадсон-Одои",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 1.2,
+    "fp_last": 103.0
+  },
+  {
+    "playerId": 214852,
+    "fullName": "Сангаре",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 21.0
+  },
+  {
+    "playerId": 214856,
+    "fullName": "Миленкович",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 9.4,
+    "fp_last": 143.0
+  },
+  {
+    "playerId": 214855,
+    "fullName": "Зельс",
+    "clubName": "Ноттингем Форест",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 11.0,
+    "fp_last": 136.0
+  },
+  {
+    "playerId": 214851,
+    "fullName": "Йейтс",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 74.0
+  },
+  {
+    "playerId": 214860,
+    "fullName": "Силва",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.3,
+    "fp_last": 51.0
+  },
+  {
+    "playerId": 214859,
+    "fullName": "Игор Жезус",
+    "clubName": "Ноттингем Форест",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214858,
+    "fullName": "Неко Уильямс",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.9,
+    "fp_last": 101.0
+  },
+  {
+    "playerId": 214854,
+    "fullName": "Домингес",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 214783,
+    "fullName": "Макати",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214838,
+    "fullName": "Карлос Мигел",
+    "clubName": "Ноттингем Форест",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214850,
+    "fullName": "Эммануэль Деннис",
+    "clubName": "Ноттингем Форест",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214849,
+    "fullName": "да Силва Морейра",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 214848,
+    "fullName": "Авонийи",
+    "clubName": "Ноттингем Форест",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.3,
+    "fp_last": 32.0
+  },
+  {
+    "playerId": 214847,
+    "fullName": "Стаменич",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214846,
+    "fullName": "Омар Ричардс",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214845,
+    "fullName": "О`Брайен",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214844,
+    "fullName": "Морато",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 34.0
+  },
+  {
+    "playerId": 214843,
+    "fullName": "Жаир Кунья",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214842,
+    "fullName": "Боулер",
+    "clubName": "Ноттингем Форест",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214841,
+    "fullName": "Боли",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 214840,
+    "fullName": "Тернер",
+    "clubName": "Ноттингем Форест",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214839,
+    "fullName": "Карму",
+    "clubName": "Ноттингем Форест",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216513,
+    "fullName": "Ганн",
+    "clubName": "Ноттингем Форест",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214885,
+    "fullName": "Поуп",
+    "clubName": "Ньюкасл",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 4.0,
+    "fp_last": 100.0
+  },
+  {
+    "playerId": 214886,
+    "fullName": "Триппьер",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 3.8,
+    "fp_last": 64.0
+  },
+  {
+    "playerId": 214883,
+    "fullName": "Берн",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 2.0,
+    "fp_last": 110.0
+  },
+  {
+    "playerId": 214888,
+    "fullName": "Шер",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 108.0
+  },
+  {
+    "playerId": 214889,
+    "fullName": "Ливраменто",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 2.9,
+    "fp_last": 99.0
+  },
+  {
+    "playerId": 214891,
+    "fullName": "Бруно Гимараэс",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 4.6,
+    "fp_last": 146.0
+  },
+  {
+    "playerId": 214892,
+    "fullName": "Тонали",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 2.9,
+    "fp_last": 120.0
+  },
+  {
+    "playerId": 214897,
+    "fullName": "Гордон",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 8.5,
+    "popularity": 2.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214893,
+    "fullName": "Харви Барнс",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214896,
+    "fullName": "Эланга",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 3.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214894,
+    "fullName": "Жоэлинтон",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 1.3,
+    "fp_last": 104.0
+  },
+  {
+    "playerId": 214895,
+    "fullName": "Джейкоб Мерфи",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.8,
+    "fp_last": 154.0
+  },
+  {
+    "playerId": 214880,
+    "fullName": "Майли",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 21.0
+  },
+  {
+    "playerId": 214881,
+    "fullName": "Осула",
+    "clubName": "Ньюкасл",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 18.0
+  },
+  {
+    "playerId": 214890,
+    "fullName": "Уиллок",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 46.0
+  },
+  {
+    "playerId": 214898,
+    "fullName": "Исак",
+    "clubName": "Ньюкасл",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 10.5,
+    "popularity": 3.1,
+    "fp_last": 192.0
+  },
+  {
+    "playerId": 216514,
+    "fullName": "Шахар",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216515,
+    "fullName": "Куол",
+    "clubName": "Ньюкасл",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214887,
+    "fullName": "Льюис Холл",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.5,
+    "fp_last": 82.0
+  },
+  {
+    "playerId": 214461,
+    "fullName": "Джейкоб Рэмзи",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214884,
+    "fullName": "Ботман",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.1,
+    "fp_last": 18.0
+  },
+  {
+    "playerId": 214866,
+    "fullName": "Влаходимос",
+    "clubName": "Ньюкасл",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214882,
+    "fullName": "Рэмсдейл",
+    "clubName": "Ньюкасл",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214879,
+    "fullName": "Хэйден",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214878,
+    "fullName": "Хернес",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214877,
+    "fullName": "Джо Уайт",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214876,
+    "fullName": "Таргетт",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 214875,
+    "fullName": "Нив",
+    "clubName": "Ньюкасл",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214874,
+    "fullName": "Кордеро",
+    "clubName": "Ньюкасл",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214872,
+    "fullName": "Эшби",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214871,
+    "fullName": "Радди",
+    "clubName": "Ньюкасл",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214870,
+    "fullName": "Алекс Мерфи",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214869,
+    "fullName": "Ласселс",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214868,
+    "fullName": "Крафт",
+    "clubName": "Ньюкасл",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 17.0
+  },
+  {
+    "playerId": 214867,
+    "fullName": "Гиллеспи",
+    "clubName": "Ньюкасл",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.5,
     "fp_last": 0.0
   },
   {
@@ -12290,44 +10570,1724 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216211,
-    "fullName": "Лукаку",
-    "clubName": "Наполи",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 11.0,
-    "popularity": 10.5,
-    "fp_last": 151.0
+    "playerId": 214915,
+    "fullName": "Бэллард",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 6.7,
+    "fp_last": 0.0
   },
   {
-    "playerId": 216212,
-    "fullName": "Мактоминей",
-    "clubName": "Наполи",
+    "playerId": 214925,
+    "fullName": "Хьюм",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214906,
+    "fullName": "Рейнилду",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 11.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214922,
+    "fullName": "Руфс",
+    "clubName": "Сандерленд",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 4.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214936,
+    "fullName": "Аденгра",
+    "clubName": "Сандерленд",
     "position": "MID",
-    "league": "Serie A",
-    "price": 11.0,
-    "popularity": 9.1,
-    "fp_last": 184.0
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.1,
+    "fp_last": 0.0
   },
   {
-    "playerId": 215982,
-    "fullName": "Мартинес",
-    "clubName": "Интер",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 10.5,
-    "popularity": 10.5,
-    "fp_last": 131.0
-  },
-  {
-    "playerId": 216183,
-    "fullName": "Пулишич",
-    "clubName": "Милан",
+    "playerId": 214935,
+    "fullName": "Тальби",
+    "clubName": "Сандерленд",
     "position": "MID",
-    "league": "Serie A",
-    "price": 10.5,
-    "popularity": 10.5,
-    "fp_last": 161.0
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214933,
+    "fullName": "Майенда",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 2.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214937,
+    "fullName": "Изидор",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214931,
+    "fullName": "Диарра",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214923,
+    "fullName": "Садики",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214927,
+    "fullName": "Джака",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 10.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214907,
+    "fullName": "Селт",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214932,
+    "fullName": "Ле Фе",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214930,
+    "fullName": "Ригг",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214929,
+    "fullName": "Нил",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214928,
+    "fullName": "Мандл",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214934,
+    "fullName": "Патрик Робертс",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214926,
+    "fullName": "Эква",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215017,
+    "fullName": "Гиу",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 3.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214924,
+    "fullName": "Серкин",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214899,
+    "fullName": "Алесе",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214919,
+    "fullName": "О`Нин",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214921,
+    "fullName": "Русин",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214910,
+    "fullName": "Хьельде",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214901,
+    "fullName": "Зак Джонсон",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214902,
+    "fullName": "Саймон Мур",
+    "clubName": "Сандерленд",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214903,
+    "fullName": "Нуке",
+    "clubName": "Сандерленд",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214904,
+    "fullName": "Пембеле",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214905,
+    "fullName": "Пэттерсон",
+    "clubName": "Сандерленд",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214908,
+    "fullName": "Триантис",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214909,
+    "fullName": "Хаггинс",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214911,
+    "fullName": "Абдуллахи",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 6.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214920,
+    "fullName": "Поведа",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214912,
+    "fullName": "Алексич",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214913,
+    "fullName": "Ба",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214914,
+    "fullName": "Браун",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214916,
+    "fullName": "Харрисон Джонс",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214917,
+    "fullName": "Луиш Семеду",
+    "clubName": "Сандерленд",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214918,
+    "fullName": "Матете",
+    "clubName": "Сандерленд",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214900,
+    "fullName": "Джозеф Андерсон",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 4.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216516,
+    "fullName": "Масуаку",
+    "clubName": "Сандерленд",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214977,
+    "fullName": "Кудус",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 16.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214974,
+    "fullName": "Ришарлисон",
+    "clubName": "Тоттенхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 13.3,
+    "fp_last": 36.0
+  },
+  {
+    "playerId": 214968,
+    "fullName": "Пап Матар Сарр",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 8.6,
+    "fp_last": 73.0
+  },
+  {
+    "playerId": 214976,
+    "fullName": "Бреннан Джонсон",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 2.6,
+    "fp_last": 133.0
+  },
+  {
+    "playerId": 214964,
+    "fullName": "ван де Вен",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 13.5,
+    "fp_last": 30.0
+  },
+  {
+    "playerId": 214973,
+    "fullName": "Порро",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 15.1,
+    "fp_last": 92.0
+  },
+  {
+    "playerId": 214965,
+    "fullName": "Викарио",
+    "clubName": "Тоттенхэм",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 10.6,
+    "fp_last": 64.0
+  },
+  {
+    "playerId": 214967,
+    "fullName": "Ромеро",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 6.0,
+    "fp_last": 43.0
+  },
+  {
+    "playerId": 214961,
+    "fullName": "Спенс",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 3.0,
+    "fp_last": 47.0
+  },
+  {
+    "playerId": 214958,
+    "fullName": "Арчи Грэй",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214963,
+    "fullName": "Бергвалль",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.3,
+    "fp_last": 47.0
+  },
+  {
+    "playerId": 214962,
+    "fullName": "Бентанкур",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.6,
+    "fp_last": 55.0
+  },
+  {
+    "playerId": 214966,
+    "fullName": "Пальинья",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214980,
+    "fullName": "Соланке",
+    "clubName": "Тоттенхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 1.6,
+    "fp_last": 115.0
+  },
+  {
+    "playerId": 214972,
+    "fullName": "Одобер",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.2,
+    "fp_last": 34.0
+  },
+  {
+    "playerId": 214975,
+    "fullName": "Тель",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.5,
+    "fp_last": 45.0
+  },
+  {
+    "playerId": 214969,
+    "fullName": "Соломон",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214970,
+    "fullName": "Удоджи",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 45.0
+  },
+  {
+    "playerId": 214978,
+    "fullName": "Кулусевски",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 0.1,
+    "fp_last": 130.0
+  },
+  {
+    "playerId": 214979,
+    "fullName": "Мэддисон",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 0.0,
+    "fp_last": 116.0
+  },
+  {
+    "playerId": 214971,
+    "fullName": "Хиль",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214938,
+    "fullName": "Вушкович",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214960,
+    "fullName": "Мин Хек",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214948,
+    "fullName": "Кьерематен",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214940,
+    "fullName": "Остин",
+    "clubName": "Тоттенхэм",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 214941,
+    "fullName": "Такаи",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214942,
+    "fullName": "Эбботт",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214943,
+    "fullName": "Дивайн",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214944,
+    "fullName": "Донли",
+    "clubName": "Тоттенхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214945,
+    "fullName": "Дрэгушин",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 24.0
+  },
+  {
+    "playerId": 214946,
+    "fullName": "Дэвис",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214947,
+    "fullName": "Кински",
+    "clubName": "Тоттенхэм",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 17.0
+  },
+  {
+    "playerId": 214949,
+    "fullName": "Лэнкшир",
+    "clubName": "Тоттенхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 214939,
+    "fullName": "Кассанова",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214950,
+    "fullName": "Майки Мур",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214951,
+    "fullName": "Олусеси",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214952,
+    "fullName": "Рассел-Дэнни",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214953,
+    "fullName": "Скарлетт",
+    "clubName": "Тоттенхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 214954,
+    "fullName": "Уильямс-Барнетт",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214955,
+    "fullName": "Тайрис Холл",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214956,
+    "fullName": "Эшкрофт",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214957,
+    "fullName": "Биссума",
+    "clubName": "Тоттенхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.9,
+    "fp_last": 50.0
+  },
+  {
+    "playerId": 214959,
+    "fullName": "Данзо",
+    "clubName": "Тоттенхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.9,
+    "fp_last": 16.0
+  },
+  {
+    "playerId": 214999,
+    "fullName": "Харри Уилсон",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.3,
+    "fp_last": 72.0
+  },
+  {
+    "playerId": 215000,
+    "fullName": "Родриго Муниз",
+    "clubName": "Фулхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.9,
+    "fp_last": 72.0
+  },
+  {
+    "playerId": 214985,
+    "fullName": "Джошуа Кинг",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 2.9,
+    "fp_last": 10.0
+  },
+  {
+    "playerId": 214981,
+    "fullName": "Куэнка",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.5,
+    "fp_last": 9.0
+  },
+  {
+    "playerId": 214992,
+    "fullName": "Лено",
+    "clubName": "Фулхэм",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.2,
+    "fp_last": 107.0
+  },
+  {
+    "playerId": 214995,
+    "fullName": "Лукич",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 65.0
+  },
+  {
+    "playerId": 214994,
+    "fullName": "Тете",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 49.0
+  },
+  {
+    "playerId": 215002,
+    "fullName": "Ивоби",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.7,
+    "fp_last": 154.0
+  },
+  {
+    "playerId": 215004,
+    "fullName": "Хименес",
+    "clubName": "Фулхэм",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 1.8,
+    "fp_last": 132.0
+  },
+  {
+    "playerId": 214988,
+    "fullName": "Басси",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 75.0
+  },
+  {
+    "playerId": 214987,
+    "fullName": "Андерсен",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.2,
+    "fp_last": 51.0
+  },
+  {
+    "playerId": 214990,
+    "fullName": "Кастань",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 46.0
+  },
+  {
+    "playerId": 215001,
+    "fullName": "Адама Траоре",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.4,
+    "fp_last": 89.0
+  },
+  {
+    "playerId": 215003,
+    "fullName": "Смит-Роу",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.4,
+    "fp_last": 100.0
+  },
+  {
+    "playerId": 214991,
+    "fullName": "Кэрни",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 214989,
+    "fullName": "Берге",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 67.0
+  },
+  {
+    "playerId": 214982,
+    "fullName": "Лекомт",
+    "clubName": "Фулхэм",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214996,
+    "fullName": "Робинсон",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 98.0
+  },
+  {
+    "playerId": 214997,
+    "fullName": "Перейра",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.3,
+    "fp_last": 78.0
+  },
+  {
+    "playerId": 214998,
+    "fullName": "Сессеньон",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.1,
+    "fp_last": 48.0
+  },
+  {
+    "playerId": 214986,
+    "fullName": "Харрис",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214984,
+    "fullName": "Диоп",
+    "clubName": "Фулхэм",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 214983,
+    "fullName": "Годо",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 214993,
+    "fullName": "Рид",
+    "clubName": "Фулхэм",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 10.0
+  },
+  {
+    "playerId": 215029,
+    "fullName": "Санчес",
+    "clubName": "Челси",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 7.4,
+    "fp_last": 115.0
+  },
+  {
+    "playerId": 215006,
+    "fullName": "Ачимпонг",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 4.1,
+    "fp_last": 4.0
+  },
+  {
+    "playerId": 215026,
+    "fullName": "Рис Джеймс",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 6.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215024,
+    "fullName": "Чалоба",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.3,
+    "fp_last": 82.0
+  },
+  {
+    "playerId": 215030,
+    "fullName": "Кукурелья",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 18.0,
+    "fp_last": 116.0
+  },
+  {
+    "playerId": 215041,
+    "fullName": "Палмер",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 11.0,
+    "popularity": 34.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215038,
+    "fullName": "Нету",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 5.4,
+    "fp_last": 110.0
+  },
+  {
+    "playerId": 215035,
+    "fullName": "Кайседо",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 4.9,
+    "fp_last": 125.0
+  },
+  {
+    "playerId": 215039,
+    "fullName": "Энцо Фернандес",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 5.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215040,
+    "fullName": "Жоао Педро",
+    "clubName": "Челси",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 8.0,
+    "popularity": 32.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215021,
+    "fullName": "Сантос",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215034,
+    "fullName": "Делап",
+    "clubName": "Челси",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 3.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215018,
+    "fullName": "Гюсто",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 2.5,
+    "fp_last": 58.0
+  },
+  {
+    "playerId": 215037,
+    "fullName": "Гиттенс",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.5,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215036,
+    "fullName": "Нкунку",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.4,
+    "fp_last": 57.0
+  },
+  {
+    "playerId": 215033,
+    "fullName": "Стерлинг",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215653,
+    "fullName": "Хато",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215032,
+    "fullName": "Джексон",
+    "clubName": "Челси",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216517,
+    "fullName": "Антви",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216518,
+    "fullName": "Сэмюэл Рак-Сакьи",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215031,
+    "fullName": "Эстевао",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215005,
+    "fullName": "Ансельмино",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215027,
+    "fullName": "Колуилл",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 103.0
+  },
+  {
+    "playerId": 215028,
+    "fullName": "Лавия",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.3,
+    "fp_last": 26.0
+  },
+  {
+    "playerId": 215025,
+    "fullName": "Чуквуэмека",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215023,
+    "fullName": "Фофана",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215020,
+    "fullName": "Йоргенсен",
+    "clubName": "Челси",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215019,
+    "fullName": "Джордж",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 15.0
+  },
+  {
+    "playerId": 215015,
+    "fullName": "Адарабиойо",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.3,
+    "fp_last": 64.0
+  },
+  {
+    "playerId": 215014,
+    "fullName": "Эссугу",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215013,
+    "fullName": "Чилуэлл",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215012,
+    "fullName": "Келлимен",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215011,
+    "fullName": "Дисаси",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215010,
+    "fullName": "Бадьяшиль",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 7.0
+  },
+  {
+    "playerId": 215009,
+    "fullName": "Слонина",
+    "clubName": "Челси",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215008,
+    "fullName": "Мамаду Сарр",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215007,
+    "fullName": "Гилкрист",
+    "clubName": "Челси",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216519,
+    "fullName": "Уолш",
+    "clubName": "Челси",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215063,
+    "fullName": "Ндиай",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 1.5,
+    "fp_last": 107.0
+  },
+  {
+    "playerId": 215060,
+    "fullName": "Гуйе",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 0.6,
+    "fp_last": 109.0
+  },
+  {
+    "playerId": 215061,
+    "fullName": "Дьюзбери-Холл",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215047,
+    "fullName": "Кин",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.0,
+    "fp_last": 44.0
+  },
+  {
+    "playerId": 215048,
+    "fullName": "О'Брайен",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 3.2,
+    "fp_last": 60.0
+  },
+  {
+    "playerId": 215059,
+    "fullName": "Бету",
+    "clubName": "Эвертон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 2.0,
+    "fp_last": 82.0
+  },
+  {
+    "playerId": 215052,
+    "fullName": "Ироэгбунам",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 25.0
+  },
+  {
+    "playerId": 215055,
+    "fullName": "Гарнер",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 53.0
+  },
+  {
+    "playerId": 215056,
+    "fullName": "Пикфорд",
+    "clubName": "Эвертон",
+    "position": "GK",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 8.9,
+    "fp_last": 143.0
+  },
+  {
+    "playerId": 215054,
+    "fullName": "Алькарас",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 41.0
+  },
+  {
+    "playerId": 215058,
+    "fullName": "Барри",
+    "clubName": "Эвертон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214787,
+    "fullName": "Грилиш",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 6.0,
+    "popularity": 4.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 214638,
+    "fullName": "Том Кинг",
+    "clubName": "Эвертон",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216520,
+    "fullName": "Оньянго",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215062,
+    "fullName": "Макнил",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 7.0,
+    "popularity": 0.1,
+    "fp_last": 88.0
+  },
+  {
+    "playerId": 215057,
+    "fullName": "Тарковски",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.5,
+    "popularity": 2.6,
+    "fp_last": 97.0
+  },
+  {
+    "playerId": 215053,
+    "fullName": "Миколенко",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.3,
+    "fp_last": 109.0
+  },
+  {
+    "playerId": 215051,
+    "fullName": "Брэнтуэйт",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 5.0,
+    "popularity": 1.2,
+    "fp_last": 85.0
+  },
+  {
+    "playerId": 215050,
+    "fullName": "Шермити",
+    "clubName": "Эвертон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.9,
+    "fp_last": 3.0
+  },
+  {
+    "playerId": 215049,
+    "fullName": "Натан Паттерсон",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 14.0
+  },
+  {
+    "playerId": 215046,
+    "fullName": "Армстронг",
+    "clubName": "Эвертон",
+    "position": "MID",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215045,
+    "fullName": "Трэверс",
+    "clubName": "Эвертон",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215044,
+    "fullName": "Тайрер",
+    "clubName": "Эвертон",
+    "position": "GK",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215043,
+    "fullName": "Коулмэн",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 1.2,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 215042,
+    "fullName": "Азну",
+    "clubName": "Эвертон",
+    "position": "DEF",
+    "league": "EPL",
+    "price": 4.0,
+    "popularity": 12.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216521,
+    "fullName": "Хит",
+    "clubName": "Эвертон",
+    "position": "FWD",
+    "league": "EPL",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
   },
   {
     "playerId": 215852,
@@ -12340,94 +12300,14 @@
     "fp_last": 158.0
   },
   {
-    "playerId": 216469,
-    "fullName": "Кин",
-    "clubName": "Фиорентина",
+    "playerId": 215851,
+    "fullName": "Скамакка",
+    "clubName": "Аталанта",
     "position": "FWD",
-    "league": "Serie A",
-    "price": 10.0,
-    "popularity": 3.5,
-    "fp_last": 161.0
-  },
-  {
-    "playerId": 215981,
-    "fullName": "Маркус Тюрам",
-    "clubName": "Интер",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 9.5,
-    "popularity": 9.8,
-    "fp_last": 142.0
-  },
-  {
-    "playerId": 216210,
-    "fullName": "де Брюйне",
-    "clubName": "Наполи",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 9.5,
-    "popularity": 13.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216504,
-    "fullName": "Дэвид",
-    "clubName": "Ювентус",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 9.0,
-    "popularity": 8.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216182,
-    "fullName": "Рафаэл Леау",
-    "clubName": "Милан",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 9.0,
-    "popularity": 6.3,
-    "fp_last": 137.0
-  },
-  {
-    "playerId": 215882,
-    "fullName": "Орсолини",
-    "clubName": "Болонья",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 9.0,
-    "popularity": 3.5,
-    "fp_last": 145.0
-  },
-  {
-    "playerId": 216331,
-    "fullName": "Дибала",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 9.0,
-    "popularity": 3.5,
-    "fp_last": 93.0
-  },
-  {
-    "playerId": 216502,
-    "fullName": "Влахович",
-    "clubName": "Ювентус",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 8.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216126,
-    "fullName": "Дзакканьи",
-    "clubName": "Лацио",
-    "position": "MID",
     "league": "Serie A",
     "price": 8.5,
     "popularity": 0.7,
-    "fp_last": 138.0
+    "fp_last": 1.0
   },
   {
     "playerId": 215850,
@@ -12440,204 +12320,14 @@
     "fp_last": 129.0
   },
   {
-    "playerId": 215851,
-    "fullName": "Скамакка",
+    "playerId": 215849,
+    "fullName": "Эдерсон",
     "clubName": "Аталанта",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 8.5,
-    "popularity": 0.7,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 216503,
-    "fullName": "Йылдыз",
-    "clubName": "Ювентус",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 8.5,
-    "popularity": 11.2,
-    "fp_last": 130.0
-  },
-  {
-    "playerId": 216127,
-    "fullName": "Кастельянос",
-    "clubName": "Лацио",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 8.5,
-    "popularity": 1.4,
-    "fp_last": 111.0
-  },
-  {
-    "playerId": 215980,
-    "fullName": "Чалханоглу",
-    "clubName": "Интер",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 8.0,
-    "popularity": 1.4,
-    "fp_last": 103.0
-  },
-  {
-    "playerId": 216208,
-    "fullName": "Ланг",
-    "clubName": "Наполи",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 8.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215979,
-    "fullName": "Барелла",
-    "clubName": "Интер",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 8.0,
-    "popularity": 0.7,
-    "fp_last": 118.0
-  },
-  {
-    "playerId": 216052,
-    "fullName": "Нико Пас",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 8.0,
-    "popularity": 5.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216181,
-    "fullName": "Сантьяго Хименес",
-    "clubName": "Милан",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 8.0,
-    "popularity": 4.9,
-    "fp_last": 39.0
-  },
-  {
-    "playerId": 215881,
-    "fullName": "Иммобиле",
-    "clubName": "Болонья",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 8.0,
-    "popularity": 4.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216209,
-    "fullName": "Политано",
-    "clubName": "Наполи",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 8.0,
-    "popularity": 0.7,
-    "fp_last": 118.0
-  },
-  {
-    "playerId": 216329,
-    "fullName": "Довбик",
-    "clubName": "Рома",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 8.0,
-    "popularity": 3.5,
-    "fp_last": 123.0
-  },
-  {
-    "playerId": 216330,
-    "fullName": "Соуле",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 8.0,
-    "popularity": 0.7,
-    "fp_last": 101.0
-  },
-  {
-    "playerId": 216401,
-    "fullName": "Сапата",
-    "clubName": "Торино",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 8.0,
-    "popularity": 1.4,
-    "fp_last": 29.0
-  },
-  {
-    "playerId": 215978,
-    "fullName": "Мхитарян",
-    "clubName": "Интер",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 0.0,
-    "fp_last": 98.0
-  },
-  {
-    "playerId": 216125,
-    "fullName": "Педро",
-    "clubName": "Лацио",
     "position": "MID",
     "league": "Serie A",
     "price": 7.5,
     "popularity": 2.1,
-    "fp_last": 88.0
-  },
-  {
-    "playerId": 216159,
-    "fullName": "Крстович",
-    "clubName": "Лечче",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 4.9,
-    "fp_last": 145.0
-  },
-  {
-    "playerId": 216206,
-    "fullName": "Замбо-Ангисса",
-    "clubName": "Наполи",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 1.4,
-    "fp_last": 145.0
-  },
-  {
-    "playerId": 216124,
-    "fullName": "Диа",
-    "clubName": "Лацио",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 0.7,
-    "fp_last": 108.0
-  },
-  {
-    "playerId": 216364,
-    "fullName": "Берарди",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216400,
-    "fullName": "Влашич",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 1.4,
-    "fp_last": 106.0
+    "fp_last": 120.0
   },
   {
     "playerId": 215848,
@@ -12650,154 +12340,14 @@
     "fp_last": 141.0
   },
   {
-    "playerId": 215849,
-    "fullName": "Эдерсон",
+    "playerId": 215847,
+    "fullName": "Пашалич",
     "clubName": "Аталанта",
     "position": "MID",
     "league": "Serie A",
-    "price": 7.5,
-    "popularity": 2.1,
-    "fp_last": 120.0
-  },
-  {
-    "playerId": 216365,
-    "fullName": "Лорьянте",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216180,
-    "fullName": "Салемакерс",
-    "clubName": "Милан",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216500,
-    "fullName": "Копмейнерс",
-    "clubName": "Ювентус",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 2.8,
-    "fp_last": 96.0
-  },
-  {
-    "playerId": 216123,
-    "fullName": "Гендузи",
-    "clubName": "Лацио",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 0.7,
-    "fp_last": 121.0
-  },
-  {
-    "playerId": 216207,
-    "fullName": "Лукка",
-    "clubName": "Наполи",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216399,
-    "fullName": "Адамс",
-    "clubName": "Торино",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 0.7,
-    "fp_last": 125.0
-  },
-  {
-    "playerId": 216051,
-    "fullName": "Мората",
-    "clubName": "Комо",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 3.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216050,
-    "fullName": "Ассане Диао",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216501,
-    "fullName": "Франсишку Консейсау",
-    "clubName": "Ювентус",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.5,
-    "popularity": 4.2,
-    "fp_last": 67.0
-  },
-  {
-    "playerId": 216122,
-    "fullName": "Нослин",
-    "clubName": "Лацио",
-    "position": "MID",
-    "league": "Serie A",
     "price": 7.0,
     "popularity": 1.4,
-    "fp_last": 50.0
-  },
-  {
-    "playerId": 216010,
-    "fullName": "Пикколи",
-    "clubName": "Кальяри",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 0.7,
-    "fp_last": 134.0
-  },
-  {
-    "playerId": 215947,
-    "fullName": "Френдруп",
-    "clubName": "Дженоа",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 0.7,
-    "fp_last": 116.0
-  },
-  {
-    "playerId": 215977,
-    "fullName": "Фраттези",
-    "clubName": "Интер",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 0.7,
-    "fp_last": 78.0
-  },
-  {
-    "playerId": 216328,
-    "fullName": "Эль-Шаарави",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 0.7,
-    "fp_last": 71.0
+    "fp_last": 93.0
   },
   {
     "playerId": 215846,
@@ -12810,216 +12360,6 @@
     "fp_last": 77.0
   },
   {
-    "playerId": 215847,
-    "fullName": "Пашалич",
-    "clubName": "Аталанта",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 1.4,
-    "fp_last": 93.0
-  },
-  {
-    "playerId": 216204,
-    "fullName": "Лоботка",
-    "clubName": "Наполи",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 0.7,
-    "fp_last": 92.0
-  },
-  {
-    "playerId": 215976,
-    "fullName": "Тареми",
-    "clubName": "Интер",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 1.4,
-    "fp_last": 45.0
-  },
-  {
-    "playerId": 215975,
-    "fullName": "Луис Энрике",
-    "clubName": "Интер",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216363,
-    "fullName": "Пинамонти",
-    "clubName": "Сассуоло",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216468,
-    "fullName": "Джеко",
-    "clubName": "Фиорентина",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 2.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216497,
-    "fullName": "Николас Гонсалес",
-    "clubName": "Ювентус",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 0.7,
-    "fp_last": 79.0
-  },
-  {
-    "playerId": 216498,
-    "fullName": "Локателли",
-    "clubName": "Ювентус",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 0.7,
-    "fp_last": 112.0
-  },
-  {
-    "playerId": 216499,
-    "fullName": "Кефрен Тюрам",
-    "clubName": "Ювентус",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 1.4,
-    "fp_last": 117.0
-  },
-  {
-    "playerId": 215880,
-    "fullName": "Кастро",
-    "clubName": "Болонья",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 0.7,
-    "fp_last": 104.0
-  },
-  {
-    "playerId": 216205,
-    "fullName": "Нерес",
-    "clubName": "Наполи",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 0.0,
-    "fp_last": 69.0
-  },
-  {
-    "playerId": 216327,
-    "fullName": "Кристанте",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 2.8,
-    "fp_last": 95.0
-  },
-  {
-    "playerId": 216177,
-    "fullName": "Модрич",
-    "clubName": "Милан",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 3.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216178,
-    "fullName": "Окафор",
-    "clubName": "Милан",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216467,
-    "fullName": "Гудмундссон",
-    "clubName": "Фиорентина",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 4.9,
-    "fp_last": 76.0
-  },
-  {
-    "playerId": 216179,
-    "fullName": "Чуквуэзе",
-    "clubName": "Милан",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 7.0,
-    "popularity": 2.1,
-    "fp_last": 61.0
-  },
-  {
-    "playerId": 216293,
-    "fullName": "Трамони",
-    "clubName": "Пиза",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216292,
-    "fullName": "Нзола",
-    "clubName": "Пиза",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216121,
-    "fullName": "Исаксен",
-    "clubName": "Лацио",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 90.0
-  },
-  {
-    "playerId": 216464,
-    "fullName": "Бельтран",
-    "clubName": "Фиорентина",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 97.0
-  },
-  {
-    "playerId": 216495,
-    "fullName": "Маккенни",
-    "clubName": "Ювентус",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 103.0
-  },
-  {
     "playerId": 215845,
     "fullName": "Самарджич",
     "clubName": "Аталанта",
@@ -13030,393 +12370,13 @@
     "fp_last": 51.0
   },
   {
-    "playerId": 216325,
-    "fullName": "Лоренцо Пеллегрини",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 62.0
-  },
-  {
-    "playerId": 216435,
-    "fullName": "Карлстрем",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 113.0
-  },
-  {
-    "playerId": 216158,
-    "fullName": "Соттиль",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216324,
-    "fullName": "Куадио Коне",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216048,
-    "fullName": "Кутроне",
-    "clubName": "Комо",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 2.1,
-    "fp_last": 98.0
-  },
-  {
-    "playerId": 215876,
-    "fullName": "Камбьяги",
-    "clubName": "Болонья",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 39.0
-  },
-  {
-    "playerId": 215877,
-    "fullName": "Одгор",
-    "clubName": "Болонья",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.7,
-    "fp_last": 81.0
-  },
-  {
-    "playerId": 215878,
-    "fullName": "Льюис Фергюсон",
-    "clubName": "Болонья",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 3.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215879,
-    "fullName": "Фройлер",
-    "clubName": "Болонья",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 116.0
-  },
-  {
-    "playerId": 216009,
-    "fullName": "Фолоруншо",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216120,
-    "fullName": "Деле-Баширу",
-    "clubName": "Лацио",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 1.4,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 216326,
-    "fullName": "Эван Фергюсон",
-    "clubName": "Рома",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 4.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216246,
-    "fullName": "Ондрейка",
-    "clubName": "Парма",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.7,
-    "fp_last": 41.0
-  },
-  {
-    "playerId": 215946,
-    "fullName": "Станчу",
-    "clubName": "Дженоа",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216465,
-    "fullName": "Зом",
-    "clubName": "Фиорентина",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215972,
-    "fullName": "Аслани",
-    "clubName": "Интер",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 2.1,
-    "fp_last": 56.0
-  },
-  {
-    "playerId": 215974,
-    "fullName": "Зелиньски",
-    "clubName": "Интер",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.7,
-    "fp_last": 59.0
-  },
-  {
-    "playerId": 215973,
-    "fullName": "Бонни",
-    "clubName": "Интер",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216173,
-    "fullName": "Адли",
-    "clubName": "Милан",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216046,
-    "fullName": "Белотти",
-    "clubName": "Комо",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 1.4,
-    "fp_last": 30.0
-  },
-  {
-    "playerId": 216049,
-    "fullName": "Кюн",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216047,
-    "fullName": "Да Кунья",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.7,
-    "fp_last": 104.0
-  },
-  {
-    "playerId": 216174,
-    "fullName": "Лофтус-Чик",
-    "clubName": "Милан",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.7,
-    "fp_last": 35.0
-  },
-  {
-    "playerId": 216175,
-    "fullName": "Риччи",
-    "clubName": "Милан",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216176,
-    "fullName": "Фофана",
-    "clubName": "Милан",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.7,
-    "fp_last": 108.0
-  },
-  {
-    "playerId": 216092,
-    "fullName": "Вандепютте",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216009,
-    "fullName": "Фолоруншо",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216158,
-    "fullName": "Соттиль",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216461,
-    "fullName": "Додо",
-    "clubName": "Фиорентина",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 2.1,
-    "fp_last": 121.0
-  },
-  {
-    "playerId": 216462,
-    "fullName": "Иконе",
-    "clubName": "Фиорентина",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216202,
-    "fullName": "Милинкович-Савич",
-    "clubName": "Наполи",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216245,
-    "fullName": "Эрнани",
-    "clubName": "Парма",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 60.0
-  },
-  {
-    "playerId": 216460,
-    "fullName": "Гозенс",
-    "clubName": "Фиорентина",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 5.6,
-    "fp_last": 119.0
-  },
-  {
-    "playerId": 216463,
-    "fullName": "Фаджоли",
-    "clubName": "Фиорентина",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 67.0
-  },
-  {
-    "playerId": 216493,
-    "fullName": "Ди Грегорио",
-    "clubName": "Ювентус",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 2.8,
-    "fp_last": 123.0
-  },
-  {
-    "playerId": 215839,
-    "fullName": "Белланова",
+    "playerId": 215844,
+    "fullName": "Эль-Билаль Туре",
     "clubName": "Аталанта",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 5.6,
-    "fp_last": 120.0
-  },
-  {
-    "playerId": 215840,
-    "fullName": "Брешианини",
-    "clubName": "Аталанта",
-    "position": "MID",
+    "position": "FWD",
     "league": "Serie A",
     "price": 6.0,
     "popularity": 1.4,
-    "fp_last": 61.0
-  },
-  {
-    "playerId": 215841,
-    "fullName": "Карнезекки",
-    "clubName": "Аталанта",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 4.2,
-    "fp_last": 130.0
-  },
-  {
-    "playerId": 215842,
-    "fullName": "Ибрагим Сулемана",
-    "clubName": "Аталанта",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.7,
     "fp_last": 0.0
   },
   {
@@ -13430,74 +12390,294 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 215844,
-    "fullName": "Эль-Билаль Туре",
+    "playerId": 215842,
+    "fullName": "Ибрагим Сулемана",
     "clubName": "Аталанта",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216244,
-    "fullName": "Джурич",
-    "clubName": "Парма",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 70.0
-  },
-  {
-    "playerId": 216118,
-    "fullName": "Нуну Тавареш",
-    "clubName": "Лацио",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 3.5,
-    "fp_last": 83.0
-  },
-  {
-    "playerId": 216491,
-    "fullName": "Бремер",
-    "clubName": "Ювентус",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 1.4,
-    "fp_last": 34.0
-  },
-  {
-    "playerId": 216322,
-    "fullName": "Анхелиньо",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 4.9,
-    "fp_last": 137.0
-  },
-  {
-    "playerId": 215873,
-    "fullName": "Бернардески",
-    "clubName": "Болонья",
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 2.8,
+    "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 215874,
-    "fullName": "Даллинга",
+    "playerId": 215841,
+    "fullName": "Карнезекки",
+    "clubName": "Аталанта",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 4.2,
+    "fp_last": 130.0
+  },
+  {
+    "playerId": 215840,
+    "fullName": "Брешианини",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 215839,
+    "fullName": "Белланова",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 5.6,
+    "fp_last": 120.0
+  },
+  {
+    "playerId": 215837,
+    "fullName": "Скальвини",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 215838,
+    "fullName": "Хин",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 83.0
+  },
+  {
+    "playerId": 215836,
+    "fullName": "Колашинац",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 71.0
+  },
+  {
+    "playerId": 215835,
+    "fullName": "Дзаппакоста",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 4.2,
+    "fp_last": 111.0
+  },
+  {
+    "playerId": 215834,
+    "fullName": "Коссуну",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 215833,
+    "fullName": "Джимшити",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1,
+    "fp_last": 96.0
+  },
+  {
+    "playerId": 215832,
+    "fullName": "Спортьелло",
+    "clubName": "Аталанта",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215831,
+    "fullName": "Палестра",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 9.0
+  },
+  {
+    "playerId": 215830,
+    "fullName": "Оливери",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215829,
+    "fullName": "Мендичино",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215828,
+    "fullName": "Сирен Диао",
+    "clubName": "Аталанта",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215827,
+    "fullName": "Джоване",
+    "clubName": "Аталанта",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215826,
+    "fullName": "Годфри",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 215825,
+    "fullName": "Баккер",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 215821,
+    "fullName": "Аханор",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 5.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215824,
+    "fullName": "Сасси",
+    "clubName": "Аталанта",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215823,
+    "fullName": "Росси",
+    "clubName": "Аталанта",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215822,
+    "fullName": "Джованни Бонфанти",
+    "clubName": "Аталанта",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215882,
+    "fullName": "Орсолини",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 9.0,
+    "popularity": 3.5,
+    "fp_last": 145.0
+  },
+  {
+    "playerId": 215881,
+    "fullName": "Иммобиле",
     "clubName": "Болонья",
     "position": "FWD",
     "league": "Serie A",
-    "price": 6.0,
+    "price": 8.0,
+    "popularity": 4.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215880,
+    "fullName": "Кастро",
+    "clubName": "Болонья",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7,
+    "fp_last": 104.0
+  },
+  {
+    "playerId": 215879,
+    "fullName": "Фройлер",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
     "popularity": 0.0,
-    "fp_last": 62.0
+    "fp_last": 116.0
+  },
+  {
+    "playerId": 215878,
+    "fullName": "Льюис Фергюсон",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 3.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215877,
+    "fullName": "Одгор",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7,
+    "fp_last": 81.0
+  },
+  {
+    "playerId": 215876,
+    "fullName": "Камбьяги",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0,
+    "fp_last": 39.0
   },
   {
     "playerId": 215875,
@@ -13510,72 +12690,222 @@
     "fp_last": 64.0
   },
   {
-    "playerId": 216434,
-    "fullName": "Ловрич",
-    "clubName": "Удинезе",
+    "playerId": 215874,
+    "fullName": "Даллинга",
+    "clubName": "Болонья",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 62.0
+  },
+  {
+    "playerId": 215873,
+    "fullName": "Бернардески",
+    "clubName": "Болонья",
     "position": "MID",
     "league": "Serie A",
     "price": 6.0,
-    "popularity": 1.4,
-    "fp_last": 91.0
+    "popularity": 2.8,
+    "fp_last": 0.0
   },
   {
-    "playerId": 216203,
-    "fullName": "Ррахмани",
-    "clubName": "Наполи",
+    "playerId": 215868,
+    "fullName": "Хуан Миранда",
+    "clubName": "Болонья",
     "position": "DEF",
     "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 159.0
-  },
-  {
-    "playerId": 216091,
-    "fullName": "Франко Васкес",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
+    "price": 5.5,
+    "popularity": 2.1,
     "fp_last": 0.0
   },
   {
-    "playerId": 216119,
-    "fullName": "Ровелла",
-    "clubName": "Лацио",
+    "playerId": 215872,
+    "fullName": "Фаббиан",
+    "clubName": "Болонья",
     "position": "MID",
     "league": "Serie A",
-    "price": 6.0,
+    "price": 5.5,
     "popularity": 0.7,
-    "fp_last": 88.0
+    "fp_last": 53.0
   },
   {
-    "playerId": 216117,
-    "fullName": "Катальди",
-    "clubName": "Лацио",
+    "playerId": 215871,
+    "fullName": "Скорупски",
+    "clubName": "Болонья",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 90.0
+  },
+  {
+    "playerId": 215870,
+    "fullName": "Побега",
+    "clubName": "Болонья",
     "position": "MID",
     "league": "Serie A",
-    "price": 6.0,
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 49.0
+  },
+  {
+    "playerId": 215869,
+    "fullName": "Никола Моро",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
     "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 216291,
-    "fullName": "Идрисса Туре",
-    "clubName": "Пиза",
-    "position": "MID",
+    "playerId": 215867,
+    "fullName": "Хольм",
+    "clubName": "Болонья",
+    "position": "DEF",
     "league": "Serie A",
-    "price": 6.0,
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 215866,
+    "fullName": "Пош",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
     "popularity": 0.0,
     "fp_last": 0.0
   },
   {
-    "playerId": 216290,
-    "fullName": "Морео",
-    "clubName": "Пиза",
+    "playerId": 215865,
+    "fullName": "Лукуми",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 80.0
+  },
+  {
+    "playerId": 215864,
+    "fullName": "Ликояннис",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 42.0
+  },
+  {
+    "playerId": 215863,
+    "fullName": "Карлссон",
+    "clubName": "Болонья",
     "position": "MID",
     "league": "Serie A",
-    "price": 6.0,
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215862,
+    "fullName": "Урбаньски",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215861,
+    "fullName": "Равалья",
+    "clubName": "Болонья",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 39.0
+  },
+  {
+    "playerId": 215860,
+    "fullName": "Оквонкво",
+    "clubName": "Болонья",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215859,
+    "fullName": "Казале",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 215858,
+    "fullName": "Де Сильвестри",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 46.0
+  },
+  {
+    "playerId": 215857,
+    "fullName": "Витик",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215853,
+    "fullName": "Бонифаци",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215856,
+    "fullName": "Эрлич",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 17.0
+  },
+  {
+    "playerId": 215855,
+    "fullName": "Корацца",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215854,
+    "fullName": "Михайло Илич",
+    "clubName": "Болонья",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
     "popularity": 0.7,
     "fp_last": 0.0
   },
@@ -13590,484 +12920,14 @@
     "fp_last": 59.0
   },
   {
-    "playerId": 216170,
-    "fullName": "Беннасер",
-    "clubName": "Милан",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 5.0
-  },
-  {
-    "playerId": 216172,
-    "fullName": "Яшари",
-    "clubName": "Милан",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216171,
-    "fullName": "Муса",
-    "clubName": "Милан",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 56.0
-  },
-  {
-    "playerId": 216396,
-    "fullName": "Нгонж",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216395,
-    "fullName": "Гинейтис",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 65.0
-  },
-  {
-    "playerId": 216398,
-    "fullName": "Симеоне",
-    "clubName": "Торино",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216397,
-    "fullName": "Санабрия",
-    "clubName": "Торино",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 55.0
-  },
-  {
-    "playerId": 215942,
-    "fullName": "Гренбек",
-    "clubName": "Дженоа",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215943,
-    "fullName": "Жуниор Мессиас",
-    "clubName": "Дженоа",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 35.0
-  },
-  {
-    "playerId": 215944,
-    "fullName": "Карбони",
-    "clubName": "Дженоа",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215945,
-    "fullName": "Малиновский",
-    "clubName": "Дженоа",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 16.0
-  },
-  {
-    "playerId": 216459,
-    "fullName": "Брекало",
-    "clubName": "Фиорентина",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216201,
-    "fullName": "Мерет",
-    "clubName": "Наполи",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 2.1,
-    "fp_last": 149.0
-  },
-  {
-    "playerId": 216200,
-    "fullName": "Ди Лоренцо",
-    "clubName": "Наполи",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 11.9,
-    "fp_last": 158.0
-  },
-  {
-    "playerId": 216494,
-    "fullName": "Камбьязо",
-    "clubName": "Ювентус",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 5.6,
-    "fp_last": 119.0
-  },
-  {
-    "playerId": 216492,
-    "fullName": "Гатти",
-    "clubName": "Ювентус",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 2.8,
-    "fp_last": 106.0
-  },
-  {
-    "playerId": 215966,
-    "fullName": "Бастони",
-    "clubName": "Интер",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 4.2,
-    "fp_last": 142.0
-  },
-  {
-    "playerId": 215967,
-    "fullName": "Димарко",
-    "clubName": "Интер",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 7.0,
-    "fp_last": 157.0
-  },
-  {
-    "playerId": 215968,
-    "fullName": "Думфрис",
-    "clubName": "Интер",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 10.5,
-    "fp_last": 123.0
-  },
-  {
-    "playerId": 215969,
-    "fullName": "Залевски",
-    "clubName": "Интер",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 41.0
-  },
-  {
-    "playerId": 215970,
-    "fullName": "Зоммер",
-    "clubName": "Интер",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 4.9,
-    "fp_last": 130.0
-  },
-  {
-    "playerId": 215971,
-    "fullName": "Сучич",
-    "clubName": "Интер",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216045,
-    "fullName": "Дувикас",
-    "clubName": "Комо",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 2.1,
-    "fp_last": 30.0
-  },
-  {
-    "playerId": 216044,
-    "fullName": "Батурина",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216199,
-    "fullName": "Буонджорно",
-    "clubName": "Наполи",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 90.0
-  },
-  {
-    "playerId": 216323,
-    "fullName": "Свилар",
-    "clubName": "Рома",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 1.4,
-    "fp_last": 154.0
-  },
-  {
-    "playerId": 216007,
-    "fullName": "Кылычсой",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216008,
-    "fullName": "Себастьяно Эспозито",
-    "clubName": "Кальяри",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216157,
-    "fullName": "Пьеротти",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 75.0
-  },
-  {
-    "playerId": 216155,
-    "fullName": "Кулибали",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216156,
-    "fullName": "Моренте",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.0,
-    "fp_last": 80.0
-  },
-  {
-    "playerId": 216362,
-    "fullName": "Торстведт",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216154,
-    "fullName": "Хельгасон",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 50.0
-  },
-  {
-    "playerId": 216360,
-    "fullName": "Мулаттьери",
-    "clubName": "Сассуоло",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216394,
-    "fullName": "Казадеи",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 41.0
-  },
-  {
-    "playerId": 215835,
-    "fullName": "Дзаппакоста",
-    "clubName": "Аталанта",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 4.2,
-    "fp_last": 111.0
-  },
-  {
-    "playerId": 216359,
-    "fullName": "Исмаэль Коне",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215868,
-    "fullName": "Хуан Миранда",
-    "clubName": "Болонья",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215869,
-    "fullName": "Никола Моро",
-    "clubName": "Болонья",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215870,
-    "fullName": "Побега",
-    "clubName": "Болонья",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 49.0
-  },
-  {
-    "playerId": 215871,
-    "fullName": "Скорупски",
-    "clubName": "Болонья",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 90.0
-  },
-  {
-    "playerId": 215872,
-    "fullName": "Фаббиан",
-    "clubName": "Болонья",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 53.0
-  },
-  {
-    "playerId": 216358,
-    "fullName": "Вольпато",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216315,
-    "fullName": "Бальданци",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 45.0
-  },
-  {
-    "playerId": 216320,
-    "fullName": "Франса",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216319,
-    "fullName": "Пизилли",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 55.0
-  },
-  {
-    "playerId": 215911,
-    "fullName": "Жиоване",
+    "playerId": 215914,
+    "fullName": "Сердар",
     "clubName": "Верона",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215912,
-    "fullName": "Москера",
-    "clubName": "Верона",
-    "position": "FWD",
+    "position": "MID",
     "league": "Serie A",
     "price": 5.5,
     "popularity": 0.7,
-    "fp_last": 63.0
+    "fp_last": 52.0
   },
   {
     "playerId": 215913,
@@ -14080,753 +12940,73 @@
     "fp_last": 73.0
   },
   {
-    "playerId": 215914,
-    "fullName": "Сердар",
+    "playerId": 215912,
+    "fullName": "Москера",
+    "clubName": "Верона",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 63.0
+  },
+  {
+    "playerId": 215911,
+    "fullName": "Жиоване",
+    "clubName": "Верона",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215908,
+    "fullName": "Сантьяго",
     "clubName": "Верона",
     "position": "MID",
     "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 216151,
-    "fullName": "Банда",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 24.0
-  },
-  {
-    "playerId": 216152,
-    "fullName": "Бериша",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
+    "price": 5.0,
+    "popularity": 1.4,
     "fp_last": 0.0
   },
   {
-    "playerId": 216169,
-    "fullName": "Эступиньян",
-    "clubName": "Милан",
+    "playerId": 215902,
+    "fullName": "Бернед",
+    "clubName": "Верона",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 23.0
+  },
+  {
+    "playerId": 215903,
+    "fullName": "Брадарич",
+    "clubName": "Верона",
     "position": "DEF",
     "league": "Serie A",
-    "price": 5.5,
-    "popularity": 4.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216391,
-    "fullName": "Абухляль",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216393,
-    "fullName": "Иван Илич",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
+    "price": 5.0,
     "popularity": 0.7,
-    "fp_last": 36.0
+    "fp_last": 57.0
   },
   {
-    "playerId": 216392,
-    "fullName": "Анджорин",
-    "clubName": "Торино",
+    "playerId": 215904,
+    "fullName": "Кастанос",
+    "clubName": "Верона",
     "position": "MID",
     "league": "Serie A",
-    "price": 5.5,
+    "price": 5.0,
     "popularity": 0.0,
-    "fp_last": 0.0
+    "fp_last": 35.0
   },
   {
-    "playerId": 215939,
-    "fullName": "Аарон Мартин",
-    "clubName": "Дженоа",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 2.8,
-    "fp_last": 119.0
-  },
-  {
-    "playerId": 215940,
-    "fullName": "Витинья",
-    "clubName": "Дженоа",
+    "playerId": 215905,
+    "fullName": "Лазанья",
+    "clubName": "Верона",
     "position": "FWD",
     "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 58.0
-  },
-  {
-    "playerId": 215941,
-    "fullName": "Торсбю",
-    "clubName": "Дженоа",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 2.1,
-    "fp_last": 65.0
-  },
-  {
-    "playerId": 216316,
-    "fullName": "Бове",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216321,
-    "fullName": "Эль-Энауи",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216318,
-    "fullName": "Ндика",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 3.5,
-    "fp_last": 132.0
-  },
-  {
-    "playerId": 216317,
-    "fullName": "Манчини",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 2.1,
-    "fp_last": 122.0
-  },
-  {
-    "playerId": 216003,
-    "fullName": "Адопо",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 81.0
-  },
-  {
-    "playerId": 216004,
-    "fullName": "Гаэтано",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 54.0
-  },
-  {
-    "playerId": 216005,
-    "fullName": "Дейола",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 56.0
-  },
-  {
-    "playerId": 216006,
-    "fullName": "Прати",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 20.0
-  },
-  {
-    "playerId": 216153,
-    "fullName": "Рамадани",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 65.0
-  },
-  {
-    "playerId": 216361,
-    "fullName": "Пьерини",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216168,
-    "fullName": "Меньян",
-    "clubName": "Милан",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 5.6,
-    "fp_last": 129.0
-  },
-  {
-    "playerId": 216457,
-    "fullName": "Раньери",
-    "clubName": "Фиорентина",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 118.0
-  },
-  {
-    "playerId": 215961,
-    "fullName": "Ачерби",
-    "clubName": "Интер",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 2.8,
-    "fp_last": 53.0
-  },
-  {
-    "playerId": 215962,
-    "fullName": "Дармиан",
-    "clubName": "Интер",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 110.0
-  },
-  {
-    "playerId": 215963,
-    "fullName": "Карлос Аугусто",
-    "clubName": "Интер",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 92.0
-  },
-  {
-    "playerId": 215964,
-    "fullName": "Павар",
-    "clubName": "Интер",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 59.0
-  },
-  {
-    "playerId": 215965,
-    "fullName": "Франческо Эспозито",
-    "clubName": "Интер",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216154,
-    "fullName": "Хельгасон",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 50.0
-  },
-  {
-    "playerId": 216455,
-    "fullName": "Де Хеа",
-    "clubName": "Фиорентина",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 9.8,
-    "fp_last": 133.0
-  },
-  {
-    "playerId": 216393,
-    "fullName": "Иван Илич",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 36.0
-  },
-  {
-    "playerId": 216003,
-    "fullName": "Адопо",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 81.0
-  },
-  {
-    "playerId": 216004,
-    "fullName": "Гаэтано",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 54.0
-  },
-  {
-    "playerId": 216005,
-    "fullName": "Дейола",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 56.0
-  },
-  {
-    "playerId": 216006,
-    "fullName": "Прати",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 20.0
-  },
-  {
-    "playerId": 216167,
-    "fullName": "Габбия",
-    "clubName": "Милан",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 93.0
-  },
-  {
-    "playerId": 216316,
-    "fullName": "Бове",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216315,
-    "fullName": "Бальданци",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 45.0
-  },
-  {
-    "playerId": 216319,
-    "fullName": "Пизилли",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 55.0
-  },
-  {
-    "playerId": 216317,
-    "fullName": "Манчини",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 2.1,
-    "fp_last": 122.0
-  },
-  {
-    "playerId": 216321,
-    "fullName": "Эль-Энауи",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216320,
-    "fullName": "Франса",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216359,
-    "fullName": "Исмаэль Коне",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216041,
-    "fullName": "Какре",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 47.0
-  },
-  {
-    "playerId": 216042,
-    "fullName": "Бенжамен Коне",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 3.0
-  },
-  {
-    "playerId": 216043,
-    "fullName": "Энгельхардт",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 51.0
-  },
-  {
-    "playerId": 216392,
-    "fullName": "Анджорин",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216391,
-    "fullName": "Абухляль",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216196,
-    "fullName": "Бекема",
-    "clubName": "Наполи",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216197,
-    "fullName": "Оливера",
-    "clubName": "Наполи",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 117.0
-  },
-  {
-    "playerId": 216429,
-    "fullName": "Байо",
-    "clubName": "Удинезе",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216430,
-    "fullName": "Бреннер",
-    "clubName": "Удинезе",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 24.0
-  },
-  {
-    "playerId": 216433,
-    "fullName": "Эккеленкамп",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 81.0
-  },
-  {
-    "playerId": 216432,
-    "fullName": "Санчес",
-    "clubName": "Удинезе",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 16.0
-  },
-  {
-    "playerId": 216087,
-    "fullName": "Бонаццоли",
-    "clubName": "Кремонезе",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216088,
-    "fullName": "Де Лука",
-    "clubName": "Кремонезе",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216089,
-    "fullName": "Дзербин",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216090,
-    "fullName": "Юнсен",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216454,
-    "fullName": "Барак",
-    "clubName": "Фиорентина",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 216487,
-    "fullName": "Дуглас Луис",
-    "clubName": "Ювентус",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 24.0
-  },
-  {
-    "playerId": 216489,
-    "fullName": "Костич",
-    "clubName": "Ювентус",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216488,
-    "fullName": "Калулу",
-    "clubName": "Ювентус",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 3.5,
-    "fp_last": 92.0
-  },
-  {
-    "playerId": 216113,
-    "fullName": "Весино",
-    "clubName": "Лацио",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 45.0
-  },
-  {
-    "playerId": 216114,
-    "fullName": "Ладзари",
-    "clubName": "Лацио",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 0.0,
-    "fp_last": 44.0
-  },
-  {
-    "playerId": 216115,
-    "fullName": "Марушич",
-    "clubName": "Лацио",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 90.0
-  },
-  {
-    "playerId": 216116,
-    "fullName": "Проведель",
-    "clubName": "Лацио",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 73.0
-  },
-  {
-    "playerId": 216313,
-    "fullName": "Челик",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 91.0
-  },
-  {
-    "playerId": 216311,
-    "fullName": "Дарбо",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
     "price": 5.0,
     "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215833,
-    "fullName": "Джимшити",
-    "clubName": "Аталанта",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 96.0
-  },
-  {
-    "playerId": 215834,
-    "fullName": "Коссуну",
-    "clubName": "Аталанта",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 31.0
-  },
-  {
-    "playerId": 215863,
-    "fullName": "Карлссон",
-    "clubName": "Болонья",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215864,
-    "fullName": "Ликояннис",
-    "clubName": "Болонья",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 42.0
-  },
-  {
-    "playerId": 215865,
-    "fullName": "Лукуми",
-    "clubName": "Болонья",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 80.0
-  },
-  {
-    "playerId": 215866,
-    "fullName": "Пош",
-    "clubName": "Болонья",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215867,
-    "fullName": "Хольм",
-    "clubName": "Болонья",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 216286,
-    "fullName": "Хойхольт",
-    "clubName": "Пиза",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
     "fp_last": 0.0
   },
   {
@@ -14850,16 +13030,6 @@
     "fp_last": 21.0
   },
   {
-    "playerId": 215908,
-    "fullName": "Сантьяго",
-    "clubName": "Верона",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
     "playerId": 215909,
     "fullName": "Тшатшуа",
     "clubName": "Верона",
@@ -14880,44 +13050,284 @@
     "fp_last": 26.0
   },
   {
-    "playerId": 216356,
-    "fullName": "Лука Моро",
-    "clubName": "Сассуоло",
-    "position": "FWD",
+    "playerId": 215899,
+    "fullName": "Фресе",
+    "clubName": "Верона",
+    "position": "DEF",
     "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.8,
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 18.0
+  },
+  {
+    "playerId": 215901,
+    "fullName": "Эбосс",
+    "clubName": "Верона",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
     "fp_last": 0.0
   },
   {
-    "playerId": 215929,
-    "fullName": "Хоан Васкес",
-    "clubName": "Дженоа",
-    "position": "DEF",
+    "playerId": 215900,
+    "fullName": "Шарлис",
+    "clubName": "Верона",
+    "position": "MID",
     "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 107.0
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
-    "playerId": 215930,
-    "fullName": "де Винтер",
-    "clubName": "Милан",
+    "playerId": 215898,
+    "fullName": "Нуньес",
+    "clubName": "Верона",
     "position": "DEF",
     "league": "Serie A",
-    "price": 5.0,
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215897,
+    "fullName": "Монтипо",
+    "clubName": "Верона",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.8,
+    "fp_last": 109.0
+  },
+  {
+    "playerId": 215896,
+    "fullName": "Митрович",
+    "clubName": "Верона",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
     "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 215931,
-    "fullName": "Коломбо",
+    "playerId": 215895,
+    "fullName": "Ламбурд",
+    "clubName": "Верона",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 10.0
+  },
+  {
+    "playerId": 215894,
+    "fullName": "Крус",
+    "clubName": "Верона",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215893,
+    "fullName": "Каллон",
+    "clubName": "Верона",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215892,
+    "fullName": "Браф",
+    "clubName": "Верона",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215891,
+    "fullName": "Аджайи",
+    "clubName": "Верона",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 4.9,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 215883,
+    "fullName": "Валентини",
+    "clubName": "Верона",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.8,
+    "fp_last": 32.0
+  },
+  {
+    "playerId": 215890,
+    "fullName": "Тоньоло",
+    "clubName": "Верона",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215889,
+    "fullName": "Слотсагер",
+    "clubName": "Верона",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215888,
+    "fullName": "Перилли",
+    "clubName": "Верона",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 215887,
+    "fullName": "Ойегоке",
+    "clubName": "Верона",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 3.0
+  },
+  {
+    "playerId": 215886,
+    "fullName": "Магро",
+    "clubName": "Верона",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215885,
+    "fullName": "Курти",
+    "clubName": "Верона",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215884,
+    "fullName": "Калабрезе",
+    "clubName": "Верона",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215947,
+    "fullName": "Френдруп",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7,
+    "fp_last": 116.0
+  },
+  {
+    "playerId": 215946,
+    "fullName": "Станчу",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215945,
+    "fullName": "Малиновский",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 16.0
+  },
+  {
+    "playerId": 215944,
+    "fullName": "Карбони",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215943,
+    "fullName": "Жуниор Мессиас",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 35.0
+  },
+  {
+    "playerId": 215942,
+    "fullName": "Гренбек",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215941,
+    "fullName": "Торсбю",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.1,
+    "fp_last": 65.0
+  },
+  {
+    "playerId": 215940,
+    "fullName": "Витинья",
     "clubName": "Дженоа",
     "position": "FWD",
     "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 0.0
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 58.0
+  },
+  {
+    "playerId": 215939,
+    "fullName": "Аарон Мартин",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.8,
+    "fp_last": 119.0
   },
   {
     "playerId": 215932,
@@ -14930,33 +13340,23 @@
     "fp_last": 114.0
   },
   {
-    "playerId": 215933,
-    "fullName": "Мазини",
+    "playerId": 215938,
+    "fullName": "Эхатор",
+    "clubName": "Дженоа",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 35.0
+  },
+  {
+    "playerId": 215937,
+    "fullName": "Эллертссон",
     "clubName": "Дженоа",
     "position": "MID",
     "league": "Serie A",
     "price": 5.0,
     "popularity": 0.0,
-    "fp_last": 57.0
-  },
-  {
-    "playerId": 215934,
-    "fullName": "Пападопулос",
-    "clubName": "Дженоа",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215935,
-    "fullName": "Фини",
-    "clubName": "Дженоа",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
     "fp_last": 0.0
   },
   {
@@ -14970,8 +13370,18 @@
     "fp_last": 32.0
   },
   {
-    "playerId": 215937,
-    "fullName": "Эллертссон",
+    "playerId": 215935,
+    "fullName": "Фини",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215934,
+    "fullName": "Пападопулос",
     "clubName": "Дженоа",
     "position": "MID",
     "league": "Serie A",
@@ -14980,979 +13390,69 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 215938,
-    "fullName": "Эхатор",
+    "playerId": 215933,
+    "fullName": "Мазини",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 57.0
+  },
+  {
+    "playerId": 215931,
+    "fullName": "Коломбо",
     "clubName": "Дженоа",
     "position": "FWD",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 35.0
+    "popularity": 2.1,
+    "fp_last": 0.0
   },
   {
-    "playerId": 216164,
-    "fullName": "Павлович",
-    "clubName": "Милан",
+    "playerId": 215929,
+    "fullName": "Хоан Васкес",
+    "clubName": "Дженоа",
     "position": "DEF",
     "league": "Serie A",
     "price": 5.0,
-    "popularity": 4.2,
+    "popularity": 1.4,
+    "fp_last": 107.0
+  },
+  {
+    "playerId": 215928,
+    "fullName": "Эстигор",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215927,
+    "fullName": "Сабелли",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
     "fp_last": 75.0
   },
   {
-    "playerId": 215996,
-    "fullName": "Винчигерра",
-    "clubName": "Кальяри",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215997,
-    "fullName": "Дзортеа",
-    "clubName": "Кальяри",
+    "playerId": 215926,
+    "fullName": "Нортон-Каффи",
+    "clubName": "Дженоа",
     "position": "DEF",
     "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 112.0
-  },
-  {
-    "playerId": 215998,
-    "fullName": "Лувумбу",
-    "clubName": "Кальяри",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
+    "price": 4.5,
     "popularity": 0.7,
-    "fp_last": 58.0
-  },
-  {
-    "playerId": 215999,
-    "fullName": "Маццителли",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216000,
-    "fullName": "Паволетти",
-    "clubName": "Кальяри",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 30.0
-  },
-  {
-    "playerId": 216001,
-    "fullName": "Рог",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216002,
-    "fullName": "Феличи",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 40.0
-  },
-  {
-    "playerId": 216166,
-    "fullName": "Алехандро Хименес",
-    "clubName": "Милан",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 43.0
-  },
-  {
-    "playerId": 216314,
-    "fullName": "Эрмосо",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 4.0
-  },
-  {
-    "playerId": 216357,
-    "fullName": "Фадера",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216355,
-    "fullName": "Гион",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216354,
-    "fullName": "Болока",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216353,
-    "fullName": "Альварес",
-    "clubName": "Сассуоло",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216033,
-    "fullName": "Алли",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.8,
-    "fp_last": -2.0
-  },
-  {
-    "playerId": 216034,
-    "fullName": "Бюте",
-    "clubName": "Комо",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 3.5,
-    "fp_last": 59.0
-  },
-  {
-    "playerId": 216035,
-    "fullName": "Войвода",
-    "clubName": "Комо",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 73.0
-  },
-  {
-    "playerId": 216036,
-    "fullName": "Гольданига",
-    "clubName": "Комо",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 68.0
-  },
-  {
-    "playerId": 216037,
-    "fullName": "Кемпф",
-    "clubName": "Комо",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 66.0
-  },
-  {
-    "playerId": 216038,
-    "fullName": "Перроне",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 65.0
-  },
-  {
-    "playerId": 216039,
-    "fullName": "Серджи Роберто",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
     "fp_last": 15.0
   },
   {
-    "playerId": 216040,
-    "fullName": "Черри",
-    "clubName": "Комо",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 5.0
-  },
-  {
-    "playerId": 216312,
-    "fullName": "Сольбаккен",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216165,
-    "fullName": "Томори",
-    "clubName": "Милан",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 46.0
-  },
-  {
-    "playerId": 216384,
-    "fullName": "Бираги",
-    "clubName": "Торино",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 54.0
-  },
-  {
-    "playerId": 216388,
-    "fullName": "Мазина",
-    "clubName": "Торино",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 71.0
-  },
-  {
-    "playerId": 216387,
-    "fullName": "Лазаро",
-    "clubName": "Торино",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 91.0
-  },
-  {
-    "playerId": 216386,
-    "fullName": "Коко",
-    "clubName": "Торино",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 93.0
-  },
-  {
-    "playerId": 216390,
-    "fullName": "Нджи",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 20.0
-  },
-  {
-    "playerId": 216389,
-    "fullName": "Марипан",
-    "clubName": "Торино",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 71.0
-  },
-  {
-    "playerId": 215999,
-    "fullName": "Маццителли",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216000,
-    "fullName": "Паволетти",
-    "clubName": "Кальяри",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 30.0
-  },
-  {
-    "playerId": 216001,
-    "fullName": "Рог",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216002,
-    "fullName": "Феличи",
-    "clubName": "Кальяри",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 40.0
-  },
-  {
-    "playerId": 216033,
-    "fullName": "Алли",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.8,
-    "fp_last": -2.0
-  },
-  {
-    "playerId": 216034,
-    "fullName": "Бюте",
-    "clubName": "Комо",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 3.5,
-    "fp_last": 59.0
-  },
-  {
-    "playerId": 216035,
-    "fullName": "Войвода",
-    "clubName": "Комо",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 73.0
-  },
-  {
-    "playerId": 216036,
-    "fullName": "Гольданига",
-    "clubName": "Комо",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 68.0
-  },
-  {
-    "playerId": 216037,
-    "fullName": "Кемпф",
-    "clubName": "Комо",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 66.0
-  },
-  {
-    "playerId": 216038,
-    "fullName": "Перроне",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 65.0
-  },
-  {
-    "playerId": 216039,
-    "fullName": "Серджи Роберто",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 15.0
-  },
-  {
-    "playerId": 216040,
-    "fullName": "Черри",
-    "clubName": "Комо",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 5.0
-  },
-  {
-    "playerId": 216313,
-    "fullName": "Челик",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 91.0
-  },
-  {
-    "playerId": 216312,
-    "fullName": "Сольбаккен",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216314,
-    "fullName": "Эрмосо",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 4.0
-  },
-  {
-    "playerId": 216311,
-    "fullName": "Дарбо",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216310,
-    "fullName": "Гиларди",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216284,
-    "fullName": "Мейстер",
-    "clubName": "Пиза",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216079,
-    "fullName": "Афена-Гьян",
-    "clubName": "Кремонезе",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216080,
-    "fullName": "Бондо",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216081,
-    "fullName": "Грасси",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216082,
-    "fullName": "Дзанимаккья",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216083,
-    "fullName": "Кастаньетти",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216084,
-    "fullName": "Коллоколо",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216085,
-    "fullName": "Окереке",
-    "clubName": "Кремонезе",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216086,
-    "fullName": "Пикель",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216390,
-    "fullName": "Нджи",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 20.0
-  },
-  {
-    "playerId": 216449,
-    "fullName": "Монтенегро",
-    "clubName": "Фиорентина",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216355,
-    "fullName": "Гион",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216354,
-    "fullName": "Болока",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216357,
-    "fullName": "Фадера",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216356,
-    "fullName": "Лука Моро",
-    "clubName": "Сассуоло",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216106,
-    "fullName": "Белаэн",
-    "clubName": "Лацио",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 61.0
-  },
-  {
-    "playerId": 216107,
-    "fullName": "Канчельери",
-    "clubName": "Лацио",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216108,
-    "fullName": "Мандас",
-    "clubName": "Лацио",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 35.0
-  },
-  {
-    "playerId": 216109,
-    "fullName": "Лука Пеллегрини",
-    "clubName": "Лацио",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 54.0
-  },
-  {
-    "playerId": 216110,
-    "fullName": "Романьоли",
-    "clubName": "Лацио",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 72.0
-  },
-  {
-    "playerId": 216111,
-    "fullName": "Серра",
-    "clubName": "Лацио",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216112,
-    "fullName": "Хила",
-    "clubName": "Лацио",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 82.0
-  },
-  {
-    "playerId": 216452,
-    "fullName": "Ричардсон",
-    "clubName": "Фиорентина",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 44.0
-  },
-  {
-    "playerId": 216279,
-    "fullName": "Акинсанмиро",
-    "clubName": "Пиза",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216427,
-    "fullName": "Миллер",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216426,
-    "fullName": "Атта",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 41.0
-  },
-  {
-    "playerId": 216144,
-    "fullName": "Галло",
-    "clubName": "Лечче",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 91.0
-  },
-  {
-    "playerId": 216145,
-    "fullName": "Жослен",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 11.0
-  },
-  {
-    "playerId": 216146,
-    "fullName": "Камарда",
-    "clubName": "Лечче",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216147,
-    "fullName": "Мале",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216148,
-    "fullName": "Пьерре",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 53.0
-  },
-  {
-    "playerId": 216149,
-    "fullName": "Рафья",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 33.0
-  },
-  {
-    "playerId": 216150,
-    "fullName": "Фальконе",
-    "clubName": "Лечче",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 129.0
-  },
-  {
-    "playerId": 216428,
-    "fullName": "Пайеро",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 55.0
-  },
-  {
-    "playerId": 216164,
-    "fullName": "Павлович",
-    "clubName": "Милан",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 4.2,
-    "fp_last": 75.0
-  },
-  {
-    "playerId": 216165,
-    "fullName": "Томори",
-    "clubName": "Милан",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 46.0
-  },
-  {
-    "playerId": 216166,
-    "fullName": "Алехандро Хименес",
-    "clubName": "Милан",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 43.0
-  },
-  {
-    "playerId": 216283,
-    "fullName": "Марин",
-    "clubName": "Пиза",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216483,
-    "fullName": "Жоау Мариу",
-    "clubName": "Ювентус",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 2.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216482,
-    "fullName": "Артур",
-    "clubName": "Ювентус",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216486,
-    "fullName": "Савона",
-    "clubName": "Ювентус",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 80.0
-  },
-  {
-    "playerId": 216485,
-    "fullName": "Перин",
-    "clubName": "Ювентус",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 23.0
-  },
-  {
-    "playerId": 216484,
-    "fullName": "Келли",
-    "clubName": "Ювентус",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 38.0
-  },
-  {
-    "playerId": 216192,
-    "fullName": "Гилмор",
-    "clubName": "Наполи",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 53.0
-  },
-  {
-    "playerId": 216193,
-    "fullName": "Жезус",
-    "clubName": "Наполи",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 41.0
-  },
-  {
-    "playerId": 216194,
-    "fullName": "Маццокки",
-    "clubName": "Наполи",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 36.0
-  },
-  {
-    "playerId": 216195,
-    "fullName": "Шеддира",
-    "clubName": "Наполи",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 216282,
-    "fullName": "Вурал",
-    "clubName": "Пиза",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216281,
-    "fullName": "Виньято",
-    "clubName": "Пиза",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 5.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216305,
-    "fullName": "Керубини",
-    "clubName": "Рома",
+    "playerId": 215925,
+    "fullName": "Куэнка",
+    "clubName": "Дженоа",
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
@@ -15960,13 +13460,43 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 215827,
-    "fullName": "Джоване",
-    "clubName": "Аталанта",
+    "playerId": 215924,
+    "fullName": "Вольякко",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215923,
+    "fullName": "Вентурино",
+    "clubName": "Дженоа",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 14.0
+  },
+  {
+    "playerId": 215922,
+    "fullName": "Бохинен",
+    "clubName": "Дженоа",
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7,
+    "popularity": 2.1,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 215921,
+    "fullName": "Араму",
+    "clubName": "Дженоа",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 5.6,
     "fp_last": 0.0
   },
   {
@@ -15980,194 +13510,874 @@
     "fp_last": 4.0
   },
   {
-    "playerId": 215921,
-    "fullName": "Араму",
+    "playerId": 215916,
+    "fullName": "Зигрист",
     "clubName": "Дженоа",
-    "position": "MID",
+    "position": "GK",
     "league": "Serie A",
-    "price": 4.5,
-    "popularity": 5.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215922,
-    "fullName": "Бохинен",
-    "clubName": "Дженоа",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 2.1,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 215924,
-    "fullName": "Вольякко",
-    "clubName": "Дженоа",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215925,
-    "fullName": "Куэнка",
-    "clubName": "Дженоа",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215926,
-    "fullName": "Нортон-Каффи",
-    "clubName": "Дженоа",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 15.0
-  },
-  {
-    "playerId": 215927,
-    "fullName": "Сабелли",
-    "clubName": "Дженоа",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 75.0
-  },
-  {
-    "playerId": 215928,
-    "fullName": "Эстигор",
-    "clubName": "Дженоа",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216307,
-    "fullName": "Ренсх",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 21.0
-  },
-  {
-    "playerId": 216309,
-    "fullName": "Салах-Эддин",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
+    "price": 4.0,
     "popularity": 1.4,
-    "fp_last": 16.0
+    "fp_last": 9.0
   },
   {
-    "playerId": 216020,
-    "fullName": "Браунедер",
-    "clubName": "Комо",
+    "playerId": 215919,
+    "fullName": "Соммарива",
+    "clubName": "Дженоа",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 215918,
+    "fullName": "Отоа",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215917,
+    "fullName": "Маркандалли",
+    "clubName": "Дженоа",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215982,
+    "fullName": "Мартинес",
+    "clubName": "Интер",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 10.5,
+    "popularity": 10.5,
+    "fp_last": 131.0
+  },
+  {
+    "playerId": 215981,
+    "fullName": "Маркус Тюрам",
+    "clubName": "Интер",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 9.5,
+    "popularity": 9.8,
+    "fp_last": 142.0
+  },
+  {
+    "playerId": 215980,
+    "fullName": "Чалханоглу",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 1.4,
+    "fp_last": 103.0
+  },
+  {
+    "playerId": 215979,
+    "fullName": "Барелла",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 0.7,
+    "fp_last": 118.0
+  },
+  {
+    "playerId": 215978,
+    "fullName": "Мхитарян",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 0.0,
+    "fp_last": 98.0
+  },
+  {
+    "playerId": 215977,
+    "fullName": "Фраттези",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7,
+    "fp_last": 78.0
+  },
+  {
+    "playerId": 215976,
+    "fullName": "Тареми",
+    "clubName": "Интер",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 1.4,
+    "fp_last": 45.0
+  },
+  {
+    "playerId": 215975,
+    "fullName": "Луис Энрике",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215974,
+    "fullName": "Зелиньски",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7,
+    "fp_last": 59.0
+  },
+  {
+    "playerId": 215972,
+    "fullName": "Аслани",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 2.1,
+    "fp_last": 56.0
+  },
+  {
+    "playerId": 215973,
+    "fullName": "Бонни",
+    "clubName": "Интер",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215971,
+    "fullName": "Сучич",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215970,
+    "fullName": "Зоммер",
+    "clubName": "Интер",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 4.9,
+    "fp_last": 130.0
+  },
+  {
+    "playerId": 215969,
+    "fullName": "Залевски",
+    "clubName": "Интер",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 41.0
+  },
+  {
+    "playerId": 215968,
+    "fullName": "Думфрис",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 10.5,
+    "fp_last": 123.0
+  },
+  {
+    "playerId": 215967,
+    "fullName": "Димарко",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 7.0,
+    "fp_last": 157.0
+  },
+  {
+    "playerId": 215966,
+    "fullName": "Бастони",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 4.2,
+    "fp_last": 142.0
+  },
+  {
+    "playerId": 215965,
+    "fullName": "Франческо Эспозито",
+    "clubName": "Интер",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215964,
+    "fullName": "Павар",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 59.0
+  },
+  {
+    "playerId": 215963,
+    "fullName": "Карлос Аугусто",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 92.0
+  },
+  {
+    "playerId": 215962,
+    "fullName": "Дармиан",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 110.0
+  },
+  {
+    "playerId": 215961,
+    "fullName": "Ачерби",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.8,
+    "fp_last": 53.0
+  },
+  {
+    "playerId": 215960,
+    "fullName": "Жозеп Мартинес",
+    "clubName": "Интер",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 23.0
+  },
+  {
+    "playerId": 215959,
+    "fullName": "де Врей",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1,
+    "fp_last": 95.0
+  },
+  {
+    "playerId": 215958,
+    "fullName": "Биссек",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1,
+    "fp_last": 80.0
+  },
+  {
+    "playerId": 215957,
+    "fullName": "Камате",
+    "clubName": "Интер",
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
     "popularity": 0.0,
-    "fp_last": 7.0
+    "fp_last": 0.0
   },
   {
-    "playerId": 216021,
-    "fullName": "Валье",
-    "clubName": "Комо",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 28.0
-  },
-  {
-    "playerId": 216023,
-    "fullName": "Габриэллони",
-    "clubName": "Комо",
+    "playerId": 215956,
+    "fullName": "Жуберек",
+    "clubName": "Интер",
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
     "popularity": 0.0,
-    "fp_last": 21.0
+    "fp_last": 0.0
   },
   {
-    "playerId": 216024,
-    "fullName": "Джасим",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 216025,
-    "fullName": "Доссена",
-    "clubName": "Комо",
+    "playerId": 215948,
+    "fullName": "Ванхейсден",
+    "clubName": "Интер",
     "position": "DEF",
     "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 43.0
-  },
-  {
-    "playerId": 216026,
-    "fullName": "Керриган",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
+    "price": 4.0,
     "popularity": 0.0,
     "fp_last": 0.0
   },
   {
-    "playerId": 216028,
-    "fullName": "Маццалья",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216029,
-    "fullName": "Рази",
-    "clubName": "Комо",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216030,
-    "fullName": "Рамон",
-    "clubName": "Комо",
+    "playerId": 215955,
+    "fullName": "Фонтанароза",
+    "clubName": "Интер",
     "position": "DEF",
     "league": "Serie A",
-    "price": 4.5,
+    "price": 4.0,
     "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 216031,
-    "fullName": "Родригес",
-    "clubName": "Комо",
-    "position": "MID",
+    "playerId": 215954,
+    "fullName": "Тахо",
+    "clubName": "Интер",
+    "position": "GK",
     "league": "Serie A",
-    "price": 4.5,
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215953,
+    "fullName": "Стабиле",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
     "popularity": 1.4,
     "fp_last": 0.0
+  },
+  {
+    "playerId": 215952,
+    "fullName": "Ре Чеккони",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215951,
+    "fullName": "Паласиос",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215950,
+    "fullName": "Кокки",
+    "clubName": "Интер",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215949,
+    "fullName": "Ди Дженнаро",
+    "clubName": "Интер",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216010,
+    "fullName": "Пикколи",
+    "clubName": "Кальяри",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7,
+    "fp_last": 134.0
+  },
+  {
+    "playerId": 216009,
+    "fullName": "Фолоруншо",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216008,
+    "fullName": "Себастьяно Эспозито",
+    "clubName": "Кальяри",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216007,
+    "fullName": "Кылычсой",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216006,
+    "fullName": "Прати",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 20.0
+  },
+  {
+    "playerId": 216005,
+    "fullName": "Дейола",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 56.0
+  },
+  {
+    "playerId": 216004,
+    "fullName": "Гаэтано",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 54.0
+  },
+  {
+    "playerId": 216003,
+    "fullName": "Адопо",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 81.0
+  },
+  {
+    "playerId": 215997,
+    "fullName": "Дзортеа",
+    "clubName": "Кальяри",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 112.0
+  },
+  {
+    "playerId": 216002,
+    "fullName": "Феличи",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 40.0
+  },
+  {
+    "playerId": 216001,
+    "fullName": "Рог",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216000,
+    "fullName": "Паволетти",
+    "clubName": "Кальяри",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 30.0
+  },
+  {
+    "playerId": 215999,
+    "fullName": "Маццителли",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215998,
+    "fullName": "Лувумбу",
+    "clubName": "Кальяри",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 58.0
+  },
+  {
+    "playerId": 215996,
+    "fullName": "Винчигерра",
+    "clubName": "Кальяри",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215995,
+    "fullName": "Мина",
+    "clubName": "Кальяри",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 66.0
+  },
+  {
+    "playerId": 215994,
+    "fullName": "Луперто",
+    "clubName": "Кальяри",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 93.0
+  },
+  {
+    "playerId": 215993,
+    "fullName": "Каприле",
+    "clubName": "Кальяри",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 74.0
+  },
+  {
+    "playerId": 215992,
+    "fullName": "Кавуоти",
+    "clubName": "Кальяри",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215991,
+    "fullName": "Боррелли",
+    "clubName": "Кальяри",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215983,
+    "fullName": "Вероли",
+    "clubName": "Кальяри",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215990,
+    "fullName": "Чоччи",
+    "clubName": "Кальяри",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 215989,
+    "fullName": "Радунович",
+    "clubName": "Кальяри",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215988,
+    "fullName": "Пинтус",
+    "clubName": "Кальяри",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215987,
+    "fullName": "Оберт",
+    "clubName": "Кальяри",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 215986,
+    "fullName": "Идрисси",
+    "clubName": "Кальяри",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215985,
+    "fullName": "Ди Пардо",
+    "clubName": "Кальяри",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 215984,
+    "fullName": "Дзаппа",
+    "clubName": "Кальяри",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.8,
+    "fp_last": 79.0
+  },
+  {
+    "playerId": 216052,
+    "fullName": "Нико Пас",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 5.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216051,
+    "fullName": "Мората",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 3.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216050,
+    "fullName": "Ассане Диао",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216049,
+    "fullName": "Кюн",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216048,
+    "fullName": "Кутроне",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 2.1,
+    "fp_last": 98.0
+  },
+  {
+    "playerId": 216047,
+    "fullName": "Да Кунья",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7,
+    "fp_last": 104.0
+  },
+  {
+    "playerId": 216046,
+    "fullName": "Белотти",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 1.4,
+    "fp_last": 30.0
+  },
+  {
+    "playerId": 216045,
+    "fullName": "Дувикас",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 2.1,
+    "fp_last": 30.0
+  },
+  {
+    "playerId": 216044,
+    "fullName": "Батурина",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216043,
+    "fullName": "Энгельхардт",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 51.0
+  },
+  {
+    "playerId": 216041,
+    "fullName": "Какре",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 47.0
+  },
+  {
+    "playerId": 216042,
+    "fullName": "Бенжамен Коне",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 3.0
+  },
+  {
+    "playerId": 216040,
+    "fullName": "Черри",
+    "clubName": "Комо",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 216039,
+    "fullName": "Серджи Роберто",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 15.0
+  },
+  {
+    "playerId": 216038,
+    "fullName": "Перроне",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 65.0
+  },
+  {
+    "playerId": 216037,
+    "fullName": "Кемпф",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 66.0
+  },
+  {
+    "playerId": 216036,
+    "fullName": "Гольданига",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 68.0
+  },
+  {
+    "playerId": 216035,
+    "fullName": "Войвода",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 73.0
+  },
+  {
+    "playerId": 216034,
+    "fullName": "Бюте",
+    "clubName": "Комо",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 3.5,
+    "fp_last": 59.0
+  },
+  {
+    "playerId": 216033,
+    "fullName": "Алли",
+    "clubName": "Комо",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.8,
+    "fp_last": -2.0
   },
   {
     "playerId": 216032,
@@ -16180,124 +14390,14 @@
     "fp_last": 14.0
   },
   {
-    "playerId": 216308,
-    "fullName": "Романо",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216306,
-    "fullName": "Кумбула",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216304,
-    "fullName": "Абдельхамид",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 18.0
-  },
-  {
-    "playerId": 216067,
-    "fullName": "Ачелла",
-    "clubName": "Кремонезе",
+    "playerId": 216031,
+    "fullName": "Родригес",
+    "clubName": "Комо",
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
     "popularity": 1.4,
     "fp_last": 0.0
-  },
-  {
-    "playerId": 216068,
-    "fullName": "Баскиротто",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216069,
-    "fullName": "Брамбилла",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216070,
-    "fullName": "Бьянкетти",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216071,
-    "fullName": "Валоти",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216072,
-    "fullName": "Лордкипанидзе",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216073,
-    "fullName": "Мамона",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216074,
-    "fullName": "Миланезе",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216422,
-    "fullName": "Сава",
-    "clubName": "Удинезе",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 42.0
   },
   {
     "playerId": 216015,
@@ -16460,108 +14560,218 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216031,
-    "fullName": "Родригес",
+    "playerId": 216011,
+    "fullName": "Вигорито",
     "clubName": "Комо",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216014,
+    "fullName": "Феллипе Джек",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 4.0
+  },
+  {
+    "playerId": 216013,
+    "fullName": "Марко Сала",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216012,
+    "fullName": "Кассандро",
+    "clubName": "Комо",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216092,
+    "fullName": "Вандепютте",
+    "clubName": "Кремонезе",
     "position": "MID",
     "league": "Serie A",
-    "price": 4.5,
+    "price": 6.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216091,
+    "fullName": "Франко Васкес",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216090,
+    "fullName": "Юнсен",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216089,
+    "fullName": "Дзербин",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216088,
+    "fullName": "Де Лука",
+    "clubName": "Кремонезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216087,
+    "fullName": "Бонаццоли",
+    "clubName": "Кремонезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216083,
+    "fullName": "Кастаньетти",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216079,
+    "fullName": "Афена-Гьян",
+    "clubName": "Кремонезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216080,
+    "fullName": "Бондо",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216081,
+    "fullName": "Грасси",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216082,
+    "fullName": "Дзанимаккья",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216084,
+    "fullName": "Коллоколо",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216085,
+    "fullName": "Окереке",
+    "clubName": "Кремонезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
     "popularity": 1.4,
     "fp_last": 0.0
   },
   {
-    "playerId": 216032,
-    "fullName": "Смолчич",
-    "clubName": "Комо",
-    "position": "DEF",
+    "playerId": 216086,
+    "fullName": "Пикель",
+    "clubName": "Кремонезе",
+    "position": "MID",
     "league": "Serie A",
-    "price": 4.5,
+    "price": 5.0,
     "popularity": 0.0,
-    "fp_last": 14.0
+    "fp_last": 0.0
   },
   {
-    "playerId": 216425,
-    "fullName": "Эхизибуэ",
-    "clubName": "Удинезе",
-    "position": "DEF",
+    "playerId": 216073,
+    "fullName": "Мамона",
+    "clubName": "Кремонезе",
+    "position": "MID",
     "league": "Serie A",
     "price": 4.5,
     "popularity": 0.7,
-    "fp_last": 75.0
+    "fp_last": 0.0
   },
   {
-    "playerId": 216421,
-    "fullName": "Писарро",
-    "clubName": "Удинезе",
+    "playerId": 216078,
+    "fullName": "Тсаджу",
+    "clubName": "Кремонезе",
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.1,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 216420,
-    "fullName": "Петровски",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
     "popularity": 0.0,
     "fp_last": 0.0
   },
   {
-    "playerId": 216424,
-    "fullName": "Соле",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 49.0
-  },
-  {
-    "playerId": 216441,
-    "fullName": "Бьянко",
-    "clubName": "Фиорентина",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216443,
-    "fullName": "Куадио",
-    "clubName": "Фиорентина",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216442,
-    "fullName": "Инфантино",
-    "clubName": "Фиорентина",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216067,
-    "fullName": "Ачелла",
+    "playerId": 216077,
+    "fullName": "Филиппо Терраччано",
     "clubName": "Кремонезе",
-    "position": "MID",
+    "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 1.4,
+    "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 216068,
-    "fullName": "Баскиротто",
+    "playerId": 216076,
+    "fullName": "Пеццелла",
     "clubName": "Кремонезе",
     "position": "DEF",
     "league": "Serie A",
@@ -16570,8 +14780,38 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216069,
-    "fullName": "Брамбилла",
+    "playerId": 216075,
+    "fullName": "Насти",
+    "clubName": "Кремонезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216074,
+    "fullName": "Миланезе",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216072,
+    "fullName": "Лордкипанидзе",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216071,
+    "fullName": "Валоти",
     "clubName": "Кремонезе",
     "position": "MID",
     "league": "Serie A",
@@ -16590,8 +14830,8 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216071,
-    "fullName": "Валоти",
+    "playerId": 216069,
+    "fullName": "Брамбилла",
     "clubName": "Кремонезе",
     "position": "MID",
     "league": "Serie A",
@@ -16600,79 +14840,9 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216072,
-    "fullName": "Лордкипанидзе",
+    "playerId": 216068,
+    "fullName": "Баскиротто",
     "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216073,
-    "fullName": "Мамона",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216074,
-    "fullName": "Миланезе",
-    "clubName": "Кремонезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216075,
-    "fullName": "Насти",
-    "clubName": "Кремонезе",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216137,
-    "fullName": "Гильбер",
-    "clubName": "Лечче",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 76.0
-  },
-  {
-    "playerId": 216138,
-    "fullName": "Данилу Вейга",
-    "clubName": "Лечче",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 13.0
-  },
-  {
-    "playerId": 216140,
-    "fullName": "Мархвиньски",
-    "clubName": "Лечче",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 216141,
-    "fullName": "Ндаба",
-    "clubName": "Лечче",
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
@@ -16680,13 +14850,663 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216142,
-    "fullName": "Уден",
-    "clubName": "Лечче",
+    "playerId": 216067,
+    "fullName": "Ачелла",
+    "clubName": "Кремонезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216054,
+    "fullName": "Ацци",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 9.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216053,
+    "fullName": "Аудеро",
+    "clubName": "Кремонезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 14.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216055,
+    "fullName": "Барбьери",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 5.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216056,
+    "fullName": "Маловец",
+    "clubName": "Кремонезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216057,
+    "fullName": "Моретти",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216058,
+    "fullName": "Нава",
+    "clubName": "Кремонезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216059,
+    "fullName": "Павези",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216060,
+    "fullName": "Раванелли",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216061,
+    "fullName": "Роккетти",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216062,
+    "fullName": "Саро",
+    "clubName": "Кремонезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216063,
+    "fullName": "Серникола",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216064,
+    "fullName": "Флориани",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216065,
+    "fullName": "Фолино",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216066,
+    "fullName": "Чеккерини",
+    "clubName": "Кремонезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216127,
+    "fullName": "Кастельянос",
+    "clubName": "Лацио",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 8.5,
+    "popularity": 1.4,
+    "fp_last": 111.0
+  },
+  {
+    "playerId": 216126,
+    "fullName": "Дзакканьи",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.5,
+    "popularity": 0.7,
+    "fp_last": 138.0
+  },
+  {
+    "playerId": 216125,
+    "fullName": "Педро",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 2.1,
+    "fp_last": 88.0
+  },
+  {
+    "playerId": 216124,
+    "fullName": "Диа",
+    "clubName": "Лацио",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 0.7,
+    "fp_last": 108.0
+  },
+  {
+    "playerId": 216123,
+    "fullName": "Гендузи",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 0.7,
+    "fp_last": 121.0
+  },
+  {
+    "playerId": 216122,
+    "fullName": "Нослин",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 1.4,
+    "fp_last": 50.0
+  },
+  {
+    "playerId": 216121,
+    "fullName": "Исаксен",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0,
+    "fp_last": 90.0
+  },
+  {
+    "playerId": 216120,
+    "fullName": "Деле-Баширу",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 1.4,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 216119,
+    "fullName": "Ровелла",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 88.0
+  },
+  {
+    "playerId": 216117,
+    "fullName": "Катальди",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216118,
+    "fullName": "Нуну Тавареш",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 3.5,
+    "fp_last": 83.0
+  },
+  {
+    "playerId": 216116,
+    "fullName": "Проведель",
+    "clubName": "Лацио",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 73.0
+  },
+  {
+    "playerId": 216115,
+    "fullName": "Марушич",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 90.0
+  },
+  {
+    "playerId": 216114,
+    "fullName": "Ладзари",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 44.0
+  },
+  {
+    "playerId": 216113,
+    "fullName": "Весино",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 45.0
+  },
+  {
+    "playerId": 216110,
+    "fullName": "Романьоли",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 72.0
+  },
+  {
+    "playerId": 216112,
+    "fullName": "Хила",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1,
+    "fp_last": 82.0
+  },
+  {
+    "playerId": 216111,
+    "fullName": "Серра",
+    "clubName": "Лацио",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216109,
+    "fullName": "Лука Пеллегрини",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 54.0
+  },
+  {
+    "playerId": 216108,
+    "fullName": "Мандас",
+    "clubName": "Лацио",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 35.0
+  },
+  {
+    "playerId": 216107,
+    "fullName": "Канчельери",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216106,
+    "fullName": "Белаэн",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 216102,
+    "fullName": "Провстгор",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216096,
+    "fullName": "Башич",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216097,
+    "fullName": "Бертини",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216098,
+    "fullName": "Габаррон",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 19.0
+  },
+  {
+    "playerId": 216099,
+    "fullName": "Жиго",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 47.0
+  },
+  {
+    "playerId": 216100,
+    "fullName": "Муньос",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216101,
+    "fullName": "Пинелли",
+    "clubName": "Лацио",
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
     "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216103,
+    "fullName": "Руджери",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216104,
+    "fullName": "Фернандеш",
+    "clubName": "Лацио",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216105,
+    "fullName": "Хюсай",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 216093,
+    "fullName": "Каменович",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216095,
+    "fullName": "Фурланетто",
+    "clubName": "Лацио",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216094,
+    "fullName": "Фарес",
+    "clubName": "Лацио",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216159,
+    "fullName": "Крстович",
+    "clubName": "Лечче",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 4.9,
+    "fp_last": 145.0
+  },
+  {
+    "playerId": 216158,
+    "fullName": "Соттиль",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216157,
+    "fullName": "Пьеротти",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 75.0
+  },
+  {
+    "playerId": 216156,
+    "fullName": "Моренте",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 80.0
+  },
+  {
+    "playerId": 216155,
+    "fullName": "Кулибали",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216154,
+    "fullName": "Хельгасон",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 50.0
+  },
+  {
+    "playerId": 216153,
+    "fullName": "Рамадани",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 65.0
+  },
+  {
+    "playerId": 216152,
+    "fullName": "Бериша",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216151,
+    "fullName": "Банда",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 24.0
+  },
+  {
+    "playerId": 216144,
+    "fullName": "Галло",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1,
+    "fp_last": 91.0
+  },
+  {
+    "playerId": 216150,
+    "fullName": "Фальконе",
+    "clubName": "Лечче",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1,
+    "fp_last": 129.0
+  },
+  {
+    "playerId": 216149,
+    "fullName": "Рафья",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 216148,
+    "fullName": "Пьерре",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 53.0
+  },
+  {
+    "playerId": 216147,
+    "fullName": "Мале",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216146,
+    "fullName": "Камарда",
+    "clubName": "Лечче",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216145,
+    "fullName": "Жослен",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
     "fp_last": 11.0
   },
   {
@@ -16700,10 +15520,370 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216381,
-    "fullName": "Схюрс",
-    "clubName": "Торино",
+    "playerId": 216142,
+    "fullName": "Уден",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 11.0
+  },
+  {
+    "playerId": 216141,
+    "fullName": "Ндаба",
+    "clubName": "Лечче",
     "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216140,
+    "fullName": "Мархвиньски",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 216139,
+    "fullName": "Каба",
+    "clubName": "Лечче",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 16.0
+  },
+  {
+    "playerId": 216138,
+    "fullName": "Данилу Вейга",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 13.0
+  },
+  {
+    "playerId": 216137,
+    "fullName": "Гильбер",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 76.0
+  },
+  {
+    "playerId": 216136,
+    "fullName": "Гашпар",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 60.0
+  },
+  {
+    "playerId": 216135,
+    "fullName": "Аддо",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216128,
+    "fullName": "Борбей",
+    "clubName": "Лечче",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216134,
+    "fullName": "Себастьян Эспозито",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216133,
+    "fullName": "Фрюхтль",
+    "clubName": "Лечче",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216132,
+    "fullName": "Самооя",
+    "clubName": "Лечче",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216131,
+    "fullName": "Куасси",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216130,
+    "fullName": "Жан",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 36.0
+  },
+  {
+    "playerId": 216129,
+    "fullName": "Габриэл",
+    "clubName": "Лечче",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1,
+    "fp_last": 3.0
+  },
+  {
+    "playerId": 216183,
+    "fullName": "Пулишич",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 10.5,
+    "popularity": 10.5,
+    "fp_last": 161.0
+  },
+  {
+    "playerId": 216182,
+    "fullName": "Рафаэл Леау",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 9.0,
+    "popularity": 6.3,
+    "fp_last": 137.0
+  },
+  {
+    "playerId": 216181,
+    "fullName": "Сантьяго Хименес",
+    "clubName": "Милан",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 4.9,
+    "fp_last": 39.0
+  },
+  {
+    "playerId": 216180,
+    "fullName": "Салемакерс",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216179,
+    "fullName": "Чуквуэзе",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 2.1,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 216178,
+    "fullName": "Окафор",
+    "clubName": "Милан",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216177,
+    "fullName": "Модрич",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 3.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216176,
+    "fullName": "Фофана",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7,
+    "fp_last": 108.0
+  },
+  {
+    "playerId": 216175,
+    "fullName": "Риччи",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216174,
+    "fullName": "Лофтус-Чик",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7,
+    "fp_last": 35.0
+  },
+  {
+    "playerId": 216173,
+    "fullName": "Адли",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216171,
+    "fullName": "Муса",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 56.0
+  },
+  {
+    "playerId": 216172,
+    "fullName": "Яшари",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216170,
+    "fullName": "Беннасер",
+    "clubName": "Милан",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 216169,
+    "fullName": "Эступиньян",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 4.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216168,
+    "fullName": "Меньян",
+    "clubName": "Милан",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 5.6,
+    "fp_last": 129.0
+  },
+  {
+    "playerId": 216167,
+    "fullName": "Габбия",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 93.0
+  },
+  {
+    "playerId": 215930,
+    "fullName": "де Винтер",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216166,
+    "fullName": "Алехандро Хименес",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1,
+    "fp_last": 43.0
+  },
+  {
+    "playerId": 216165,
+    "fullName": "Томори",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 46.0
+  },
+  {
+    "playerId": 216164,
+    "fullName": "Павлович",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 4.2,
+    "fp_last": 75.0
+  },
+  {
+    "playerId": 216163,
+    "fullName": "Пьетро Терраччано",
+    "clubName": "Милан",
+    "position": "GK",
     "league": "Serie A",
     "price": 4.5,
     "popularity": 0.0,
@@ -16720,48 +15900,238 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216163,
-    "fullName": "Пьетро Терраччано",
+    "playerId": 216161,
+    "fullName": "Торрьяни",
     "clubName": "Милан",
     "position": "GK",
     "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
+    "price": 4.0,
+    "popularity": 1.4,
     "fp_last": 0.0
   },
   {
-    "playerId": 216186,
-    "fullName": "Амброзино",
+    "playerId": 216160,
+    "fullName": "Бартезаги",
+    "clubName": "Милан",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 4.2,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 216212,
+    "fullName": "Мактоминей",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 11.0,
+    "popularity": 9.1,
+    "fp_last": 184.0
+  },
+  {
+    "playerId": 216211,
+    "fullName": "Лукаку",
     "clubName": "Наполи",
     "position": "FWD",
     "league": "Serie A",
-    "price": 4.5,
-    "popularity": 4.9,
+    "price": 11.0,
+    "popularity": 10.5,
+    "fp_last": 151.0
+  },
+  {
+    "playerId": 216210,
+    "fullName": "де Брюйне",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 9.5,
+    "popularity": 13.3,
     "fp_last": 0.0
   },
   {
-    "playerId": 216187,
-    "fullName": "Вергара",
+    "playerId": 216209,
+    "fullName": "Политано",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 0.7,
+    "fp_last": 118.0
+  },
+  {
+    "playerId": 216208,
+    "fullName": "Ланг",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216207,
+    "fullName": "Лукка",
     "clubName": "Наполи",
     "position": "FWD",
     "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
+    "price": 7.5,
+    "popularity": 1.4,
     "fp_last": 0.0
   },
   {
-    "playerId": 216188,
-    "fullName": "Дзаноли",
+    "playerId": 216206,
+    "fullName": "Замбо-Ангисса",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 1.4,
+    "fp_last": 145.0
+  },
+  {
+    "playerId": 216205,
+    "fullName": "Нерес",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.0,
+    "fp_last": 69.0
+  },
+  {
+    "playerId": 216204,
+    "fullName": "Лоботка",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7,
+    "fp_last": 92.0
+  },
+  {
+    "playerId": 216203,
+    "fullName": "Ррахмани",
     "clubName": "Наполи",
     "position": "DEF",
     "league": "Serie A",
-    "price": 4.5,
+    "price": 6.0,
     "popularity": 0.0,
+    "fp_last": 159.0
+  },
+  {
+    "playerId": 216202,
+    "fullName": "Милинкович-Савич",
+    "clubName": "Наполи",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 216189,
-    "fullName": "Каюсте",
+    "playerId": 216201,
+    "fullName": "Мерет",
+    "clubName": "Наполи",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 2.1,
+    "fp_last": 149.0
+  },
+  {
+    "playerId": 216200,
+    "fullName": "Ди Лоренцо",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 11.9,
+    "fp_last": 158.0
+  },
+  {
+    "playerId": 216199,
+    "fullName": "Буонджорно",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 90.0
+  },
+  {
+    "playerId": 216198,
+    "fullName": "Спинаццола",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.1,
+    "fp_last": 84.0
+  },
+  {
+    "playerId": 216197,
+    "fullName": "Оливера",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 117.0
+  },
+  {
+    "playerId": 216196,
+    "fullName": "Бекема",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216195,
+    "fullName": "Шеддира",
+    "clubName": "Наполи",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 216194,
+    "fullName": "Маццокки",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 36.0
+  },
+  {
+    "playerId": 216193,
+    "fullName": "Жезус",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 41.0
+  },
+  {
+    "playerId": 216192,
+    "fullName": "Гилмор",
+    "clubName": "Наполи",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 53.0
+  },
+  {
+    "playerId": 216191,
+    "fullName": "Хаса",
     "clubName": "Наполи",
     "position": "MID",
     "league": "Serie A",
@@ -16780,14 +16150,244 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216191,
-    "fullName": "Хаса",
+    "playerId": 216189,
+    "fullName": "Каюсте",
     "clubName": "Наполи",
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
     "popularity": 0.7,
     "fp_last": 0.0
+  },
+  {
+    "playerId": 216188,
+    "fullName": "Дзаноли",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216187,
+    "fullName": "Вергара",
+    "clubName": "Наполи",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216186,
+    "fullName": "Амброзино",
+    "clubName": "Наполи",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 4.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216184,
+    "fullName": "Контини-Барановский",
+    "clubName": "Наполи",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216185,
+    "fullName": "Обаретин",
+    "clubName": "Наполи",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216246,
+    "fullName": "Ондрейка",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.7,
+    "fp_last": 41.0
+  },
+  {
+    "playerId": 216245,
+    "fullName": "Эрнани",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 60.0
+  },
+  {
+    "playerId": 216244,
+    "fullName": "Джурич",
+    "clubName": "Парма",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 70.0
+  },
+  {
+    "playerId": 216243,
+    "fullName": "Пеллегрино",
+    "clubName": "Парма",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 36.0
+  },
+  {
+    "playerId": 216242,
+    "fullName": "Кейта",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 216241,
+    "fullName": "Бенедычак",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 9.0
+  },
+  {
+    "playerId": 216240,
+    "fullName": "Альмквист",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 43.0
+  },
+  {
+    "playerId": 216231,
+    "fullName": "Бегич",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216232,
+    "fullName": "Бернабе",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 55.0
+  },
+  {
+    "playerId": 216233,
+    "fullName": "Валери",
+    "clubName": "Парма",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 110.0
+  },
+  {
+    "playerId": 216234,
+    "fullName": "Дель Прато",
+    "clubName": "Парма",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 94.0
+  },
+  {
+    "playerId": 216235,
+    "fullName": "Жужу",
+    "clubName": "Парма",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216236,
+    "fullName": "Ордоньес",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216237,
+    "fullName": "Судзуки",
+    "clubName": "Парма",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 107.0
+  },
+  {
+    "playerId": 216238,
+    "fullName": "Хадж Мохамед",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216239,
+    "fullName": "Шарпантье",
+    "clubName": "Парма",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 21.0
+  },
+  {
+    "playerId": 216230,
+    "fullName": "Эстевес",
+    "clubName": "Парма",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 19.0
+  },
+  {
+    "playerId": 216229,
+    "fullName": "Эно",
+    "clubName": "Парма",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 50.0
   },
   {
     "playerId": 216216,
@@ -16920,193 +16520,183 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216229,
-    "fullName": "Эно",
+    "playerId": 216213,
+    "fullName": "Аморан",
     "clubName": "Парма",
     "position": "DEF",
     "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 50.0
+    "price": 4.0,
+    "popularity": 9.8,
+    "fp_last": 0.0
   },
   {
-    "playerId": 216230,
-    "fullName": "Эстевес",
+    "playerId": 216215,
+    "fullName": "Ринальди",
     "clubName": "Парма",
-    "position": "MID",
+    "position": "GK",
     "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 19.0
-  },
-  {
-    "playerId": 216409,
-    "fullName": "Браво",
-    "clubName": "Удинезе",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 2.8,
-    "fp_last": 40.0
-  },
-  {
-    "playerId": 216408,
-    "fullName": "Балларини",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 2.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216411,
-    "fullName": "Де Паоли",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216413,
-    "fullName": "Кабаселе",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 49.0
-  },
-  {
-    "playerId": 216412,
-    "fullName": "Земура",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 46.0
-  },
-  {
-    "playerId": 216410,
-    "fullName": "Гогличидзе",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
+    "price": 4.0,
     "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 216414,
-    "fullName": "Абдулай Камара",
-    "clubName": "Удинезе",
-    "position": "MID",
+    "playerId": 216214,
+    "fullName": "Корви",
+    "clubName": "Парма",
+    "position": "GK",
     "league": "Serie A",
-    "price": 4.5,
+    "price": 4.0,
     "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 216423,
-    "fullName": "Саррага",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 37.0
-  },
-  {
-    "playerId": 216261,
-    "fullName": "Ангори",
-    "clubName": "Пиза",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216262,
-    "fullName": "Арена",
+    "playerId": 216293,
+    "fullName": "Трамони",
     "clubName": "Пиза",
     "position": "MID",
     "league": "Serie A",
-    "price": 4.5,
-    "popularity": 5.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216263,
-    "fullName": "Буффон",
-    "clubName": "Пиза",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
+    "price": 6.5,
     "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 216264,
-    "fullName": "Джани",
+    "playerId": 216292,
+    "fullName": "Нзола",
     "clubName": "Пиза",
     "position": "FWD",
     "league": "Serie A",
-    "price": 4.5,
-    "popularity": 2.8,
+    "price": 6.5,
+    "popularity": 2.1,
     "fp_last": 0.0
   },
   {
-    "playerId": 216265,
-    "fullName": "Дубицкас",
+    "playerId": 216291,
+    "fullName": "Идрисса Туре",
     "clubName": "Пиза",
-    "position": "FWD",
+    "position": "MID",
     "league": "Serie A",
-    "price": 4.5,
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216290,
+    "fullName": "Морео",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
     "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 216266,
-    "fullName": "Дурмуш",
+    "playerId": 216289,
+    "fullName": "Эбишер",
     "clubName": "Пиза",
     "position": "MID",
     "league": "Serie A",
-    "price": 4.5,
+    "price": 5.5,
     "popularity": 0.0,
     "fp_last": 0.0
   },
   {
-    "playerId": 216267,
-    "fullName": "Евшенак",
+    "playerId": 216288,
+    "fullName": "Млакар",
     "clubName": "Пиза",
     "position": "MID",
     "league": "Serie A",
-    "price": 4.5,
-    "popularity": 1.4,
+    "price": 5.5,
+    "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 216268,
-    "fullName": "Канестрелли",
+    "playerId": 216287,
+    "fullName": "Куадрадо",
     "clubName": "Пиза",
-    "position": "DEF",
+    "position": "MID",
     "league": "Serie A",
-    "price": 4.5,
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216282,
+    "fullName": "Вурал",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
     "popularity": 0.0,
     "fp_last": 0.0
   },
   {
-    "playerId": 216269,
-    "fullName": "Караччоло",
+    "playerId": 216279,
+    "fullName": "Акинсанмиро",
     "clubName": "Пиза",
-    "position": "DEF",
+    "position": "MID",
     "league": "Serie A",
-    "price": 4.5,
+    "price": 5.0,
     "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216280,
+    "fullName": "Николас Бонфанти",
+    "clubName": "Пиза",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216281,
+    "fullName": "Виньято",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216283,
+    "fullName": "Марин",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216284,
+    "fullName": "Мейстер",
+    "clubName": "Пиза",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216285,
+    "fullName": "Пиччинини",
+    "clubName": "Пиза",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216286,
+    "fullName": "Хойхольт",
+    "clubName": "Пиза",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
     "fp_last": 0.0
   },
   {
@@ -17120,28 +16710,38 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216271,
-    "fullName": "Лерис",
+    "playerId": 216278,
+    "fullName": "Шемпер",
+    "clubName": "Пиза",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216277,
+    "fullName": "Трдан",
     "clubName": "Пиза",
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7,
+    "popularity": 0.0,
     "fp_last": 0.0
   },
   {
-    "playerId": 216272,
-    "fullName": "Паванелло",
+    "playerId": 216276,
+    "fullName": "Този",
     "clubName": "Пиза",
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.7,
+    "popularity": 2.1,
     "fp_last": 0.0
   },
   {
-    "playerId": 216273,
-    "fullName": "Райчев",
+    "playerId": 216275,
+    "fullName": "Маттиа Сала",
     "clubName": "Пиза",
     "position": "MID",
     "league": "Serie A",
@@ -17160,8 +16760,8 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216275,
-    "fullName": "Маттиа Сала",
+    "playerId": 216273,
+    "fullName": "Райчев",
     "clubName": "Пиза",
     "position": "MID",
     "league": "Serie A",
@@ -17170,239 +16770,29 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216276,
-    "fullName": "Този",
-    "clubName": "Пиза",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216277,
-    "fullName": "Трдан",
-    "clubName": "Пиза",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216278,
-    "fullName": "Шемпер",
-    "clubName": "Пиза",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216419,
-    "fullName": "Пейичич",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216417,
-    "fullName": "Окойе",
-    "clubName": "Удинезе",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 2.8,
-    "fp_last": 72.0
-  },
-  {
-    "playerId": 216416,
-    "fullName": "Модешту",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 27.0
-  },
-  {
-    "playerId": 216415,
-    "fullName": "Хассан Камара",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 83.0
-  },
-  {
-    "playerId": 216304,
-    "fullName": "Абдельхамид",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 18.0
-  },
-  {
-    "playerId": 216305,
-    "fullName": "Керубини",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216306,
-    "fullName": "Кумбула",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216307,
-    "fullName": "Ренсх",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 21.0
-  },
-  {
-    "playerId": 216308,
-    "fullName": "Романо",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216276,
-    "fullName": "Този",
+    "playerId": 216272,
+    "fullName": "Паванелло",
     "clubName": "Пиза",
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.1,
+    "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 216277,
-    "fullName": "Трдан",
+    "playerId": 216271,
+    "fullName": "Лерис",
     "clubName": "Пиза",
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0,
+    "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 216278,
-    "fullName": "Шемпер",
+    "playerId": 216269,
+    "fullName": "Караччоло",
     "clubName": "Пиза",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216441,
-    "fullName": "Бьянко",
-    "clubName": "Фиорентина",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216304,
-    "fullName": "Абдельхамид",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 18.0
-  },
-  {
-    "playerId": 216305,
-    "fullName": "Керубини",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216306,
-    "fullName": "Кумбула",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216307,
-    "fullName": "Ренсх",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 21.0
-  },
-  {
-    "playerId": 216308,
-    "fullName": "Романо",
-    "clubName": "Рома",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216309,
-    "fullName": "Салах-Эддин",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 1.4,
-    "fp_last": 16.0
-  },
-  {
-    "playerId": 216443,
-    "fullName": "Куадио",
-    "clubName": "Фиорентина",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216341,
-    "fullName": "Дойг",
-    "clubName": "Сассуоло",
     "position": "DEF",
     "league": "Serie A",
     "price": 4.5,
@@ -17410,39 +16800,19 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216342,
-    "fullName": "Идзес",
-    "clubName": "Сассуоло",
+    "playerId": 216268,
+    "fullName": "Канестрелли",
+    "clubName": "Пиза",
     "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216343,
-    "fullName": "Калигара",
-    "clubName": "Сассуоло",
-    "position": "MID",
     "league": "Serie A",
     "price": 4.5,
     "popularity": 0.0,
     "fp_last": 0.0
   },
   {
-    "playerId": 216344,
-    "fullName": "Кнезович",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216345,
-    "fullName": "Липани",
-    "clubName": "Сассуоло",
+    "playerId": 216267,
+    "fullName": "Евшенак",
+    "clubName": "Пиза",
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
@@ -17450,19 +16820,9 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216346,
-    "fullName": "Одентал",
-    "clubName": "Сассуоло",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216347,
-    "fullName": "Еферсон Пас",
-    "clubName": "Сассуоло",
+    "playerId": 216266,
+    "fullName": "Дурмуш",
+    "clubName": "Пиза",
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
@@ -17470,299 +16830,29 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216348,
-    "fullName": "Пьераньоло",
-    "clubName": "Сассуоло",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216349,
-    "fullName": "Скьеллеруп",
-    "clubName": "Сассуоло",
+    "playerId": 216265,
+    "fullName": "Дубицкас",
+    "clubName": "Пиза",
     "position": "FWD",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216350,
-    "fullName": "Турати",
-    "clubName": "Сассуоло",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.5,
     "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 216351,
-    "fullName": "Чьерво",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216352,
-    "fullName": "Яннони",
-    "clubName": "Сассуоло",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216425,
-    "fullName": "Эхизибуэ",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 75.0
-  },
-  {
-    "playerId": 216479,
-    "fullName": "Ругани",
-    "clubName": "Ювентус",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216478,
-    "fullName": "Пьетрелли",
-    "clubName": "Ювентус",
+    "playerId": 216264,
+    "fullName": "Джани",
+    "clubName": "Пиза",
     "position": "FWD",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216477,
-    "fullName": "Кабаль",
-    "clubName": "Ювентус",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 19.0
-  },
-  {
-    "playerId": 216374,
-    "fullName": "Ди Марко",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216375,
-    "fullName": "Илкхан",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216376,
-    "fullName": "Исмайли",
-    "clubName": "Торино",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216377,
-    "fullName": "Педерсен",
-    "clubName": "Торино",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 216378,
-    "fullName": "Перчун",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 5.0
-  },
-  {
-    "playerId": 216379,
-    "fullName": "Раути",
-    "clubName": "Торино",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216380,
-    "fullName": "Савва",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216381,
-    "fullName": "Схюрс",
-    "clubName": "Торино",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216382,
-    "fullName": "Тамез",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 23.0
-  },
-  {
-    "playerId": 216383,
-    "fullName": "Чаммальикелла",
-    "clubName": "Торино",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 216476,
-    "fullName": "Аджич",
-    "clubName": "Ювентус",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 3.5,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 216424,
-    "fullName": "Соле",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 49.0
-  },
-  {
-    "playerId": 216423,
-    "fullName": "Саррага",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 37.0
-  },
-  {
-    "playerId": 216422,
-    "fullName": "Сава",
-    "clubName": "Удинезе",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 42.0
-  },
-  {
-    "playerId": 216408,
-    "fullName": "Балларини",
-    "clubName": "Удинезе",
-    "position": "MID",
     "league": "Serie A",
     "price": 4.5,
     "popularity": 2.8,
     "fp_last": 0.0
   },
   {
-    "playerId": 216409,
-    "fullName": "Браво",
-    "clubName": "Удинезе",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 2.8,
-    "fp_last": 40.0
-  },
-  {
-    "playerId": 216410,
-    "fullName": "Гогличидзе",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216411,
-    "fullName": "Де Паоли",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216412,
-    "fullName": "Земура",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 46.0
-  },
-  {
-    "playerId": 216413,
-    "fullName": "Кабаселе",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 49.0
-  },
-  {
-    "playerId": 216414,
-    "fullName": "Абдулай Камара",
-    "clubName": "Удинезе",
+    "playerId": 216263,
+    "fullName": "Буффон",
+    "clubName": "Пиза",
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
@@ -17770,333 +16860,23 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216415,
-    "fullName": "Хассан Камара",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 83.0
-  },
-  {
-    "playerId": 216416,
-    "fullName": "Модешту",
-    "clubName": "Удинезе",
+    "playerId": 216262,
+    "fullName": "Арена",
+    "clubName": "Пиза",
     "position": "MID",
     "league": "Serie A",
     "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 27.0
-  },
-  {
-    "playerId": 216417,
-    "fullName": "Окойе",
-    "clubName": "Удинезе",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 2.8,
-    "fp_last": 72.0
-  },
-  {
-    "playerId": 216418,
-    "fullName": "Пафунди",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 2.1,
-    "fp_last": 9.0
-  },
-  {
-    "playerId": 216419,
-    "fullName": "Пейичич",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216420,
-    "fullName": "Петровски",
-    "clubName": "Удинезе",
-    "position": "MID",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216421,
-    "fullName": "Писарро",
-    "clubName": "Удинезе",
-    "position": "FWD",
-    "league": "Serie A",
-    "price": 4.5,
-    "popularity": 2.1,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 215822,
-    "fullName": "Джованни Бонфанти",
-    "clubName": "Аталанта",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215856,
-    "fullName": "Эрлич",
-    "clubName": "Болонья",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 17.0
-  },
-  {
-    "playerId": 215890,
-    "fullName": "Тоньоло",
-    "clubName": "Верона",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215916,
-    "fullName": "Зигрист",
-    "clubName": "Дженоа",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 9.0
-  },
-  {
-    "playerId": 215917,
-    "fullName": "Маркандалли",
-    "clubName": "Дженоа",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 215918,
-    "fullName": "Отоа",
-    "clubName": "Дженоа",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216011,
-    "fullName": "Вигорито",
-    "clubName": "Комо",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 2.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216012,
-    "fullName": "Кассандро",
-    "clubName": "Комо",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216013,
-    "fullName": "Марко Сала",
-    "clubName": "Комо",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216014,
-    "fullName": "Феллипе Джек",
-    "clubName": "Комо",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 4.0
-  },
-  {
-    "playerId": 216053,
-    "fullName": "Аудеро",
-    "clubName": "Кремонезе",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 14.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216054,
-    "fullName": "Ацци",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 9.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216055,
-    "fullName": "Барбьери",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
     "popularity": 5.6,
     "fp_last": 0.0
   },
   {
-    "playerId": 216056,
-    "fullName": "Маловец",
-    "clubName": "Кремонезе",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216057,
-    "fullName": "Моретти",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216058,
-    "fullName": "Нава",
-    "clubName": "Кремонезе",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216059,
-    "fullName": "Павези",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216060,
-    "fullName": "Раванелли",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216061,
-    "fullName": "Роккетти",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216062,
-    "fullName": "Саро",
-    "clubName": "Кремонезе",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216063,
-    "fullName": "Серникола",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216064,
-    "fullName": "Флориани",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216213,
-    "fullName": "Аморан",
-    "clubName": "Парма",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 9.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216214,
-    "fullName": "Корви",
-    "clubName": "Парма",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216215,
-    "fullName": "Ринальди",
-    "clubName": "Парма",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216247,
-    "fullName": "Беруатто",
+    "playerId": 216261,
+    "fullName": "Ангори",
     "clubName": "Пиза",
     "position": "DEF",
     "league": "Serie A",
-    "price": 4.0,
-    "popularity": 3.5,
+    "price": 4.5,
+    "popularity": 0.7,
     "fp_last": 0.0
   },
   {
@@ -18110,460 +16890,10 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216249,
-    "fullName": "Гуаданьо",
-    "clubName": "Пиза",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216250,
-    "fullName": "Денун",
-    "clubName": "Пиза",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216251,
-    "fullName": "Калабрези",
-    "clubName": "Пиза",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216252,
-    "fullName": "Коппола",
-    "clubName": "Пиза",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216253,
-    "fullName": "Ливьери",
-    "clubName": "Пиза",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216254,
-    "fullName": "Лория",
-    "clubName": "Пиза",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216255,
-    "fullName": "Лузуарди",
-    "clubName": "Пиза",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216256,
-    "fullName": "Николас",
-    "clubName": "Пиза",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216257,
-    "fullName": "Рус",
-    "clubName": "Пиза",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216259,
-    "fullName": "Томаш Эштевеш",
-    "clubName": "Пиза",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216260,
-    "fullName": "Шапола",
-    "clubName": "Пиза",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216294,
-    "fullName": "Боер",
-    "clubName": "Рома",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 3.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216295,
-    "fullName": "Девис Васкес",
-    "clubName": "Рома",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216296,
-    "fullName": "Голлини",
-    "clubName": "Рома",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 19.0
-  },
-  {
-    "playerId": 216297,
-    "fullName": "Де Марци",
-    "clubName": "Рома",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216298,
-    "fullName": "Железный",
-    "clubName": "Рома",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216299,
-    "fullName": "Маркаччини",
-    "clubName": "Рома",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216300,
-    "fullName": "Нардин",
-    "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216058,
-    "fullName": "Нава",
-    "clubName": "Кремонезе",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216059,
-    "fullName": "Павези",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216060,
-    "fullName": "Раванелли",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216061,
-    "fullName": "Роккетти",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216062,
-    "fullName": "Саро",
-    "clubName": "Кремонезе",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216063,
-    "fullName": "Серникола",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216064,
-    "fullName": "Флориани",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216065,
-    "fullName": "Фолино",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216066,
-    "fullName": "Чеккерини",
-    "clubName": "Кремонезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216093,
-    "fullName": "Каменович",
-    "clubName": "Лацио",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216094,
-    "fullName": "Фарес",
-    "clubName": "Лацио",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216095,
-    "fullName": "Фурланетто",
-    "clubName": "Лацио",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216128,
-    "fullName": "Борбей",
-    "clubName": "Лечче",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 2.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216129,
-    "fullName": "Габриэл",
-    "clubName": "Лечче",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 2.1,
-    "fp_last": 3.0
-  },
-  {
-    "playerId": 216130,
-    "fullName": "Жан",
-    "clubName": "Лечче",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 36.0
-  },
-  {
-    "playerId": 216131,
-    "fullName": "Куасси",
-    "clubName": "Лечче",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216132,
-    "fullName": "Самооя",
-    "clubName": "Лечче",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216133,
-    "fullName": "Фрюхтль",
-    "clubName": "Лечче",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216134,
-    "fullName": "Себастьян Эспозито",
-    "clubName": "Лечче",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216160,
-    "fullName": "Бартезаги",
-    "clubName": "Милан",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 4.2,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 216161,
-    "fullName": "Торрьяни",
-    "clubName": "Милан",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216184,
-    "fullName": "Контини-Барановский",
-    "clubName": "Наполи",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216185,
-    "fullName": "Обаретин",
-    "clubName": "Наполи",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216213,
-    "fullName": "Аморан",
-    "clubName": "Парма",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 9.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216214,
-    "fullName": "Корви",
-    "clubName": "Парма",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216215,
-    "fullName": "Ринальди",
-    "clubName": "Парма",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
     "playerId": 216247,
     "fullName": "Беруатто",
     "clubName": "Пиза",
     "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 3.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216248,
-    "fullName": "Вукович",
-    "clubName": "Пиза",
-    "position": "GK",
     "league": "Serie A",
     "price": 4.0,
     "popularity": 3.5,
@@ -18690,6 +17020,286 @@
     "fp_last": 0.0
   },
   {
+    "playerId": 216331,
+    "fullName": "Дибала",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 9.0,
+    "popularity": 3.5,
+    "fp_last": 93.0
+  },
+  {
+    "playerId": 216330,
+    "fullName": "Соуле",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 0.7,
+    "fp_last": 101.0
+  },
+  {
+    "playerId": 216329,
+    "fullName": "Довбик",
+    "clubName": "Рома",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 3.5,
+    "fp_last": 123.0
+  },
+  {
+    "playerId": 216328,
+    "fullName": "Эль-Шаарави",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7,
+    "fp_last": 71.0
+  },
+  {
+    "playerId": 216327,
+    "fullName": "Кристанте",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 2.8,
+    "fp_last": 95.0
+  },
+  {
+    "playerId": 216326,
+    "fullName": "Эван Фергюсон",
+    "clubName": "Рома",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 4.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216325,
+    "fullName": "Лоренцо Пеллегрини",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0,
+    "fp_last": 62.0
+  },
+  {
+    "playerId": 216324,
+    "fullName": "Куадио Коне",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216323,
+    "fullName": "Свилар",
+    "clubName": "Рома",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4,
+    "fp_last": 154.0
+  },
+  {
+    "playerId": 216322,
+    "fullName": "Анхелиньо",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 4.9,
+    "fp_last": 137.0
+  },
+  {
+    "playerId": 216321,
+    "fullName": "Эль-Энауи",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216320,
+    "fullName": "Франса",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216319,
+    "fullName": "Пизилли",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 55.0
+  },
+  {
+    "playerId": 216318,
+    "fullName": "Ндика",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 3.5,
+    "fp_last": 132.0
+  },
+  {
+    "playerId": 216317,
+    "fullName": "Манчини",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.1,
+    "fp_last": 122.0
+  },
+  {
+    "playerId": 216316,
+    "fullName": "Бове",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216315,
+    "fullName": "Бальданци",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 45.0
+  },
+  {
+    "playerId": 216313,
+    "fullName": "Челик",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 91.0
+  },
+  {
+    "playerId": 216314,
+    "fullName": "Эрмосо",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 4.0
+  },
+  {
+    "playerId": 216312,
+    "fullName": "Сольбаккен",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216311,
+    "fullName": "Дарбо",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216310,
+    "fullName": "Гиларди",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216304,
+    "fullName": "Абдельхамид",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 18.0
+  },
+  {
+    "playerId": 216305,
+    "fullName": "Керубини",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216306,
+    "fullName": "Кумбула",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216307,
+    "fullName": "Ренсх",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 21.0
+  },
+  {
+    "playerId": 216308,
+    "fullName": "Романо",
+    "clubName": "Рома",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216309,
+    "fullName": "Салах-Эддин",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 16.0
+  },
+  {
     "playerId": 216294,
     "fullName": "Боер",
     "clubName": "Рома",
@@ -18700,28 +17310,48 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216295,
-    "fullName": "Девис Васкес",
+    "playerId": 216303,
+    "fullName": "Сангаре",
     "clubName": "Рома",
-    "position": "GK",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216302,
+    "fullName": "Реале",
+    "clubName": "Рома",
+    "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
     "popularity": 1.4,
     "fp_last": 0.0
   },
   {
-    "playerId": 216296,
-    "fullName": "Голлини",
+    "playerId": 216301,
+    "fullName": "Оливерас",
     "clubName": "Рома",
-    "position": "GK",
+    "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 19.0
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
-    "playerId": 216297,
-    "fullName": "Де Марци",
+    "playerId": 216300,
+    "fullName": "Нардин",
+    "clubName": "Рома",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216299,
+    "fullName": "Маркаччини",
     "clubName": "Рома",
     "position": "GK",
     "league": "Serie A",
@@ -18740,8 +17370,8 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216299,
-    "fullName": "Маркаччини",
+    "playerId": 216297,
+    "fullName": "Де Марци",
     "clubName": "Рома",
     "position": "GK",
     "league": "Serie A",
@@ -18750,43 +17380,273 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216300,
-    "fullName": "Нардин",
+    "playerId": 216296,
+    "fullName": "Голлини",
     "clubName": "Рома",
-    "position": "DEF",
+    "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
+    "popularity": 1.4,
+    "fp_last": 19.0
   },
   {
-    "playerId": 216301,
-    "fullName": "Оливерас",
+    "playerId": 216295,
+    "fullName": "Девис Васкес",
     "clubName": "Рома",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216302,
-    "fullName": "Реале",
-    "clubName": "Рома",
-    "position": "DEF",
+    "position": "GK",
     "league": "Serie A",
     "price": 4.0,
     "popularity": 1.4,
     "fp_last": 0.0
   },
   {
-    "playerId": 216303,
-    "fullName": "Сангаре",
-    "clubName": "Рома",
+    "playerId": 216365,
+    "fullName": "Лорьянте",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216364,
+    "fullName": "Берарди",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216363,
+    "fullName": "Пинамонти",
+    "clubName": "Сассуоло",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216362,
+    "fullName": "Торстведт",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216358,
+    "fullName": "Вольпато",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216359,
+    "fullName": "Исмаэль Коне",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216360,
+    "fullName": "Мулаттьери",
+    "clubName": "Сассуоло",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216361,
+    "fullName": "Пьерини",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216357,
+    "fullName": "Фадера",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216356,
+    "fullName": "Лука Моро",
+    "clubName": "Сассуоло",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216355,
+    "fullName": "Гион",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216354,
+    "fullName": "Болока",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216353,
+    "fullName": "Альварес",
+    "clubName": "Сассуоло",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216349,
+    "fullName": "Скьеллеруп",
+    "clubName": "Сассуоло",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216352,
+    "fullName": "Яннони",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216351,
+    "fullName": "Чьерво",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216350,
+    "fullName": "Турати",
+    "clubName": "Сассуоло",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216348,
+    "fullName": "Пьераньоло",
+    "clubName": "Сассуоло",
     "position": "DEF",
     "league": "Serie A",
-    "price": 4.0,
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216341,
+    "fullName": "Дойг",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216342,
+    "fullName": "Идзес",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
     "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216343,
+    "fullName": "Калигара",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216344,
+    "fullName": "Кнезович",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216345,
+    "fullName": "Липани",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216346,
+    "fullName": "Одентал",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216347,
+    "fullName": "Еферсон Пас",
+    "clubName": "Сассуоло",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
     "fp_last": 0.0
   },
   {
@@ -18800,38 +17660,28 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216333,
-    "fullName": "Дзакки",
+    "playerId": 216340,
+    "fullName": "Саталино",
     "clubName": "Сассуоло",
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7,
+    "popularity": 0.0,
     "fp_last": 0.0
   },
   {
-    "playerId": 216334,
-    "fullName": "Канде",
+    "playerId": 216339,
+    "fullName": "Руссо",
     "clubName": "Сассуоло",
-    "position": "DEF",
+    "position": "GK",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 0.7,
+    "popularity": 2.1,
     "fp_last": 0.0
   },
   {
-    "playerId": 216335,
-    "fullName": "Кевин Миранда",
-    "clubName": "Сассуоло",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216336,
-    "fullName": "Миссори",
+    "playerId": 216338,
+    "fullName": "Романья",
     "clubName": "Сассуоло",
     "position": "DEF",
     "league": "Serie A",
@@ -18850,8 +17700,8 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216338,
-    "fullName": "Романья",
+    "playerId": 216336,
+    "fullName": "Миссори",
     "clubName": "Сассуоло",
     "position": "DEF",
     "league": "Serie A",
@@ -18860,24 +17710,314 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216339,
-    "fullName": "Руссо",
+    "playerId": 216335,
+    "fullName": "Кевин Миранда",
     "clubName": "Сассуоло",
-    "position": "GK",
+    "position": "DEF",
     "league": "Serie A",
     "price": 4.0,
-    "popularity": 2.1,
+    "popularity": 1.4,
     "fp_last": 0.0
   },
   {
-    "playerId": 216340,
-    "fullName": "Саталино",
+    "playerId": 216334,
+    "fullName": "Канде",
+    "clubName": "Сассуоло",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216333,
+    "fullName": "Дзакки",
     "clubName": "Сассуоло",
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216401,
+    "fullName": "Сапата",
+    "clubName": "Торино",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 8.0,
+    "popularity": 1.4,
+    "fp_last": 29.0
+  },
+  {
+    "playerId": 216400,
+    "fullName": "Влашич",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 1.4,
+    "fp_last": 106.0
+  },
+  {
+    "playerId": 216399,
+    "fullName": "Адамс",
+    "clubName": "Торино",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 0.7,
+    "fp_last": 125.0
+  },
+  {
+    "playerId": 216398,
+    "fullName": "Симеоне",
+    "clubName": "Торино",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.0,
     "popularity": 0.0,
     "fp_last": 0.0
+  },
+  {
+    "playerId": 216397,
+    "fullName": "Санабрия",
+    "clubName": "Торино",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 55.0
+  },
+  {
+    "playerId": 216396,
+    "fullName": "Нгонж",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216395,
+    "fullName": "Гинейтис",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 65.0
+  },
+  {
+    "playerId": 216393,
+    "fullName": "Иван Илич",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 36.0
+  },
+  {
+    "playerId": 216391,
+    "fullName": "Абухляль",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216392,
+    "fullName": "Анджорин",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216394,
+    "fullName": "Казадеи",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 41.0
+  },
+  {
+    "playerId": 216384,
+    "fullName": "Бираги",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 54.0
+  },
+  {
+    "playerId": 216390,
+    "fullName": "Нджи",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 20.0
+  },
+  {
+    "playerId": 216389,
+    "fullName": "Марипан",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 71.0
+  },
+  {
+    "playerId": 216388,
+    "fullName": "Мазина",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 71.0
+  },
+  {
+    "playerId": 216387,
+    "fullName": "Лазаро",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 91.0
+  },
+  {
+    "playerId": 216386,
+    "fullName": "Коко",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 93.0
+  },
+  {
+    "playerId": 216385,
+    "fullName": "Исраэль",
+    "clubName": "Торино",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216383,
+    "fullName": "Чаммальикелла",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 216374,
+    "fullName": "Ди Марко",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216375,
+    "fullName": "Илкхан",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216376,
+    "fullName": "Исмайли",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216377,
+    "fullName": "Педерсен",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 216378,
+    "fullName": "Перчун",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 216379,
+    "fullName": "Раути",
+    "clubName": "Торино",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216380,
+    "fullName": "Савва",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216381,
+    "fullName": "Схюрс",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216382,
+    "fullName": "Тамез",
+    "clubName": "Торино",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 23.0
   },
   {
     "playerId": 216366,
@@ -18890,10 +18030,50 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216367,
-    "fullName": "Бьяне-Балько",
+    "playerId": 216373,
+    "fullName": "Сазонов",
     "clubName": "Торино",
     "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216372,
+    "fullName": "Попа",
+    "clubName": "Торино",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216371,
+    "fullName": "Палеари",
+    "clubName": "Торино",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 216370,
+    "fullName": "Маллен",
+    "clubName": "Торино",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216369,
+    "fullName": "Доннарумма",
+    "clubName": "Торино",
+    "position": "GK",
     "league": "Serie A",
     "price": 4.0,
     "popularity": 0.7,
@@ -18910,18 +18090,8 @@
     "fp_last": 15.0
   },
   {
-    "playerId": 216369,
-    "fullName": "Доннарумма",
-    "clubName": "Торино",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216370,
-    "fullName": "Маллен",
+    "playerId": 216367,
+    "fullName": "Бьяне-Балько",
     "clubName": "Торино",
     "position": "DEF",
     "league": "Serie A",
@@ -18930,34 +18100,284 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216371,
-    "fullName": "Палеари",
-    "clubName": "Торино",
+    "playerId": 216435,
+    "fullName": "Карлстрем",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0,
+    "fp_last": 113.0
+  },
+  {
+    "playerId": 216434,
+    "fullName": "Ловрич",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4,
+    "fp_last": 91.0
+  },
+  {
+    "playerId": 216433,
+    "fullName": "Эккеленкамп",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 81.0
+  },
+  {
+    "playerId": 216432,
+    "fullName": "Санчес",
+    "clubName": "Удинезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 16.0
+  },
+  {
+    "playerId": 216431,
+    "fullName": "Дэвис",
+    "clubName": "Удинезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 45.0
+  },
+  {
+    "playerId": 216430,
+    "fullName": "Бреннер",
+    "clubName": "Удинезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 24.0
+  },
+  {
+    "playerId": 216429,
+    "fullName": "Байо",
+    "clubName": "Удинезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216428,
+    "fullName": "Пайеро",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 55.0
+  },
+  {
+    "playerId": 216426,
+    "fullName": "Атта",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 41.0
+  },
+  {
+    "playerId": 216427,
+    "fullName": "Миллер",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216419,
+    "fullName": "Пейичич",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216425,
+    "fullName": "Эхизибуэ",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 75.0
+  },
+  {
+    "playerId": 216424,
+    "fullName": "Соле",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 49.0
+  },
+  {
+    "playerId": 216423,
+    "fullName": "Саррага",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 37.0
+  },
+  {
+    "playerId": 216422,
+    "fullName": "Сава",
+    "clubName": "Удинезе",
     "position": "GK",
     "league": "Serie A",
-    "price": 4.0,
+    "price": 4.5,
     "popularity": 0.0,
+    "fp_last": 42.0
+  },
+  {
+    "playerId": 216421,
+    "fullName": "Писарро",
+    "clubName": "Удинезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1,
     "fp_last": 2.0
   },
   {
-    "playerId": 216372,
-    "fullName": "Попа",
-    "clubName": "Торино",
-    "position": "GK",
+    "playerId": 216420,
+    "fullName": "Петровски",
+    "clubName": "Удинезе",
+    "position": "MID",
     "league": "Serie A",
-    "price": 4.0,
-    "popularity": 2.1,
+    "price": 4.5,
+    "popularity": 0.0,
     "fp_last": 0.0
   },
   {
-    "playerId": 216373,
-    "fullName": "Сазонов",
-    "clubName": "Торино",
+    "playerId": 216418,
+    "fullName": "Пафунди",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.1,
+    "fp_last": 9.0
+  },
+  {
+    "playerId": 216408,
+    "fullName": "Балларини",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216409,
+    "fullName": "Браво",
+    "clubName": "Удинезе",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.8,
+    "fp_last": 40.0
+  },
+  {
+    "playerId": 216410,
+    "fullName": "Гогличидзе",
+    "clubName": "Удинезе",
     "position": "DEF",
     "league": "Serie A",
-    "price": 4.0,
+    "price": 4.5,
     "popularity": 0.7,
     "fp_last": 0.0
+  },
+  {
+    "playerId": 216411,
+    "fullName": "Де Паоли",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216412,
+    "fullName": "Земура",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 46.0
+  },
+  {
+    "playerId": 216413,
+    "fullName": "Кабаселе",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 49.0
+  },
+  {
+    "playerId": 216414,
+    "fullName": "Абдулай Камара",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216415,
+    "fullName": "Хассан Камара",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 83.0
+  },
+  {
+    "playerId": 216416,
+    "fullName": "Модешту",
+    "clubName": "Удинезе",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 27.0
+  },
+  {
+    "playerId": 216417,
+    "fullName": "Окойе",
+    "clubName": "Удинезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 2.8,
+    "fp_last": 72.0
   },
   {
     "playerId": 216402,
@@ -18967,6 +18387,46 @@
     "league": "Serie A",
     "price": 4.0,
     "popularity": 3.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216407,
+    "fullName": "Пальма",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 216406,
+    "fullName": "Паделли",
+    "clubName": "Удинезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 7.0
+  },
+  {
+    "playerId": 216405,
+    "fullName": "Нунцианте",
+    "clubName": "Удинезе",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216404,
+    "fullName": "Кристенсен",
+    "clubName": "Удинезе",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
     "fp_last": 0.0
   },
   {
@@ -18980,44 +18440,294 @@
     "fp_last": 28.0
   },
   {
-    "playerId": 216404,
-    "fullName": "Кристенсен",
-    "clubName": "Удинезе",
-    "position": "DEF",
+    "playerId": 216469,
+    "fullName": "Кин",
+    "clubName": "Фиорентина",
+    "position": "FWD",
     "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
+    "price": 10.0,
+    "popularity": 3.5,
+    "fp_last": 161.0
+  },
+  {
+    "playerId": 216468,
+    "fullName": "Джеко",
+    "clubName": "Фиорентина",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 2.8,
     "fp_last": 0.0
   },
   {
-    "playerId": 216405,
-    "fullName": "Нунцианте",
-    "clubName": "Удинезе",
-    "position": "GK",
+    "playerId": 216467,
+    "fullName": "Гудмундссон",
+    "clubName": "Фиорентина",
+    "position": "MID",
     "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
+    "price": 7.0,
+    "popularity": 4.9,
+    "fp_last": 76.0
   },
   {
-    "playerId": 216406,
-    "fullName": "Паделли",
-    "clubName": "Удинезе",
-    "position": "GK",
+    "playerId": 216466,
+    "fullName": "Мандрагора",
+    "clubName": "Фиорентина",
+    "position": "MID",
     "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 7.0
-  },
-  {
-    "playerId": 216407,
-    "fullName": "Пальма",
-    "clubName": "Удинезе",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
+    "price": 6.5,
     "popularity": 0.7,
+    "fp_last": 89.0
+  },
+  {
+    "playerId": 216465,
+    "fullName": "Зом",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216464,
+    "fullName": "Бельтран",
+    "clubName": "Фиорентина",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0,
+    "fp_last": 97.0
+  },
+  {
+    "playerId": 216462,
+    "fullName": "Иконе",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216459,
+    "fullName": "Брекало",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216460,
+    "fullName": "Гозенс",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 5.6,
+    "fp_last": 119.0
+  },
+  {
+    "playerId": 216461,
+    "fullName": "Додо",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 2.1,
+    "fp_last": 121.0
+  },
+  {
+    "playerId": 216463,
+    "fullName": "Фаджоли",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 67.0
+  },
+  {
+    "playerId": 216458,
+    "fullName": "Фаццини",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216457,
+    "fullName": "Раньери",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 118.0
+  },
+  {
+    "playerId": 216456,
+    "fullName": "Куаме",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216455,
+    "fullName": "Де Хеа",
+    "clubName": "Фиорентина",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 9.8,
+    "fp_last": 133.0
+  },
+  {
+    "playerId": 216454,
+    "fullName": "Барак",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
     "fp_last": 1.0
+  },
+  {
+    "playerId": 216453,
+    "fullName": "Сабири",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216452,
+    "fullName": "Ричардсон",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.1,
+    "fp_last": 44.0
+  },
+  {
+    "playerId": 216451,
+    "fullName": "Понграчич",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 46.0
+  },
+  {
+    "playerId": 216450,
+    "fullName": "Паризи",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 56.0
+  },
+  {
+    "playerId": 216449,
+    "fullName": "Монтенегро",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216448,
+    "fullName": "Комуццо",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 78.0
+  },
+  {
+    "playerId": 216447,
+    "fullName": "Браски",
+    "clubName": "Фиорентина",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216445,
+    "fullName": "Ндур",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 15.0
+  },
+  {
+    "playerId": 216441,
+    "fullName": "Бьянко",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216442,
+    "fullName": "Инфантино",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216443,
+    "fullName": "Куадио",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216444,
+    "fullName": "Мари",
+    "clubName": "Фиорентина",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 65.0
+  },
+  {
+    "playerId": 216446,
+    "fullName": "Трапани",
+    "clubName": "Фиорентина",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
   },
   {
     "playerId": 216436,
@@ -19027,36 +18737,6 @@
     "league": "Serie A",
     "price": 4.0,
     "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216437,
-    "fullName": "Ледзерини",
-    "clubName": "Фиорентина",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216438,
-    "fullName": "Леонарделли",
-    "clubName": "Фиорентина",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216439,
-    "fullName": "Мартинелли",
-    "clubName": "Фиорентина",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.7,
     "fp_last": 0.0
   },
   {
@@ -19070,6 +18750,326 @@
     "fp_last": 0.0
   },
   {
+    "playerId": 216439,
+    "fullName": "Мартинелли",
+    "clubName": "Фиорентина",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216438,
+    "fullName": "Леонарделли",
+    "clubName": "Фиорентина",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216437,
+    "fullName": "Ледзерини",
+    "clubName": "Фиорентина",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216504,
+    "fullName": "Дэвид",
+    "clubName": "Ювентус",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 9.0,
+    "popularity": 8.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216503,
+    "fullName": "Йылдыз",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 8.5,
+    "popularity": 11.2,
+    "fp_last": 130.0
+  },
+  {
+    "playerId": 216502,
+    "fullName": "Влахович",
+    "clubName": "Ювентус",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 8.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216501,
+    "fullName": "Франсишку Консейсау",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 4.2,
+    "fp_last": 67.0
+  },
+  {
+    "playerId": 216500,
+    "fullName": "Копмейнерс",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.5,
+    "popularity": 2.8,
+    "fp_last": 96.0
+  },
+  {
+    "playerId": 216499,
+    "fullName": "Кефрен Тюрам",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 1.4,
+    "fp_last": 117.0
+  },
+  {
+    "playerId": 216498,
+    "fullName": "Локателли",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7,
+    "fp_last": 112.0
+  },
+  {
+    "playerId": 216497,
+    "fullName": "Николас Гонсалес",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 7.0,
+    "popularity": 0.7,
+    "fp_last": 79.0
+  },
+  {
+    "playerId": 216496,
+    "fullName": "Милик",
+    "clubName": "Ювентус",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216495,
+    "fullName": "Маккенни",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 6.5,
+    "popularity": 0.0,
+    "fp_last": 103.0
+  },
+  {
+    "playerId": 216494,
+    "fullName": "Камбьязо",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 5.6,
+    "fp_last": 119.0
+  },
+  {
+    "playerId": 216493,
+    "fullName": "Ди Грегорио",
+    "clubName": "Ювентус",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 2.8,
+    "fp_last": 123.0
+  },
+  {
+    "playerId": 216492,
+    "fullName": "Гатти",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 2.8,
+    "fp_last": 106.0
+  },
+  {
+    "playerId": 216491,
+    "fullName": "Бремер",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 6.0,
+    "popularity": 1.4,
+    "fp_last": 34.0
+  },
+  {
+    "playerId": 216487,
+    "fullName": "Дуглас Луис",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 24.0
+  },
+  {
+    "playerId": 216490,
+    "fullName": "Миретти",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216489,
+    "fullName": "Костич",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216488,
+    "fullName": "Калулу",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.5,
+    "popularity": 3.5,
+    "fp_last": 92.0
+  },
+  {
+    "playerId": 216486,
+    "fullName": "Савона",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 80.0
+  },
+  {
+    "playerId": 216485,
+    "fullName": "Перин",
+    "clubName": "Ювентус",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 23.0
+  },
+  {
+    "playerId": 216484,
+    "fullName": "Келли",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 38.0
+  },
+  {
+    "playerId": 216483,
+    "fullName": "Жоау Мариу",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 2.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216482,
+    "fullName": "Артур",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 5.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216479,
+    "fullName": "Ругани",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216476,
+    "fullName": "Аджич",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 3.5,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 216477,
+    "fullName": "Кабаль",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 19.0
+  },
+  {
+    "playerId": 216478,
+    "fullName": "Пьетрелли",
+    "clubName": "Ювентус",
+    "position": "FWD",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216480,
+    "fullName": "Серсанти",
+    "clubName": "Ювентус",
+    "position": "MID",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216481,
+    "fullName": "Тиагу Джало",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.5,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
     "playerId": 216470,
     "fullName": "Факундо Гонсалес",
     "clubName": "Ювентус",
@@ -19080,8 +19080,28 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 216471,
-    "fullName": "Пинсольо",
+    "playerId": 216475,
+    "fullName": "Хиль",
+    "clubName": "Ювентус",
+    "position": "DEF",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216474,
+    "fullName": "Фускальдо",
+    "clubName": "Ювентус",
+    "position": "GK",
+    "league": "Serie A",
+    "price": 4.0,
+    "popularity": 0.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 216473,
+    "fullName": "Скалья",
     "clubName": "Ювентус",
     "position": "GK",
     "league": "Serie A",
@@ -19100,154 +19120,14 @@
     "fp_last": 10.0
   },
   {
-    "playerId": 216473,
-    "fullName": "Скалья",
+    "playerId": 216471,
+    "fullName": "Пинсольо",
     "clubName": "Ювентус",
     "position": "GK",
     "league": "Serie A",
     "price": 4.0,
     "popularity": 0.0,
     "fp_last": 0.0
-  },
-  {
-    "playerId": 216474,
-    "fullName": "Фускальдо",
-    "clubName": "Ювентус",
-    "position": "GK",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 0.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 216475,
-    "fullName": "Хиль",
-    "clubName": "Ювентус",
-    "position": "DEF",
-    "league": "Serie A",
-    "price": 4.0,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213183,
-    "fullName": "Кейн",
-    "clubName": "Бавария",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 11.5,
-    "popularity": 58.7,
-    "fp_last": 199.0
-  },
-  {
-    "playerId": 213182,
-    "fullName": "Олисе",
-    "clubName": "Бавария",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 11.0,
-    "popularity": 40.8,
-    "fp_last": 190.0
-  },
-  {
-    "playerId": 213239,
-    "fullName": "Гирасси",
-    "clubName": "Боруссия Д",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 10.5,
-    "popularity": 37.5,
-    "fp_last": 171.0
-  },
-  {
-    "playerId": 213181,
-    "fullName": "Мусиала",
-    "clubName": "Бавария",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 10.5,
-    "popularity": 8.4,
-    "fp_last": 127.0
-  },
-  {
-    "playerId": 213444,
-    "fullName": "Симонс",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 10.0,
-    "popularity": 7.6,
-    "fp_last": 146.0
-  },
-  {
-    "playerId": 213207,
-    "fullName": "Шик",
-    "clubName": "Байер",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 9.0,
-    "popularity": 14.2,
-    "fp_last": 139.0
-  },
-  {
-    "playerId": 213238,
-    "fullName": "Адейеми",
-    "clubName": "Боруссия Д",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 9.0,
-    "popularity": 12.4,
-    "fp_last": 96.0
-  },
-  {
-    "playerId": 213618,
-    "fullName": "Ундав",
-    "clubName": "Штутгарт",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 9.0,
-    "popularity": 8.8,
-    "fp_last": 112.0
-  },
-  {
-    "playerId": 213443,
-    "fullName": "Шешко",
-    "clubName": "РБ Лейпциг",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 9.0,
-    "popularity": 2.4,
-    "fp_last": 136.0
-  },
-  {
-    "playerId": 213180,
-    "fullName": "Диас",
-    "clubName": "Бавария",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 9.0,
-    "popularity": 16.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213237,
-    "fullName": "Брандт",
-    "clubName": "Боруссия Д",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 8.5,
-    "popularity": 8.6,
-    "fp_last": 126.0
-  },
-  {
-    "playerId": 213442,
-    "fullName": "Опенда",
-    "clubName": "РБ Лейпциг",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 8.5,
-    "popularity": 10.0,
-    "fp_last": 123.0
   },
   {
     "playerId": 213533,
@@ -19260,56 +19140,6 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213268,
-    "fullName": "Кляйндинст",
-    "clubName": "Боруссия М",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 8.5,
-    "popularity": 8.8,
-    "fp_last": 166.0
-  },
-  {
-    "playerId": 213206,
-    "fullName": "Тилльман",
-    "clubName": "Байер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 8.0,
-    "popularity": 5.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213532,
-    "fullName": "Грифо",
-    "clubName": "Фрайбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 8.0,
-    "popularity": 9.7,
-    "fp_last": 144.0
-  },
-  {
-    "playerId": 213236,
-    "fullName": "Байер",
-    "clubName": "Боруссия Д",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 8.0,
-    "popularity": 2.7,
-    "fp_last": 93.0
-  },
-  {
-    "playerId": 213591,
-    "fullName": "Крамарич",
-    "clubName": "Хоффенхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 8.0,
-    "popularity": 11.6,
-    "fp_last": 162.0
-  },
-  {
     "playerId": 213127,
     "fullName": "Буркардт",
     "clubName": "Айнтрахт Ф",
@@ -19318,86 +19148,6 @@
     "price": 8.0,
     "popularity": 15.2,
     "fp_last": 0.0
-  },
-  {
-    "playerId": 213205,
-    "fullName": "Бонифасе",
-    "clubName": "Байер",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 8.0,
-    "popularity": 9.2,
-    "fp_last": 61.0
-  },
-  {
-    "playerId": 213617,
-    "fullName": "Вольтемаде",
-    "clubName": "Штутгарт",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 8.0,
-    "popularity": 9.2,
-    "fp_last": 99.0
-  },
-  {
-    "playerId": 213441,
-    "fullName": "Бакайоко",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 8.0,
-    "popularity": 5.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213204,
-    "fullName": "Телла",
-    "clubName": "Байер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 2.7,
-    "fp_last": 67.0
-  },
-  {
-    "playerId": 213406,
-    "fullName": "Небель",
-    "clubName": "Майнц",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 4.1,
-    "fp_last": 137.0
-  },
-  {
-    "playerId": 213266,
-    "fullName": "Онора",
-    "clubName": "Боруссия М",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 3.0,
-    "fp_last": 84.0
-  },
-  {
-    "playerId": 213235,
-    "fullName": "Беллингем",
-    "clubName": "Боруссия Д",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 27.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213616,
-    "fullName": "Демирович",
-    "clubName": "Штутгарт",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 3.2,
-    "fp_last": 117.0
   },
   {
     "playerId": 213126,
@@ -19410,154 +19160,14 @@
     "fp_last": 21.0
   },
   {
-    "playerId": 213440,
-    "fullName": "Нуса",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 3.0,
-    "fp_last": 81.0
-  },
-  {
-    "playerId": 213404,
-    "fullName": "Амири",
-    "clubName": "Майнц",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 7.8,
-    "fp_last": 120.0
-  },
-  {
-    "playerId": 213405,
-    "fullName": "Ли Чжэ Сон",
-    "clubName": "Майнц",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 3.5,
-    "fp_last": 138.0
-  },
-  {
-    "playerId": 213265,
-    "fullName": "Матино",
-    "clubName": "Боруссия М",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213321,
-    "fullName": "Амура",
-    "clubName": "Вольфсбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 3.7,
-    "fp_last": 131.0
-  },
-  {
-    "playerId": 213177,
-    "fullName": "Гнабри",
-    "clubName": "Бавария",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 2.3,
-    "fp_last": 98.0
-  },
-  {
-    "playerId": 213178,
-    "fullName": "Киммих",
-    "clubName": "Бавария",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 17.5,
-    "fp_last": 147.0
-  },
-  {
-    "playerId": 213179,
-    "fullName": "Коман",
-    "clubName": "Бавария",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 1.9,
-    "fp_last": 88.0
-  },
-  {
-    "playerId": 213267,
-    "fullName": "Хак",
-    "clubName": "Боруссия М",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.5,
-    "popularity": 2.2,
-    "fp_last": 110.0
-  },
-  {
-    "playerId": 213201,
-    "fullName": "Адли",
-    "clubName": "Байер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 4.5,
-    "fp_last": 38.0
-  },
-  {
-    "playerId": 213234,
-    "fullName": "Гросс",
-    "clubName": "Боруссия Д",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 5.4,
-    "fp_last": 100.0
-  },
-  {
-    "playerId": 213264,
-    "fullName": "Штегер",
-    "clubName": "Боруссия М",
+    "playerId": 213125,
+    "fullName": "Узун",
+    "clubName": "Айнтрахт Ф",
     "position": "MID",
     "league": "Bundesliga",
     "price": 7.0,
     "popularity": 1.2,
-    "fp_last": 79.0
-  },
-  {
-    "playerId": 213531,
-    "fullName": "Хелер",
-    "clubName": "Фрайбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 1.0,
-    "fp_last": 90.0
-  },
-  {
-    "playerId": 213614,
-    "fullName": "Фюрих",
-    "clubName": "Штутгарт",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 1.5,
-    "fp_last": 85.0
-  },
-  {
-    "playerId": 213123,
-    "fullName": "Ваи",
-    "clubName": "Айнтрахт Ф",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 2.6,
-    "fp_last": 8.0
+    "fp_last": 50.0
   },
   {
     "playerId": 213124,
@@ -19570,244 +19180,24 @@
     "fp_last": 82.0
   },
   {
-    "playerId": 213125,
-    "fullName": "Узун",
+    "playerId": 213123,
+    "fullName": "Ваи",
+    "clubName": "Айнтрахт Ф",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 2.6,
+    "fp_last": 8.0
+  },
+  {
+    "playerId": 213120,
+    "fullName": "Гетце",
     "clubName": "Айнтрахт Ф",
     "position": "MID",
     "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 1.2,
-    "fp_last": 50.0
-  },
-  {
-    "playerId": 213203,
-    "fullName": "Терье",
-    "clubName": "Байер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 1.1,
-    "fp_last": 33.0
-  },
-  {
-    "playerId": 213613,
-    "fullName": "Левелинг",
-    "clubName": "Штутгарт",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 2.4,
-    "fp_last": 68.0
-  },
-  {
-    "playerId": 213292,
-    "fullName": "Дукш",
-    "clubName": "Вердер",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 2.1,
-    "fp_last": 120.0
-  },
-  {
-    "playerId": 213294,
-    "fullName": "Романо Шмид",
-    "clubName": "Вердер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 1.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213293,
-    "fullName": "Стаге",
-    "clubName": "Вердер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 3.1,
-    "fp_last": 134.0
-  },
-  {
-    "playerId": 213403,
-    "fullName": "Холлербах",
-    "clubName": "Майнц",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 1.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213156,
-    "fullName": "Клод-Морис",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 1.8,
-    "fp_last": 120.0
-  },
-  {
-    "playerId": 213202,
-    "fullName": "Алеиш Гарсия",
-    "clubName": "Байер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 2.7,
-    "fp_last": 77.0
-  },
-  {
-    "playerId": 213318,
-    "fullName": "Винд",
-    "clubName": "Вольфсбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 7.0,
+    "price": 6.5,
     "popularity": 2.9,
-    "fp_last": 101.0
-  },
-  {
-    "playerId": 213317,
-    "fullName": "Виммер",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 2.3,
-    "fp_last": 78.0
-  },
-  {
-    "playerId": 213319,
-    "fullName": "Маер",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 1.7,
-    "fp_last": 24.0
-  },
-  {
-    "playerId": 213320,
-    "fullName": "Черны",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 1.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213175,
-    "fullName": "Бисхоф",
-    "clubName": "Бавария",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213176,
-    "fullName": "Горетцка",
-    "clubName": "Бавария",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 1.7,
-    "fp_last": 71.0
-  },
-  {
-    "playerId": 213615,
-    "fullName": "Штиллер",
-    "clubName": "Штутгарт",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 7.0,
-    "popularity": 5.3,
-    "fp_last": 119.0
-  },
-  {
-    "playerId": 213200,
-    "fullName": "Хофманн",
-    "clubName": "Байер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 1.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213199,
-    "fullName": "Гримальдо",
-    "clubName": "Байер",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 32.0,
-    "fp_last": 122.0
-  },
-  {
-    "playerId": 213471,
-    "fullName": "Ирвайн",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 1.1,
-    "fp_last": 111.0
-  },
-  {
-    "playerId": 213233,
-    "fullName": "Нмеча",
-    "clubName": "Боруссия Д",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213530,
-    "fullName": "Шерхант",
-    "clubName": "Фрайбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213529,
-    "fullName": "Судзуки",
-    "clubName": "Фрайбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 1.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213590,
-    "fullName": "Гложек",
-    "clubName": "Хоффенхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 2.3,
-    "fp_last": 99.0
-  },
-  {
-    "playerId": 213379,
-    "fullName": "Бюльтер",
-    "clubName": "Кельн",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 1.6,
-    "fp_last": 0.0
+    "fp_last": 72.0
   },
   {
     "playerId": 213118,
@@ -19830,16 +19220,6 @@
     "fp_last": 54.0
   },
   {
-    "playerId": 213120,
-    "fullName": "Гетце",
-    "clubName": "Айнтрахт Ф",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 2.9,
-    "fp_last": 72.0
-  },
-  {
     "playerId": 213121,
     "fullName": "Ларссон",
     "clubName": "Айнтрахт Ф",
@@ -19860,344 +19240,14 @@
     "fp_last": 50.0
   },
   {
-    "playerId": 213439,
-    "fullName": "Диоманде",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213349,
-    "fullName": "Поульсен",
-    "clubName": "Гамбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 2.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213437,
-    "fullName": "Баумгартнер",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 2.9,
-    "fp_last": 69.0
-  },
-  {
-    "playerId": 213230,
-    "fullName": "Аллер",
-    "clubName": "Боруссия Д",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 1.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213232,
-    "fullName": "Забитцер",
-    "clubName": "Боруссия Д",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 3.2,
-    "fp_last": 58.0
-  },
-  {
-    "playerId": 213380,
-    "fullName": "Вальдшмидт",
-    "clubName": "Кельн",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 1.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213290,
-    "fullName": "Мбангула",
-    "clubName": "Вердер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 1.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213289,
-    "fullName": "Грюлль",
-    "clubName": "Вердер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 0.8,
-    "fp_last": 80.0
-  },
-  {
-    "playerId": 213291,
-    "fullName": "Топп",
-    "clubName": "Вердер",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 0.7,
-    "fp_last": 32.0
-  },
-  {
-    "playerId": 213402,
-    "fullName": "Сано",
-    "clubName": "Майнц",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 1.1,
-    "fp_last": 106.0
-  },
-  {
-    "playerId": 213401,
-    "fullName": "Вайпер",
-    "clubName": "Майнц",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 1.4,
-    "fp_last": 46.0
-  },
-  {
-    "playerId": 213154,
-    "fullName": "Титц",
-    "clubName": "Аугсбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 0.8,
-    "fp_last": 82.0
-  },
-  {
-    "playerId": 213155,
-    "fullName": "Эссенде",
-    "clubName": "Аугсбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 0.5,
-    "fp_last": 75.0
-  },
-  {
-    "playerId": 213314,
-    "fullName": "Арнольд",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 4.4,
-    "fp_last": 102.0
-  },
-  {
-    "playerId": 213316,
-    "fullName": "Тиагу Томаш",
-    "clubName": "Штутгарт",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213315,
-    "fullName": "Линдстрем",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213527,
-    "fullName": "Адаму",
-    "clubName": "Фрайбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 0.8,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 213528,
-    "fullName": "Динкчи",
-    "clubName": "Фрайбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 0.7,
-    "fp_last": 54.0
-  },
-  {
-    "playerId": 213173,
-    "fullName": "Ваннер",
-    "clubName": "Бавария",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213174,
-    "fullName": "Павлович",
-    "clubName": "Бавария",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 0.8,
-    "fp_last": 56.0
-  },
-  {
-    "playerId": 213438,
-    "fullName": "Вернер",
-    "clubName": "РБ Лейпциг",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 4.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213472,
-    "fullName": "Перейра Лаже",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 1.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213589,
-    "fullName": "Аслани",
-    "clubName": "Хоффенхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 1.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213231,
-    "fullName": "Дюранвиль",
-    "clubName": "Боруссия Д",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 0.5,
-    "fp_last": 11.0
-  },
-  {
-    "playerId": 213612,
-    "fullName": "Каразор",
-    "clubName": "Штутгарт",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.5,
-    "popularity": 1.1,
-    "fp_last": 101.0
-  },
-  {
-    "playerId": 213152,
-    "fullName": "Кемюр",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.4,
-    "fp_last": 38.0
-  },
-  {
-    "playerId": 213153,
-    "fullName": "Саад",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213347,
-    "fullName": "Кенигсдорффер",
-    "clubName": "Гамбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 1.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213374,
-    "fullName": "Ахе",
-    "clubName": "Кельн",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 1.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213378,
-    "fullName": "Тильманн",
-    "clubName": "Кельн",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213558,
-    "fullName": "Хонзак",
-    "clubName": "Хайденхайм",
+    "playerId": 213117,
+    "fullName": "Схири",
+    "clubName": "Айнтрахт Ф",
     "position": "MID",
     "league": "Bundesliga",
     "price": 6.0,
     "popularity": 0.6,
-    "fp_last": 68.0
-  },
-  {
-    "playerId": 213432,
-    "fullName": "Гулачи",
-    "clubName": "РБ Лейпциг",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 6.9,
-    "fp_last": 127.0
-  },
-  {
-    "playerId": 213433,
-    "fullName": "Зайвальд",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.5,
-    "fp_last": 70.0
-  },
-  {
-    "playerId": 213470,
-    "fullName": "Синани",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 54.0
+    "fp_last": 82.0
   },
   {
     "playerId": 213116,
@@ -20210,534 +19260,14 @@
     "fp_last": 108.0
   },
   {
-    "playerId": 213117,
-    "fullName": "Схири",
+    "playerId": 213115,
+    "fullName": "Хейлунд",
     "clubName": "Айнтрахт Ф",
     "position": "MID",
     "league": "Bundesliga",
-    "price": 6.0,
+    "price": 5.5,
     "popularity": 0.6,
-    "fp_last": 82.0
-  },
-  {
-    "playerId": 213346,
-    "fullName": "Домпе",
-    "clubName": "Гамбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 2.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213376,
-    "fullName": "Каминьски",
-    "clubName": "Кельн",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213375,
-    "fullName": "Кайнц",
-    "clubName": "Кельн",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 1.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213377,
-    "fullName": "Майна",
-    "clubName": "Кельн",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213501,
-    "fullName": "Чжон Ву Ен",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 62.0
-  },
-  {
-    "playerId": 213523,
-    "fullName": "Грегорич",
-    "clubName": "Фрайбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 1.0,
-    "fp_last": 35.0
-  },
-  {
-    "playerId": 213526,
-    "fullName": "Эггештайн",
-    "clubName": "Фрайбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213152,
-    "fullName": "Кемюр",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.4,
-    "fp_last": 38.0
-  },
-  {
-    "playerId": 213153,
-    "fullName": "Саад",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213434,
-    "fullName": "Раум",
-    "clubName": "РБ Лейпциг",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 9.6,
-    "fp_last": 92.0
-  },
-  {
-    "playerId": 213168,
-    "fullName": "Геррейру",
-    "clubName": "Бавария",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 5.4,
-    "fp_last": 112.0
-  },
-  {
-    "playerId": 213169,
-    "fullName": "Дэвис",
-    "clubName": "Бавария",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 6.8,
-    "fp_last": 76.0
-  },
-  {
-    "playerId": 213170,
-    "fullName": "Лаймер",
-    "clubName": "Бавария",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 3.3,
-    "fp_last": 73.0
-  },
-  {
-    "playerId": 213171,
-    "fullName": "Нойер",
-    "clubName": "Бавария",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 9.5,
-    "fp_last": 100.0
-  },
-  {
-    "playerId": 213172,
-    "fullName": "Та",
-    "clubName": "Бавария",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 8.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213588,
-    "fullName": "Туре",
-    "clubName": "Хоффенхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213524,
-    "fullName": "Матанович",
-    "clubName": "Фрайбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213522,
-    "fullName": "Бесте",
-    "clubName": "Фрайбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 1.7,
-    "fp_last": 15.0
-  },
-  {
-    "playerId": 213525,
-    "fullName": "Рель",
-    "clubName": "Фрайбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.2,
-    "fp_last": 36.0
-  },
-  {
-    "playerId": 213195,
-    "fullName": "Андрих",
-    "clubName": "Байер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 3.4,
-    "fp_last": 61.0
-  },
-  {
-    "playerId": 213196,
-    "fullName": "Маза",
-    "clubName": "Байер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213197,
-    "fullName": "Паласиос",
-    "clubName": "Байер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 2.2,
-    "fp_last": 66.0
-  },
-  {
-    "playerId": 213198,
-    "fullName": "Флеккен",
-    "clubName": "Байер",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 6.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213557,
-    "fullName": "Пирингер",
-    "clubName": "Хайденхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.8,
-    "fp_last": 99.0
-  },
-  {
-    "playerId": 213587,
-    "fullName": "Лемперле",
-    "clubName": "Хоффенхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213430,
-    "fullName": "Андре Силва",
-    "clubName": "РБ Лейпциг",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 1.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213431,
-    "fullName": "Баку",
-    "clubName": "РБ Лейпциг",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 5.1,
-    "fp_last": 112.0
-  },
-  {
-    "playerId": 213429,
-    "fullName": "Айдара",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.8,
-    "fp_last": 46.0
-  },
-  {
-    "playerId": 213227,
-    "fullName": "Кобель",
-    "clubName": "Боруссия Д",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 14.9,
-    "fp_last": 90.0
-  },
-  {
-    "playerId": 213228,
-    "fullName": "Рюэрсон",
-    "clubName": "Боруссия Д",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 6.0,
-    "fp_last": 84.0
-  },
-  {
-    "playerId": 213229,
-    "fullName": "Свенссон",
-    "clubName": "Боруссия Д",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 7.9,
-    "fp_last": 42.0
-  },
-  {
-    "playerId": 213313,
-    "fullName": "Ольсен",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 25.0
-  },
-  {
-    "playerId": 213435,
-    "fullName": "Шлагер",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.8,
-    "fp_last": 5.0
-  },
-  {
-    "playerId": 213348,
-    "fullName": "Райан Филипп",
-    "clubName": "Гамбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 1.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213499,
-    "fullName": "Бенеш",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 1.1,
-    "fp_last": 36.0
-  },
-  {
-    "playerId": 213469,
-    "fullName": "Афолайян",
-    "clubName": "Санкт-Паули",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.9,
-    "fp_last": 71.0
-  },
-  {
-    "playerId": 213260,
-    "fullName": "Вайгль",
-    "clubName": "Боруссия М",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 3.8,
-    "fp_last": 97.0
-  },
-  {
-    "playerId": 213261,
-    "fullName": "Нгуму",
-    "clubName": "Боруссия М",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.3,
-    "fp_last": 46.0
-  },
-  {
-    "playerId": 213262,
-    "fullName": "Райтц",
-    "clubName": "Боруссия М",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.7,
-    "fp_last": 69.0
-  },
-  {
-    "playerId": 213263,
-    "fullName": "Табакович",
-    "clubName": "Боруссия М",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213400,
-    "fullName": "Норден",
-    "clubName": "Майнц",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.4,
-    "fp_last": 5.0
-  },
-  {
-    "playerId": 213500,
-    "fullName": "Илич",
-    "clubName": "Унион Берлин",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 1.4,
-    "fp_last": 53.0
-  },
-  {
-    "playerId": 213286,
-    "fullName": "Вайзер",
-    "clubName": "Вердер",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 6.6,
-    "fp_last": 128.0
-  },
-  {
-    "playerId": 213287,
-    "fullName": "Линен",
-    "clubName": "Вердер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.5,
-    "fp_last": 85.0
-  },
-  {
-    "playerId": 213288,
-    "fullName": "Нджинма",
-    "clubName": "Вердер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 6.0,
-    "popularity": 0.5,
-    "fp_last": 59.0
-  },
-  {
-    "playerId": 213308,
-    "fullName": "Винисиус",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213311,
-    "fullName": "Паредес",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 213494,
-    "fullName": "Ансах",
-    "clubName": "Унион Берлин",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213582,
-    "fullName": "Бебу",
-    "clubName": "Хоффенхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 213556,
-    "fullName": "Сиенза",
-    "clubName": "Хайденхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 60.0
-  },
-  {
-    "playerId": 213112,
-    "fullName": "Расмус Кристенсен",
-    "clubName": "Айнтрахт Ф",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 11.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213113,
-    "fullName": "Теате",
-    "clubName": "Айнтрахт Ф",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 3.1,
-    "fp_last": 77.0
+    "fp_last": 32.0
   },
   {
     "playerId": 213114,
@@ -20750,674 +19280,24 @@
     "fp_last": 92.0
   },
   {
-    "playerId": 213115,
-    "fullName": "Хейлунд",
-    "clubName": "Айнтрахт Ф",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.6,
-    "fp_last": 32.0
-  },
-  {
-    "playerId": 213345,
-    "fullName": "Сахити",
-    "clubName": "Гамбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213310,
-    "fullName": "Грабара",
-    "clubName": "Вольфсбург",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 3.0,
-    "fp_last": 89.0
-  },
-  {
-    "playerId": 213344,
-    "fullName": "Капальдо",
-    "clubName": "Гамбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213519,
-    "fullName": "Манзамби",
-    "clubName": "Фрайбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 26.0
-  },
-  {
-    "playerId": 213555,
-    "fullName": "Зивзивадзе",
-    "clubName": "Хайденхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.7,
-    "fp_last": 42.0
-  },
-  {
-    "playerId": 213554,
-    "fullName": "Бек",
-    "clubName": "Хайденхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 1.2,
-    "fp_last": 78.0
-  },
-  {
-    "playerId": 213149,
-    "fullName": "Арне Майер",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 33.0
-  },
-  {
-    "playerId": 213150,
-    "fullName": "Мунье",
-    "clubName": "Аугсбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.6,
-    "fp_last": 18.0
-  },
-  {
-    "playerId": 213151,
-    "fullName": "Реджбечай",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.6,
-    "fp_last": 60.0
-  },
-  {
-    "playerId": 213343,
-    "fullName": "Глатцель",
-    "clubName": "Гамбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213163,
-    "fullName": "Ким Мин Чжэ",
-    "clubName": "Бавария",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 1.7,
-    "fp_last": 99.0
-  },
-  {
-    "playerId": 213164,
-    "fullName": "Пальинья",
-    "clubName": "Бавария",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 1.1,
-    "fp_last": 24.0
-  },
-  {
-    "playerId": 213165,
-    "fullName": "Станишич",
-    "clubName": "Бавария",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 42.0
-  },
-  {
-    "playerId": 213166,
-    "fullName": "Упамекано",
-    "clubName": "Бавария",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 3.3,
-    "fp_last": 81.0
-  },
-  {
-    "playerId": 213167,
-    "fullName": "Урбиг",
-    "clubName": "Бавария",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.5,
-    "fp_last": 23.0
-  },
-  {
-    "playerId": 213521,
-    "fullName": "Максимилиан Филипп",
-    "clubName": "Фрайбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 1.1,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 213192,
-    "fullName": "Артур",
-    "clubName": "Байер",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 3.8,
-    "fp_last": 37.0
-  },
-  {
-    "playerId": 213193,
-    "fullName": "Инкапиэ",
-    "clubName": "Байер",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 5.9,
-    "fp_last": 92.0
-  },
-  {
-    "playerId": 213194,
-    "fullName": "Тапсоба",
-    "clubName": "Байер",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 4.7,
-    "fp_last": 68.0
-  },
-  {
-    "playerId": 213518,
-    "fullName": "Ириэ",
-    "clubName": "Фрайбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213583,
-    "fullName": "Гриллич",
-    "clubName": "Хоффенхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 19.0
-  },
-  {
-    "playerId": 213467,
-    "fullName": "Унтонджи",
-    "clubName": "Санкт-Паули",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213468,
-    "fullName": "Фудзита",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213496,
-    "fullName": "Роте",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 2.7,
-    "fp_last": 71.0
-  },
-  {
-    "playerId": 213495,
-    "fullName": "Берк",
-    "clubName": "Унион Берлин",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213498,
-    "fullName": "Шефер",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.5,
-    "fp_last": 54.0
-  },
-  {
-    "playerId": 213497,
-    "fullName": "Скарке",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 46.0
-  },
-  {
-    "playerId": 213259,
-    "fullName": "Зандер",
-    "clubName": "Боруссия М",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.6,
-    "fp_last": 54.0
-  },
-  {
-    "playerId": 213312,
-    "fullName": "Сванберг",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.5,
-    "fp_last": 54.0
-  },
-  {
-    "playerId": 213309,
-    "fullName": "Герхардт",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.5,
-    "fp_last": 56.0
-  },
-  {
-    "playerId": 213398,
-    "fullName": "Мвене",
-    "clubName": "Майнц",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 2.6,
-    "fp_last": 97.0
-  },
-  {
-    "playerId": 213397,
-    "fullName": "Каси",
-    "clubName": "Майнц",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 6.2,
-    "fp_last": 107.0
-  },
-  {
-    "playerId": 213515,
-    "fullName": "Атуболу",
-    "clubName": "Фрайбург",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 7.1,
-    "fp_last": 104.0
-  },
-  {
-    "playerId": 213399,
-    "fullName": "Центнер",
-    "clubName": "Майнц",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 3.3,
-    "fp_last": 110.0
-  },
-  {
-    "playerId": 213517,
-    "fullName": "Гюнтер",
-    "clubName": "Фрайбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 6.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213520,
-    "fullName": "Остерхаге",
-    "clubName": "Фрайбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 81.0
-  },
-  {
-    "playerId": 213284,
-    "fullName": "Битенкур",
-    "clubName": "Вердер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.5,
-    "fp_last": 48.0
-  },
-  {
-    "playerId": 213311,
-    "fullName": "Паредес",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 213312,
-    "fullName": "Сванберг",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.5,
-    "fp_last": 54.0
-  },
-  {
-    "playerId": 213428,
-    "fullName": "Уэдраого",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.2,
-    "fp_last": 3.0
-  },
-  {
-    "playerId": 213398,
-    "fullName": "Мвене",
-    "clubName": "Майнц",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 2.6,
-    "fp_last": 97.0
-  },
-  {
-    "playerId": 213582,
-    "fullName": "Бебу",
-    "clubName": "Хоффенхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 213584,
-    "fullName": "Морстедт",
-    "clubName": "Хоффенхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 13.0
-  },
-  {
-    "playerId": 213583,
-    "fullName": "Гриллич",
-    "clubName": "Хоффенхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 1.4,
-    "fp_last": 19.0
-  },
-  {
-    "playerId": 213585,
-    "fullName": "Гифт Орбан",
-    "clubName": "Хоффенхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.8,
-    "fp_last": 31.0
-  },
-  {
-    "playerId": 213343,
-    "fullName": "Глатцель",
-    "clubName": "Гамбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213344,
-    "fullName": "Капальдо",
-    "clubName": "Гамбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213345,
-    "fullName": "Сахити",
-    "clubName": "Гамбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213397,
-    "fullName": "Каси",
-    "clubName": "Майнц",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 6.2,
-    "fp_last": 107.0
-  },
-  {
-    "playerId": 213610,
-    "fullName": "Миттельштедт",
-    "clubName": "Штутгарт",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 18.3,
-    "fp_last": 86.0
-  },
-  {
-    "playerId": 213607,
-    "fullName": "Диль",
-    "clubName": "Штутгарт",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 11.0
-  },
-  {
-    "playerId": 213467,
-    "fullName": "Унтонджи",
-    "clubName": "Санкт-Паули",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213468,
-    "fullName": "Фудзита",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213606,
-    "fullName": "Ассиньон",
-    "clubName": "Штутгарт",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 3.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213611,
-    "fullName": "Нюбель",
-    "clubName": "Штутгарт",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 9.3,
-    "fp_last": 101.0
-  },
-  {
-    "playerId": 213494,
-    "fullName": "Ансах",
-    "clubName": "Унион Берлин",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213497,
-    "fullName": "Скарке",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 0.4,
-    "fp_last": 46.0
-  },
-  {
-    "playerId": 213496,
-    "fullName": "Роте",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.5,
-    "popularity": 2.7,
-    "fp_last": 71.0
-  },
-  {
-    "playerId": 213419,
-    "fullName": "Гомис",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 10.0
-  },
-  {
-    "playerId": 213422,
-    "fullName": "Лукеба",
-    "clubName": "РБ Лейпциг",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 2.1,
-    "fp_last": 61.0
-  },
-  {
-    "playerId": 213418,
-    "fullName": "Гертрюйда",
-    "clubName": "РБ Лейпциг",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 3.3,
-    "fp_last": 64.0
-  },
-  {
-    "playerId": 213553,
-    "fullName": "Конте",
-    "clubName": "Хайденхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.5,
-    "fp_last": 39.0
-  },
-  {
-    "playerId": 213576,
-    "fullName": "Бекер",
-    "clubName": "Хоффенхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.6,
-    "fp_last": 28.0
-  },
-  {
-    "playerId": 213580,
-    "fullName": "Премель",
-    "clubName": "Хоффенхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 5.0
-  },
-  {
-    "playerId": 213108,
-    "fullName": "Коллинз",
+    "playerId": 213113,
+    "fullName": "Теате",
     "clubName": "Айнтрахт Ф",
     "position": "DEF",
     "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.0,
-    "fp_last": 62.0
+    "price": 5.5,
+    "popularity": 3.1,
+    "fp_last": 77.0
   },
   {
-    "playerId": 213109,
-    "fullName": "Кох",
+    "playerId": 213112,
+    "fullName": "Расмус Кристенсен",
     "clubName": "Айнтрахт Ф",
     "position": "DEF",
     "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 2.7,
-    "fp_last": 96.0
+    "price": 5.5,
+    "popularity": 11.5,
+    "fp_last": 0.0
   },
   {
     "playerId": 213110,
@@ -21440,894 +19320,34 @@
     "fp_last": 35.0
   },
   {
-    "playerId": 213421,
-    "fullName": "Клостерманн",
-    "clubName": "РБ Лейпциг",
+    "playerId": 213109,
+    "fullName": "Кох",
+    "clubName": "Айнтрахт Ф",
     "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 2.2,
-    "fp_last": 71.0
-  },
-  {
-    "playerId": 213550,
-    "fullName": "Бройниг",
-    "clubName": "Хайденхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.8,
-    "fp_last": 23.0
-  },
-  {
-    "playerId": 213552,
-    "fullName": "Ибрагимович",
-    "clubName": "Хайденхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213140,
-    "fullName": "Вольф",
-    "clubName": "Аугсбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 2.4,
-    "fp_last": 104.0
-  },
-  {
-    "playerId": 213141,
-    "fullName": "Гауэлеу",
-    "clubName": "Аугсбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.3,
-    "fp_last": 101.0
-  },
-  {
-    "playerId": 213142,
-    "fullName": "Дамен",
-    "clubName": "Аугсбург",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.7,
-    "fp_last": 82.0
-  },
-  {
-    "playerId": 213143,
-    "fullName": "Донг",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213144,
-    "fullName": "Кабадайы",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 10.0
-  },
-  {
-    "playerId": 213145,
-    "fullName": "Массенго",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213146,
-    "fullName": "Фелльхауэр",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213147,
-    "fullName": "Якич",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.5,
-    "fp_last": 81.0
-  },
-  {
-    "playerId": 213148,
-    "fullName": "Яннулис",
-    "clubName": "Аугсбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.3,
-    "fp_last": 91.0
-  },
-  {
-    "playerId": 213416,
-    "fullName": "Битшиабу",
-    "clubName": "РБ Лейпциг",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.5,
-    "fp_last": 38.0
-  },
-  {
-    "playerId": 213161,
-    "fullName": "Ито",
-    "clubName": "Бавария",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.2,
-    "fp_last": 21.0
-  },
-  {
-    "playerId": 213188,
-    "fullName": "Белосьян",
-    "clubName": "Байер",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.8,
-    "fp_last": 3.0
-  },
-  {
-    "playerId": 213189,
-    "fullName": "Кофан",
-    "clubName": "Байер",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213190,
-    "fullName": "Куанса",
-    "clubName": "Байер",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 4.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213191,
-    "fullName": "Сарко",
-    "clubName": "Байер",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213461,
-    "fullName": "Скотт Бэнкс",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.9,
-    "fp_last": 11.0
-  },
-  {
-    "playerId": 213551,
-    "fullName": "Дорш",
-    "clubName": "Хайденхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 54.0
-  },
-  {
-    "playerId": 213488,
-    "fullName": "Реннов",
-    "clubName": "Унион Берлин",
-    "position": "GK",
     "league": "Bundesliga",
     "price": 5.0,
     "popularity": 2.7,
-    "fp_last": 110.0
+    "fp_last": 96.0
   },
   {
-    "playerId": 213217,
-    "fullName": "Зюле",
-    "clubName": "Боруссия Д",
+    "playerId": 213108,
+    "fullName": "Коллинз",
+    "clubName": "Айнтрахт Ф",
     "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 2.0,
-    "fp_last": 31.0
-  },
-  {
-    "playerId": 213218,
-    "fullName": "Кэмпбелл",
-    "clubName": "Боруссия Д",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 4.0
-  },
-  {
-    "playerId": 213424,
-    "fullName": "Неделькович",
-    "clubName": "РБ Лейпциг",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 15.0
-  },
-  {
-    "playerId": 213511,
-    "fullName": "Кюблер",
-    "clubName": "Фрайбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 9.4,
-    "fp_last": 91.0
-  },
-  {
-    "playerId": 213510,
-    "fullName": "Гинтер",
-    "clubName": "Фрайбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 7.2,
-    "fp_last": 98.0
-  },
-  {
-    "playerId": 213514,
-    "fullName": "Хефлер",
-    "clubName": "Фрайбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 32.0
-  },
-  {
-    "playerId": 213250,
-    "fullName": "Итакура",
-    "clubName": "Боруссия М",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 3.5,
-    "fp_last": 82.0
-  },
-  {
-    "playerId": 213251,
-    "fullName": "Кастроп",
-    "clubName": "Боруссия М",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213252,
-    "fullName": "Николас",
-    "clubName": "Боруссия М",
-    "position": "GK",
     "league": "Bundesliga",
     "price": 5.0,
     "popularity": 1.0,
-    "fp_last": 63.0
+    "fp_last": 62.0
   },
   {
-    "playerId": 213253,
-    "fullName": "Омлин",
-    "clubName": "Боруссия М",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.7,
-    "fp_last": 31.0
-  },
-  {
-    "playerId": 213254,
-    "fullName": "Скалли",
-    "clubName": "Боруссия М",
-    "position": "DEF",
+    "playerId": 213107,
+    "fullName": "Дауд",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
     "league": "Bundesliga",
     "price": 5.0,
     "popularity": 1.4,
-    "fp_last": 64.0
-  },
-  {
-    "playerId": 213255,
-    "fullName": "Ульрих",
-    "clubName": "Боруссия М",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213256,
-    "fullName": "Фрауло",
-    "clubName": "Боруссия М",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213257,
-    "fullName": "Фукуда",
-    "clubName": "Боруссия М",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.9,
-    "fp_last": 10.0
-  },
-  {
-    "playerId": 213258,
-    "fullName": "Эльведи",
-    "clubName": "Боруссия М",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 3.1,
-    "fp_last": 66.0
-  },
-  {
-    "playerId": 213423,
-    "fullName": "Максимович",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213420,
-    "fullName": "Кампль",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.9,
-    "fp_last": 53.0
-  },
-  {
-    "playerId": 213282,
-    "fullName": "Агу",
-    "clubName": "Вердер",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 3.3,
-    "fp_last": 79.0
-  },
-  {
-    "playerId": 213283,
-    "fullName": "Фридль",
-    "clubName": "Вердер",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.0,
-    "fp_last": 63.0
-  },
-  {
-    "playerId": 213303,
-    "fullName": "Вранкс",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.6,
-    "fp_last": 20.0
-  },
-  {
-    "playerId": 213304,
-    "fullName": "Дардаи",
-    "clubName": "Вольфсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.5,
-    "fp_last": 53.0
-  },
-  {
-    "playerId": 213305,
-    "fullName": "Кульеракис",
-    "clubName": "Вольфсбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.0,
-    "fp_last": 71.0
-  },
-  {
-    "playerId": 213306,
-    "fullName": "Мэле",
-    "clubName": "Вольфсбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 5.2,
-    "fp_last": 87.0
-  },
-  {
-    "playerId": 213307,
-    "fullName": "Пейчинович",
-    "clubName": "Вольфсбург",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213574,
-    "fullName": "Авдуллаху",
-    "clubName": "Хоффенхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213577,
-    "fullName": "Бериша",
-    "clubName": "Хоффенхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213575,
-    "fullName": "Бауманн",
-    "clubName": "Хоффенхайм",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 4.6,
-    "fp_last": 90.0
-  },
-  {
-    "playerId": 213579,
-    "fullName": "Гайгер",
-    "clubName": "Хоффенхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.5,
-    "fp_last": 24.0
-  },
-  {
-    "playerId": 213581,
-    "fullName": "Тохумджу",
-    "clubName": "Хоффенхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 16.0
-  },
-  {
-    "playerId": 213578,
-    "fullName": "Бургер",
-    "clubName": "Хоффенхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213340,
-    "fullName": "Бакери Джатта",
-    "clubName": "Гамбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213341,
-    "fullName": "Мухайм",
-    "clubName": "Гамбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213342,
-    "fullName": "Ремберг",
-    "clubName": "Гамбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213512,
-    "fullName": "Линхарт",
-    "clubName": "Фрайбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.1,
-    "fp_last": 92.0
-  },
-  {
-    "playerId": 213490,
-    "fullName": "Триммель",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.8,
-    "fp_last": 60.0
-  },
-  {
-    "playerId": 213462,
-    "fullName": "Валь",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 2.3,
-    "fp_last": 89.0
-  },
-  {
-    "playerId": 213466,
-    "fullName": "Смит",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.3,
-    "fp_last": 80.0
-  },
-  {
-    "playerId": 213485,
-    "fullName": "Дуки",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.9,
-    "fp_last": 86.0
-  },
-  {
-    "playerId": 213487,
-    "fullName": "Крал",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213486,
-    "fullName": "Кемляйн",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 33.0
-  },
-  {
-    "playerId": 213369,
-    "fullName": "Йоуханнессон",
-    "clubName": "Кельн",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213370,
-    "fullName": "Краус",
-    "clubName": "Кельн",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213371,
-    "fullName": "Мартель",
-    "clubName": "Кельн",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213372,
-    "fullName": "Тиггес",
-    "clubName": "Кельн",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213373,
-    "fullName": "Хусейнбашич",
-    "clubName": "Кельн",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213489,
-    "fullName": "Сков",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 43.0
-  },
-  {
-    "playerId": 213492,
-    "fullName": "Хаберер",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 60.0
-  },
-  {
-    "playerId": 213493,
-    "fullName": "Хедира",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 97.0
-  },
-  {
-    "playerId": 213423,
-    "fullName": "Максимович",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213424,
-    "fullName": "Неделькович",
-    "clubName": "РБ Лейпциг",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 15.0
-  },
-  {
-    "playerId": 213575,
-    "fullName": "Бауманн",
-    "clubName": "Хоффенхайм",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 4.6,
-    "fp_last": 90.0
-  },
-  {
-    "playerId": 213461,
-    "fullName": "Скотт Бэнкс",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.9,
-    "fp_last": 11.0
-  },
-  {
-    "playerId": 213462,
-    "fullName": "Валь",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 2.3,
-    "fp_last": 89.0
-  },
-  {
-    "playerId": 213463,
-    "fullName": "Василь",
-    "clubName": "Санкт-Паули",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 9.6,
-    "fp_last": 127.0
-  },
-  {
-    "playerId": 213464,
-    "fullName": "Меткалф",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 10.0
-  },
-  {
-    "playerId": 213465,
-    "fullName": "Салиакас",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.3,
-    "fp_last": 106.0
-  },
-  {
-    "playerId": 213466,
-    "fullName": "Смит",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.3,
-    "fp_last": 80.0
-  },
-  {
-    "playerId": 213493,
-    "fullName": "Хедира",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 97.0
-  },
-  {
-    "playerId": 213484,
-    "fullName": "Диогу Лейте",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 1.6,
-    "fp_last": 91.0
-  },
-  {
-    "playerId": 213485,
-    "fullName": "Дуки",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.9,
-    "fp_last": 86.0
-  },
-  {
-    "playerId": 213486,
-    "fullName": "Кемляйн",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.3,
-    "fp_last": 33.0
-  },
-  {
-    "playerId": 213487,
-    "fullName": "Крал",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213488,
-    "fullName": "Реннов",
-    "clubName": "Унион Берлин",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 2.7,
-    "fp_last": 110.0
-  },
-  {
-    "playerId": 213489,
-    "fullName": "Сков",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 43.0
-  },
-  {
-    "playerId": 213490,
-    "fullName": "Триммель",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.8,
-    "fp_last": 60.0
-  },
-  {
-    "playerId": 213491,
-    "fullName": "Тузар",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.7,
-    "fp_last": 21.0
-  },
-  {
-    "playerId": 213492,
-    "fullName": "Хаберер",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 5.0,
-    "popularity": 0.4,
-    "fp_last": 60.0
-  },
-  {
-    "playerId": 213566,
-    "fullName": "Акпогума",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.3,
-    "fp_last": 46.0
+    "fp_last": 18.0
   },
   {
     "playerId": 213101,
@@ -22338,6 +19358,26 @@
     "price": 4.5,
     "popularity": 0.8,
     "fp_last": 12.0
+  },
+  {
+    "playerId": 213099,
+    "fullName": "Аменда",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 7.0
+  },
+  {
+    "playerId": 213100,
+    "fullName": "Диллс",
+    "clubName": "Айнтрахт Ф",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
   },
   {
     "playerId": 213102,
@@ -22390,1216 +19430,6 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213133,
-    "fullName": "Брайтхаупт",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 213134,
-    "fullName": "Дардари",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213135,
-    "fullName": "Кудоссу",
-    "clubName": "Аугсбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 33.0
-  },
-  {
-    "playerId": 213136,
-    "fullName": "Кюджюксахын",
-    "clubName": "Аугсбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213137,
-    "fullName": "Матсима",
-    "clubName": "Аугсбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 95.0
-  },
-  {
-    "playerId": 213138,
-    "fullName": "Цезигер",
-    "clubName": "Аугсбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 61.0
-  },
-  {
-    "playerId": 213139,
-    "fullName": "Кевен Шлоттербек",
-    "clubName": "Аугсбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 51.0
-  },
-  {
-    "playerId": 213540,
-    "fullName": "Зирслебен",
-    "clubName": "Хайденхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 35.0
-  },
-  {
-    "playerId": 213185,
-    "fullName": "Альфа-Рупрехт",
-    "clubName": "Байер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213186,
-    "fullName": "Градецки",
-    "clubName": "Байер",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.9,
-    "fp_last": 87.0
-  },
-  {
-    "playerId": 213187,
-    "fullName": "Тап",
-    "clubName": "Байер",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213568,
-    "fullName": "Жандре",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 40.0
-  },
-  {
-    "playerId": 213567,
-    "fullName": "Бернардо",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213549,
-    "fullName": "Янеш",
-    "clubName": "Хайденхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213214,
-    "fullName": "Азхиль",
-    "clubName": "Боруссия Д",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213215,
-    "fullName": "Боямба",
-    "clubName": "Боруссия Д",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213216,
-    "fullName": "Диалло",
-    "clubName": "Боруссия Д",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213539,
-    "fullName": "Гимбер",
-    "clubName": "Хайденхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.3,
-    "fp_last": 67.0
-  },
-  {
-    "playerId": 213249,
-    "fullName": "Фридрих",
-    "clubName": "Боруссия М",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 42.0
-  },
-  {
-    "playerId": 213548,
-    "fullName": "Шиммер",
-    "clubName": "Хайденхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 12.0
-  },
-  {
-    "playerId": 213273,
-    "fullName": "Аде",
-    "clubName": "Вердер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 10.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213274,
-    "fullName": "Альверо",
-    "clubName": "Вердер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 3.4,
-    "fp_last": 11.0
-  },
-  {
-    "playerId": 213275,
-    "fullName": "Вебер",
-    "clubName": "Вердер",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213276,
-    "fullName": "Деман",
-    "clubName": "Вердер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 8.0
-  },
-  {
-    "playerId": 213277,
-    "fullName": "Опиц",
-    "clubName": "Вердер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213278,
-    "fullName": "Пипер",
-    "clubName": "Вердер",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 49.0
-  },
-  {
-    "playerId": 213279,
-    "fullName": "Хансен-Ороэн",
-    "clubName": "Вердер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213280,
-    "fullName": "Чович",
-    "clubName": "Вердер",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213281,
-    "fullName": "Штарк",
-    "clubName": "Вердер",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 67.0
-  },
-  {
-    "playerId": 213547,
-    "fullName": "Траоре",
-    "clubName": "Хайденхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.0,
-    "fp_last": 69.0
-  },
-  {
-    "playerId": 213546,
-    "fullName": "Рамай",
-    "clubName": "Хайденхайм",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213299,
-    "fullName": "Вавро",
-    "clubName": "Вольфсбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.8,
-    "fp_last": 77.0
-  },
-  {
-    "playerId": 213300,
-    "fullName": "Мариус Мюллер",
-    "clubName": "Вольфсбург",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 20.0
-  },
-  {
-    "playerId": 213301,
-    "fullName": "Фишер",
-    "clubName": "Вольфсбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 65.0
-  },
-  {
-    "playerId": 213302,
-    "fullName": "Центер",
-    "clubName": "Вольфсбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213545,
-    "fullName": "Нихьюс",
-    "clubName": "Хайденхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 7.0
-  },
-  {
-    "playerId": 213328,
-    "fullName": "Аджекум",
-    "clubName": "Гамбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213329,
-    "fullName": "Бальде",
-    "clubName": "Гамбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 4.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213330,
-    "fullName": "Мефферт",
-    "clubName": "Гамбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213331,
-    "fullName": "Микельбрансис",
-    "clubName": "Гамбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213332,
-    "fullName": "Озтуналы",
-    "clubName": "Гамбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213333,
-    "fullName": "Перец",
-    "clubName": "Гамбург",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 3.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213334,
-    "fullName": "Сумаоро",
-    "clubName": "Гамбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213335,
-    "fullName": "Торунарига",
-    "clubName": "Гамбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213336,
-    "fullName": "Фераи",
-    "clubName": "Гамбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213337,
-    "fullName": "Хойер",
-    "clubName": "Гамбург",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213338,
-    "fullName": "Эльфадли",
-    "clubName": "Гамбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213339,
-    "fullName": "Ялчинкая",
-    "clubName": "Гамбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213410,
-    "fullName": "Бунги",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213411,
-    "fullName": "Вигго Гебель",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213412,
-    "fullName": "Нуха Джатта",
-    "clubName": "РБ Лейпциг",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213413,
-    "fullName": "Рамсак",
-    "clubName": "РБ Лейпциг",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213414,
-    "fullName": "Финкгрефе",
-    "clubName": "РБ Лейпциг",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213415,
-    "fullName": "Хенрихс",
-    "clubName": "РБ Лейпциг",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 32.0
-  },
-  {
-    "playerId": 213542,
-    "fullName": "Кербер",
-    "clubName": "Хайденхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.9,
-    "fp_last": 36.0
-  },
-  {
-    "playerId": 213450,
-    "fullName": "Айгбекэн",
-    "clubName": "Санкт-Паули",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 2.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213451,
-    "fullName": "Альстранд",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 11.4,
-    "fp_last": 5.0
-  },
-  {
-    "playerId": 213452,
-    "fullName": "Джонс",
-    "clubName": "Санкт-Паули",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213453,
-    "fullName": "Метс",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 31.0
-  },
-  {
-    "playerId": 213454,
-    "fullName": "Немет",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 59.0
-  },
-  {
-    "playerId": 213455,
-    "fullName": "Оппи",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213456,
-    "fullName": "Пырка",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213457,
-    "fullName": "Ритцка",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 40.0
-  },
-  {
-    "playerId": 213458,
-    "fullName": "Сисей",
-    "clubName": "Санкт-Паули",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 213459,
-    "fullName": "Сэндс",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.1,
-    "fp_last": 15.0
-  },
-  {
-    "playerId": 213460,
-    "fullName": "Шмиц",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213544,
-    "fullName": "Кевин Мюллер",
-    "clubName": "Хайденхайм",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 2.7,
-    "fp_last": 95.0
-  },
-  {
-    "playerId": 213543,
-    "fullName": "Майнка",
-    "clubName": "Хайденхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.1,
-    "fp_last": 81.0
-  },
-  {
-    "playerId": 213477,
-    "fullName": "Бурджу",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213478,
-    "fullName": "Кверфельд",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 213479,
-    "fullName": "Любичич",
-    "clubName": "Унион Берлин",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.8,
-    "fp_last": 19.0
-  },
-  {
-    "playerId": 213480,
-    "fullName": "Маркграф",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213481,
-    "fullName": "Нсоки",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213482,
-    "fullName": "Прой",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 5.0
-  },
-  {
-    "playerId": 213413,
-    "fullName": "Рамсак",
-    "clubName": "РБ Лейпциг",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213414,
-    "fullName": "Финкгрефе",
-    "clubName": "РБ Лейпциг",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213415,
-    "fullName": "Хенрихс",
-    "clubName": "РБ Лейпциг",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 32.0
-  },
-  {
-    "playerId": 213450,
-    "fullName": "Айгбекэн",
-    "clubName": "Санкт-Паули",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 2.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213451,
-    "fullName": "Альстранд",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 11.4,
-    "fp_last": 5.0
-  },
-  {
-    "playerId": 213452,
-    "fullName": "Джонс",
-    "clubName": "Санкт-Паули",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 2.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213453,
-    "fullName": "Метс",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 31.0
-  },
-  {
-    "playerId": 213454,
-    "fullName": "Немет",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 59.0
-  },
-  {
-    "playerId": 213455,
-    "fullName": "Оппи",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213456,
-    "fullName": "Пырка",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213457,
-    "fullName": "Ритцка",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 40.0
-  },
-  {
-    "playerId": 213458,
-    "fullName": "Сисей",
-    "clubName": "Санкт-Паули",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 6.0
-  },
-  {
-    "playerId": 213459,
-    "fullName": "Сэндс",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.1,
-    "fp_last": 15.0
-  },
-  {
-    "playerId": 213460,
-    "fullName": "Шмиц",
-    "clubName": "Санкт-Паули",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.0,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213596,
-    "fullName": "Ельч",
-    "clubName": "Штутгарт",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 16.0
-  },
-  {
-    "playerId": 213477,
-    "fullName": "Бурджу",
-    "clubName": "Унион Берлин",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213478,
-    "fullName": "Кверфельд",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.8,
-    "fp_last": 52.0
-  },
-  {
-    "playerId": 213479,
-    "fullName": "Любичич",
-    "clubName": "Унион Берлин",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.8,
-    "fp_last": 19.0
-  },
-  {
-    "playerId": 213480,
-    "fullName": "Маркграф",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213481,
-    "fullName": "Нсоки",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213482,
-    "fullName": "Прой",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 5.0
-  },
-  {
-    "playerId": 213483,
-    "fullName": "Юранович",
-    "clubName": "Унион Берлин",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.3,
-    "fp_last": 37.0
-  },
-  {
-    "playerId": 213505,
-    "fullName": "Кьере",
-    "clubName": "Фрайбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213506,
-    "fullName": "Макенго",
-    "clubName": "Фрайбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 21.0
-  },
-  {
-    "playerId": 213507,
-    "fullName": "Муслия",
-    "clubName": "Фрайбург",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.3,
-    "fp_last": 9.0
-  },
-  {
-    "playerId": 213508,
-    "fullName": "Розенфельдер",
-    "clubName": "Фрайбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.4,
-    "fp_last": 44.0
-  },
-  {
-    "playerId": 213509,
-    "fullName": "Юнг",
-    "clubName": "Фрайбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213539,
-    "fullName": "Гимбер",
-    "clubName": "Хайденхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.3,
-    "fp_last": 67.0
-  },
-  {
-    "playerId": 213540,
-    "fullName": "Зирслебен",
-    "clubName": "Хайденхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 35.0
-  },
-  {
-    "playerId": 213541,
-    "fullName": "Кауфманн",
-    "clubName": "Хайденхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.4,
-    "fp_last": 11.0
-  },
-  {
-    "playerId": 213542,
-    "fullName": "Кербер",
-    "clubName": "Хайденхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.9,
-    "fp_last": 36.0
-  },
-  {
-    "playerId": 213543,
-    "fullName": "Майнка",
-    "clubName": "Хайденхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.1,
-    "fp_last": 81.0
-  },
-  {
-    "playerId": 213544,
-    "fullName": "Кевин Мюллер",
-    "clubName": "Хайденхайм",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 2.7,
-    "fp_last": 95.0
-  },
-  {
-    "playerId": 213545,
-    "fullName": "Нихьюс",
-    "clubName": "Хайденхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 7.0
-  },
-  {
-    "playerId": 213546,
-    "fullName": "Рамай",
-    "clubName": "Хайденхайм",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213547,
-    "fullName": "Траоре",
-    "clubName": "Хайденхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.0,
-    "fp_last": 69.0
-  },
-  {
-    "playerId": 213548,
-    "fullName": "Шиммер",
-    "clubName": "Хайденхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 12.0
-  },
-  {
-    "playerId": 213549,
-    "fullName": "Янеш",
-    "clubName": "Хайденхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213566,
-    "fullName": "Акпогума",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.3,
-    "fp_last": 46.0
-  },
-  {
-    "playerId": 213567,
-    "fullName": "Бернардо",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 1.1,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213568,
-    "fullName": "Жандре",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.2,
-    "fp_last": 40.0
-  },
-  {
-    "playerId": 213569,
-    "fullName": "Матида",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213570,
-    "fullName": "Моква",
-    "clubName": "Хоффенхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 213571,
-    "fullName": "Хюрюляйнен",
-    "clubName": "Хоффенхайм",
-    "position": "MID",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213572,
-    "fullName": "Цайтлер",
-    "clubName": "Хоффенхайм",
-    "position": "FWD",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213573,
-    "fullName": "Чавес",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.9,
-    "fp_last": 41.0
-  },
-  {
-    "playerId": 213595,
-    "fullName": "Бредлов",
-    "clubName": "Штутгарт",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.5,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
     "playerId": 213092,
     "fullName": "Баум",
     "clubName": "Айнтрахт Ф",
@@ -23610,43 +19440,13 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213093,
-    "fullName": "Бута",
-    "clubName": "Айнтрахт Ф",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 2.2,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213094,
-    "fullName": "Граль",
+    "playerId": 213098,
+    "fullName": "Шильевич",
     "clubName": "Айнтрахт Ф",
     "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213095,
-    "fullName": "Думбия",
-    "clubName": "Айнтрахт Ф",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213096,
-    "fullName": "Смолчич",
-    "clubName": "Айнтрахт Ф",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.7,
+    "popularity": 0.6,
     "fp_last": 0.0
   },
   {
@@ -23660,14 +19460,314 @@
     "fp_last": 3.0
   },
   {
-    "playerId": 213129,
-    "fullName": "Ноакай Бэнкс",
+    "playerId": 213096,
+    "fullName": "Смолчич",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213095,
+    "fullName": "Думбия",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213094,
+    "fullName": "Граль",
+    "clubName": "Айнтрахт Ф",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213093,
+    "fullName": "Бута",
+    "clubName": "Айнтрахт Ф",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 2.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213156,
+    "fullName": "Клод-Морис",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.8,
+    "fp_last": 120.0
+  },
+  {
+    "playerId": 213155,
+    "fullName": "Эссенде",
+    "clubName": "Аугсбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.5,
+    "fp_last": 75.0
+  },
+  {
+    "playerId": 213154,
+    "fullName": "Титц",
+    "clubName": "Аугсбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.8,
+    "fp_last": 82.0
+  },
+  {
+    "playerId": 213153,
+    "fullName": "Саад",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213152,
+    "fullName": "Кемюр",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.4,
+    "fp_last": 38.0
+  },
+  {
+    "playerId": 213151,
+    "fullName": "Реджбечай",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.6,
+    "fp_last": 60.0
+  },
+  {
+    "playerId": 213150,
+    "fullName": "Мунье",
+    "clubName": "Аугсбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.6,
+    "fp_last": 18.0
+  },
+  {
+    "playerId": 213149,
+    "fullName": "Арне Майер",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 213142,
+    "fullName": "Дамен",
+    "clubName": "Аугсбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.7,
+    "fp_last": 82.0
+  },
+  {
+    "playerId": 213148,
+    "fullName": "Яннулис",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.3,
+    "fp_last": 91.0
+  },
+  {
+    "playerId": 213147,
+    "fullName": "Якич",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 81.0
+  },
+  {
+    "playerId": 213146,
+    "fullName": "Фелльхауэр",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213145,
+    "fullName": "Массенго",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213144,
+    "fullName": "Кабадайы",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 10.0
+  },
+  {
+    "playerId": 213143,
+    "fullName": "Донг",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213141,
+    "fullName": "Гауэлеу",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.3,
+    "fp_last": 101.0
+  },
+  {
+    "playerId": 213140,
+    "fullName": "Вольф",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.4,
+    "fp_last": 104.0
+  },
+  {
+    "playerId": 213139,
+    "fullName": "Кевен Шлоттербек",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 51.0
+  },
+  {
+    "playerId": 213138,
+    "fullName": "Цезигер",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 213137,
+    "fullName": "Матсима",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 95.0
+  },
+  {
+    "playerId": 213136,
+    "fullName": "Кюджюксахын",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213135,
+    "fullName": "Кудоссу",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 213134,
+    "fullName": "Дардари",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213133,
+    "fullName": "Брайтхаупт",
+    "clubName": "Аугсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 213128,
+    "fullName": "Бауэр",
     "clubName": "Аугсбург",
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.1,
-    "fp_last": 10.0
+    "popularity": 17.1,
+    "fp_last": 14.0
+  },
+  {
+    "playerId": 213132,
+    "fullName": "Педерсен",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.4,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 213131,
+    "fullName": "Лабрович",
+    "clubName": "Аугсбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.3,
+    "fp_last": 35.0
   },
   {
     "playerId": 213130,
@@ -23680,6 +19780,276 @@
     "fp_last": 0.0
   },
   {
+    "playerId": 213129,
+    "fullName": "Ноакай Бэнкс",
+    "clubName": "Аугсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.1,
+    "fp_last": 10.0
+  },
+  {
+    "playerId": 213183,
+    "fullName": "Кейн",
+    "clubName": "Бавария",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 11.5,
+    "popularity": 58.7,
+    "fp_last": 199.0
+  },
+  {
+    "playerId": 213182,
+    "fullName": "Олисе",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 11.0,
+    "popularity": 40.8,
+    "fp_last": 190.0
+  },
+  {
+    "playerId": 213181,
+    "fullName": "Мусиала",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 10.5,
+    "popularity": 8.4,
+    "fp_last": 127.0
+  },
+  {
+    "playerId": 213180,
+    "fullName": "Диас",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 9.0,
+    "popularity": 16.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213179,
+    "fullName": "Коман",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 1.9,
+    "fp_last": 88.0
+  },
+  {
+    "playerId": 213178,
+    "fullName": "Киммих",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 17.5,
+    "fp_last": 147.0
+  },
+  {
+    "playerId": 213177,
+    "fullName": "Гнабри",
+    "clubName": "Бавария",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 2.3,
+    "fp_last": 98.0
+  },
+  {
+    "playerId": 213176,
+    "fullName": "Горетцка",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.7,
+    "fp_last": 71.0
+  },
+  {
+    "playerId": 213175,
+    "fullName": "Бисхоф",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213174,
+    "fullName": "Павлович",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.8,
+    "fp_last": 56.0
+  },
+  {
+    "playerId": 213173,
+    "fullName": "Ваннер",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213170,
+    "fullName": "Лаймер",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 3.3,
+    "fp_last": 73.0
+  },
+  {
+    "playerId": 213172,
+    "fullName": "Та",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 8.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213171,
+    "fullName": "Нойер",
+    "clubName": "Бавария",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 9.5,
+    "fp_last": 100.0
+  },
+  {
+    "playerId": 213169,
+    "fullName": "Дэвис",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 6.8,
+    "fp_last": 76.0
+  },
+  {
+    "playerId": 213168,
+    "fullName": "Геррейру",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 5.4,
+    "fp_last": 112.0
+  },
+  {
+    "playerId": 213167,
+    "fullName": "Урбиг",
+    "clubName": "Бавария",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5,
+    "fp_last": 23.0
+  },
+  {
+    "playerId": 213166,
+    "fullName": "Упамекано",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 3.3,
+    "fp_last": 81.0
+  },
+  {
+    "playerId": 213165,
+    "fullName": "Станишич",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 42.0
+  },
+  {
+    "playerId": 213164,
+    "fullName": "Пальинья",
+    "clubName": "Бавария",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.1,
+    "fp_last": 24.0
+  },
+  {
+    "playerId": 213163,
+    "fullName": "Ким Мин Чжэ",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.7,
+    "fp_last": 99.0
+  },
+  {
+    "playerId": 213162,
+    "fullName": "Боэ",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 28.0
+  },
+  {
+    "playerId": 213161,
+    "fullName": "Ито",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 21.0
+  },
+  {
+    "playerId": 213160,
+    "fullName": "Куси-Асаре",
+    "clubName": "Бавария",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 213157,
+    "fullName": "Бухманн",
+    "clubName": "Бавария",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213159,
+    "fullName": "Ульрайх",
+    "clubName": "Бавария",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 6.0
+  },
+  {
     "playerId": 213158,
     "fullName": "Кланац",
     "clubName": "Бавария",
@@ -23690,6 +20060,236 @@
     "fp_last": 0.0
   },
   {
+    "playerId": 213207,
+    "fullName": "Шик",
+    "clubName": "Байер",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 9.0,
+    "popularity": 14.2,
+    "fp_last": 139.0
+  },
+  {
+    "playerId": 213206,
+    "fullName": "Тилльман",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 5.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213205,
+    "fullName": "Бонифасе",
+    "clubName": "Байер",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 9.2,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 213204,
+    "fullName": "Телла",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 2.7,
+    "fp_last": 67.0
+  },
+  {
+    "playerId": 213203,
+    "fullName": "Терье",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.1,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 213202,
+    "fullName": "Алеиш Гарсия",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 2.7,
+    "fp_last": 77.0
+  },
+  {
+    "playerId": 213201,
+    "fullName": "Адли",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 4.5,
+    "fp_last": 38.0
+  },
+  {
+    "playerId": 213199,
+    "fullName": "Гримальдо",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 32.0,
+    "fp_last": 122.0
+  },
+  {
+    "playerId": 213200,
+    "fullName": "Хофманн",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213195,
+    "fullName": "Андрих",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 3.4,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 213196,
+    "fullName": "Маза",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213197,
+    "fullName": "Паласиос",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 2.2,
+    "fp_last": 66.0
+  },
+  {
+    "playerId": 213198,
+    "fullName": "Флеккен",
+    "clubName": "Байер",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 6.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213192,
+    "fullName": "Артур",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 3.8,
+    "fp_last": 37.0
+  },
+  {
+    "playerId": 213193,
+    "fullName": "Инкапиэ",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 5.9,
+    "fp_last": 92.0
+  },
+  {
+    "playerId": 213194,
+    "fullName": "Тапсоба",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 4.7,
+    "fp_last": 68.0
+  },
+  {
+    "playerId": 213189,
+    "fullName": "Кофан",
+    "clubName": "Байер",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213191,
+    "fullName": "Сарко",
+    "clubName": "Байер",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213190,
+    "fullName": "Куанса",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 4.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213188,
+    "fullName": "Белосьян",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.8,
+    "fp_last": 3.0
+  },
+  {
+    "playerId": 213185,
+    "fullName": "Альфа-Рупрехт",
+    "clubName": "Байер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213187,
+    "fullName": "Тап",
+    "clubName": "Байер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213186,
+    "fullName": "Градецки",
+    "clubName": "Байер",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.9,
+    "fp_last": 87.0
+  },
+  {
     "playerId": 213184,
     "fullName": "Ломб",
     "clubName": "Байер",
@@ -23697,6 +20297,276 @@
     "league": "Bundesliga",
     "price": 4.0,
     "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213407,
+    "fullName": "Бласвих",
+    "clubName": "Байер",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 2.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213239,
+    "fullName": "Гирасси",
+    "clubName": "Боруссия Д",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 10.5,
+    "popularity": 37.5,
+    "fp_last": 171.0
+  },
+  {
+    "playerId": 213238,
+    "fullName": "Адейеми",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 9.0,
+    "popularity": 12.4,
+    "fp_last": 96.0
+  },
+  {
+    "playerId": 213237,
+    "fullName": "Брандт",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 8.5,
+    "popularity": 8.6,
+    "fp_last": 126.0
+  },
+  {
+    "playerId": 213236,
+    "fullName": "Байер",
+    "clubName": "Боруссия Д",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 2.7,
+    "fp_last": 93.0
+  },
+  {
+    "playerId": 213235,
+    "fullName": "Беллингем",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 27.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213234,
+    "fullName": "Гросс",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 5.4,
+    "fp_last": 100.0
+  },
+  {
+    "playerId": 213233,
+    "fullName": "Нмеча",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213232,
+    "fullName": "Забитцер",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 3.2,
+    "fp_last": 58.0
+  },
+  {
+    "playerId": 213231,
+    "fullName": "Дюранвиль",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.5,
+    "fp_last": 11.0
+  },
+  {
+    "playerId": 213230,
+    "fullName": "Аллер",
+    "clubName": "Боруссия Д",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213229,
+    "fullName": "Свенссон",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 7.9,
+    "fp_last": 42.0
+  },
+  {
+    "playerId": 213228,
+    "fullName": "Рюэрсон",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 6.0,
+    "fp_last": 84.0
+  },
+  {
+    "playerId": 213227,
+    "fullName": "Кобель",
+    "clubName": "Боруссия Д",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 14.9,
+    "fp_last": 90.0
+  },
+  {
+    "playerId": 213224,
+    "fullName": "Джан",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 3.7,
+    "fp_last": 85.0
+  },
+  {
+    "playerId": 213226,
+    "fullName": "Нико Шлоттербек",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 7.7,
+    "fp_last": 55.0
+  },
+  {
+    "playerId": 213225,
+    "fullName": "Рейна",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 29.0
+  },
+  {
+    "playerId": 213223,
+    "fullName": "Бенсебайни",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 4.9,
+    "fp_last": 86.0
+  },
+  {
+    "playerId": 213222,
+    "fullName": "Антон",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 7.1,
+    "fp_last": 68.0
+  },
+  {
+    "playerId": 213221,
+    "fullName": "Ян Коуто",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.0,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 213220,
+    "fullName": "Озджан",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 213219,
+    "fullName": "Александр Майер",
+    "clubName": "Боруссия Д",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.9,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 213218,
+    "fullName": "Кэмпбелл",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 4.0
+  },
+  {
+    "playerId": 213217,
+    "fullName": "Зюле",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.0,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 213216,
+    "fullName": "Диалло",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213215,
+    "fullName": "Боямба",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213214,
+    "fullName": "Азхиль",
+    "clubName": "Боруссия Д",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.5,
     "fp_last": 0.0
   },
   {
@@ -23710,34 +20580,14 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213209,
-    "fullName": "Патрик Гебель",
-    "clubName": "Боруссия Д",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.3,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213210,
-    "fullName": "Древес",
-    "clubName": "Боруссия Д",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213211,
-    "fullName": "Кабар",
+    "playerId": 213213,
+    "fullName": "Мане",
     "clubName": "Боруссия Д",
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
     "popularity": 0.5,
-    "fp_last": 2.0
+    "fp_last": 0.0
   },
   {
     "playerId": 213212,
@@ -23750,6 +20600,316 @@
     "fp_last": 2.0
   },
   {
+    "playerId": 213211,
+    "fullName": "Кабар",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 213210,
+    "fullName": "Древес",
+    "clubName": "Боруссия Д",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213209,
+    "fullName": "Патрик Гебель",
+    "clubName": "Боруссия Д",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213268,
+    "fullName": "Кляйндинст",
+    "clubName": "Боруссия М",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 8.5,
+    "popularity": 8.8,
+    "fp_last": 166.0
+  },
+  {
+    "playerId": 213267,
+    "fullName": "Хак",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 2.2,
+    "fp_last": 110.0
+  },
+  {
+    "playerId": 213266,
+    "fullName": "Онора",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 3.0,
+    "fp_last": 84.0
+  },
+  {
+    "playerId": 213265,
+    "fullName": "Матино",
+    "clubName": "Боруссия М",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213264,
+    "fullName": "Штегер",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.2,
+    "fp_last": 79.0
+  },
+  {
+    "playerId": 213263,
+    "fullName": "Табакович",
+    "clubName": "Боруссия М",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213262,
+    "fullName": "Райтц",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 69.0
+  },
+  {
+    "playerId": 213261,
+    "fullName": "Нгуму",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.3,
+    "fp_last": 46.0
+  },
+  {
+    "playerId": 213260,
+    "fullName": "Вайгль",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 3.8,
+    "fp_last": 97.0
+  },
+  {
+    "playerId": 213259,
+    "fullName": "Зандер",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.6,
+    "fp_last": 54.0
+  },
+  {
+    "playerId": 213254,
+    "fullName": "Скалли",
+    "clubName": "Боруссия М",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 64.0
+  },
+  {
+    "playerId": 213258,
+    "fullName": "Эльведи",
+    "clubName": "Боруссия М",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 3.1,
+    "fp_last": 66.0
+  },
+  {
+    "playerId": 213257,
+    "fullName": "Фукуда",
+    "clubName": "Боруссия М",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.9,
+    "fp_last": 10.0
+  },
+  {
+    "playerId": 213256,
+    "fullName": "Фрауло",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213255,
+    "fullName": "Ульрих",
+    "clubName": "Боруссия М",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213253,
+    "fullName": "Омлин",
+    "clubName": "Боруссия М",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.7,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 213252,
+    "fullName": "Николас",
+    "clubName": "Боруссия М",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.0,
+    "fp_last": 63.0
+  },
+  {
+    "playerId": 213251,
+    "fullName": "Кастроп",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213250,
+    "fullName": "Итакура",
+    "clubName": "Боруссия М",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 3.5,
+    "fp_last": 82.0
+  },
+  {
+    "playerId": 213249,
+    "fullName": "Фридрих",
+    "clubName": "Боруссия М",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 42.0
+  },
+  {
+    "playerId": 213248,
+    "fullName": "Свидер",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213247,
+    "fullName": "Ранос",
+    "clubName": "Боруссия М",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 213246,
+    "fullName": "Нойхаус",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.6,
+    "fp_last": 23.0
+  },
+  {
+    "playerId": 213245,
+    "fullName": "Нетц",
+    "clubName": "Боруссия М",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.9,
+    "fp_last": 39.0
+  },
+  {
+    "playerId": 213244,
+    "fullName": "Дикс",
+    "clubName": "Боруссия М",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 2.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213243,
+    "fullName": "Боржес Санчес",
+    "clubName": "Боруссия М",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213240,
+    "fullName": "Зиппель",
+    "clubName": "Боруссия М",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213242,
+    "fullName": "Перейра Кардозу",
+    "clubName": "Боруссия М",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
     "playerId": 213241,
     "fullName": "Кьяродиа",
     "clubName": "Боруссия М",
@@ -23760,13 +20920,223 @@
     "fp_last": 22.0
   },
   {
-    "playerId": 213242,
-    "fullName": "Перейра Кардозу",
-    "clubName": "Боруссия М",
+    "playerId": 213294,
+    "fullName": "Романо Шмид",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213293,
+    "fullName": "Стаге",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 3.1,
+    "fp_last": 134.0
+  },
+  {
+    "playerId": 213292,
+    "fullName": "Дукш",
+    "clubName": "Вердер",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 2.1,
+    "fp_last": 120.0
+  },
+  {
+    "playerId": 213291,
+    "fullName": "Топп",
+    "clubName": "Вердер",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.7,
+    "fp_last": 32.0
+  },
+  {
+    "playerId": 213290,
+    "fullName": "Мбангула",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213289,
+    "fullName": "Грюлль",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.8,
+    "fp_last": 80.0
+  },
+  {
+    "playerId": 213288,
+    "fullName": "Нджинма",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.5,
+    "fp_last": 59.0
+  },
+  {
+    "playerId": 213287,
+    "fullName": "Линен",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.5,
+    "fp_last": 85.0
+  },
+  {
+    "playerId": 213286,
+    "fullName": "Вайзер",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 6.6,
+    "fp_last": 128.0
+  },
+  {
+    "playerId": 213285,
+    "fullName": "Цеттерер",
+    "clubName": "Вердер",
     "position": "GK",
     "league": "Bundesliga",
-    "price": 4.0,
+    "price": 5.5,
+    "popularity": 1.5,
+    "fp_last": 109.0
+  },
+  {
+    "playerId": 213284,
+    "fullName": "Битенкур",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5,
+    "fp_last": 48.0
+  },
+  {
+    "playerId": 213282,
+    "fullName": "Агу",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 3.3,
+    "fp_last": 79.0
+  },
+  {
+    "playerId": 213283,
+    "fullName": "Фридль",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.0,
+    "fp_last": 63.0
+  },
+  {
+    "playerId": 213281,
+    "fullName": "Штарк",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 67.0
+  },
+  {
+    "playerId": 213280,
+    "fullName": "Чович",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213279,
+    "fullName": "Хансен-Ороэн",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
     "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213278,
+    "fullName": "Пипер",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 49.0
+  },
+  {
+    "playerId": 213277,
+    "fullName": "Опиц",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213276,
+    "fullName": "Деман",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 8.0
+  },
+  {
+    "playerId": 213275,
+    "fullName": "Вебер",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213274,
+    "fullName": "Альверо",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 3.4,
+    "fp_last": 11.0
+  },
+  {
+    "playerId": 213273,
+    "fullName": "Аде",
+    "clubName": "Вердер",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 10.3,
     "fp_last": 0.0
   },
   {
@@ -23780,16 +21150,6 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213270,
-    "fullName": "Кольке",
-    "clubName": "Вердер",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
     "playerId": 213272,
     "fullName": "Шметгенс",
     "clubName": "Вердер",
@@ -23800,6 +21160,246 @@
     "fp_last": 0.0
   },
   {
+    "playerId": 213271,
+    "fullName": "Малатини",
+    "clubName": "Вердер",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.9,
+    "fp_last": 18.0
+  },
+  {
+    "playerId": 213270,
+    "fullName": "Кольке",
+    "clubName": "Вердер",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213321,
+    "fullName": "Амура",
+    "clubName": "Вольфсбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 3.7,
+    "fp_last": 131.0
+  },
+  {
+    "playerId": 213320,
+    "fullName": "Черны",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213319,
+    "fullName": "Маер",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.7,
+    "fp_last": 24.0
+  },
+  {
+    "playerId": 213318,
+    "fullName": "Винд",
+    "clubName": "Вольфсбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 2.9,
+    "fp_last": 101.0
+  },
+  {
+    "playerId": 213317,
+    "fullName": "Виммер",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 2.3,
+    "fp_last": 78.0
+  },
+  {
+    "playerId": 213315,
+    "fullName": "Линдстрем",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213314,
+    "fullName": "Арнольд",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 4.4,
+    "fp_last": 102.0
+  },
+  {
+    "playerId": 213313,
+    "fullName": "Ольсен",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 25.0
+  },
+  {
+    "playerId": 213308,
+    "fullName": "Винисиус",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213312,
+    "fullName": "Сванберг",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5,
+    "fp_last": 54.0
+  },
+  {
+    "playerId": 213311,
+    "fullName": "Паредес",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 213310,
+    "fullName": "Грабара",
+    "clubName": "Вольфсбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 3.0,
+    "fp_last": 89.0
+  },
+  {
+    "playerId": 213309,
+    "fullName": "Герхардт",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5,
+    "fp_last": 56.0
+  },
+  {
+    "playerId": 213307,
+    "fullName": "Пейчинович",
+    "clubName": "Вольфсбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213306,
+    "fullName": "Мэле",
+    "clubName": "Вольфсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 5.2,
+    "fp_last": 87.0
+  },
+  {
+    "playerId": 213305,
+    "fullName": "Кульеракис",
+    "clubName": "Вольфсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.0,
+    "fp_last": 71.0
+  },
+  {
+    "playerId": 213304,
+    "fullName": "Дардаи",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 53.0
+  },
+  {
+    "playerId": 213303,
+    "fullName": "Вранкс",
+    "clubName": "Вольфсбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.6,
+    "fp_last": 20.0
+  },
+  {
+    "playerId": 213302,
+    "fullName": "Центер",
+    "clubName": "Вольфсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213301,
+    "fullName": "Фишер",
+    "clubName": "Вольфсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 65.0
+  },
+  {
+    "playerId": 213300,
+    "fullName": "Мариус Мюллер",
+    "clubName": "Вольфсбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 20.0
+  },
+  {
+    "playerId": 213299,
+    "fullName": "Вавро",
+    "clubName": "Вольфсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.8,
+    "fp_last": 77.0
+  },
+  {
     "playerId": 213295,
     "fullName": "Зелиньски",
     "clubName": "Вольфсбург",
@@ -23807,26 +21407,6 @@
     "league": "Bundesliga",
     "price": 4.0,
     "popularity": 2.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213296,
-    "fullName": "Йенц",
-    "clubName": "Вольфсбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213297,
-    "fullName": "Перван",
-    "clubName": "Вольфсбург",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.5,
     "fp_last": 0.0
   },
   {
@@ -23840,6 +21420,246 @@
     "fp_last": 0.0
   },
   {
+    "playerId": 213297,
+    "fullName": "Перван",
+    "clubName": "Вольфсбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213296,
+    "fullName": "Йенц",
+    "clubName": "Вольфсбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213349,
+    "fullName": "Поульсен",
+    "clubName": "Гамбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 2.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213348,
+    "fullName": "Райан Филипп",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213347,
+    "fullName": "Кенигсдорффер",
+    "clubName": "Гамбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213346,
+    "fullName": "Домпе",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 2.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213345,
+    "fullName": "Сахити",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213344,
+    "fullName": "Капальдо",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213343,
+    "fullName": "Глатцель",
+    "clubName": "Гамбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213342,
+    "fullName": "Ремберг",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213341,
+    "fullName": "Мухайм",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213340,
+    "fullName": "Бакери Джатта",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213336,
+    "fullName": "Фераи",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213339,
+    "fullName": "Ялчинкая",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213338,
+    "fullName": "Эльфадли",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213337,
+    "fullName": "Хойер",
+    "clubName": "Гамбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213335,
+    "fullName": "Торунарига",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213334,
+    "fullName": "Сумаоро",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213333,
+    "fullName": "Перец",
+    "clubName": "Гамбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 3.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213332,
+    "fullName": "Озтуналы",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213331,
+    "fullName": "Микельбрансис",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213330,
+    "fullName": "Мефферт",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213329,
+    "fullName": "Бальде",
+    "clubName": "Гамбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 4.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213328,
+    "fullName": "Аджекум",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
     "playerId": 213322,
     "fullName": "Дикес",
     "clubName": "Гамбург",
@@ -23850,33 +21670,13 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213323,
-    "fullName": "Каттербах",
+    "playerId": 213327,
+    "fullName": "Шонлау",
     "clubName": "Гамбург",
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213324,
-    "fullName": "Рамуш",
-    "clubName": "Гамбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.7,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213325,
-    "fullName": "Херман",
-    "clubName": "Гамбург",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.8,
+    "popularity": 1.8,
     "fp_last": 0.0
   },
   {
@@ -23890,6 +21690,586 @@
     "fp_last": 0.0
   },
   {
+    "playerId": 213325,
+    "fullName": "Херман",
+    "clubName": "Гамбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213324,
+    "fullName": "Рамуш",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213323,
+    "fullName": "Каттербах",
+    "clubName": "Гамбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213380,
+    "fullName": "Вальдшмидт",
+    "clubName": "Кельн",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213379,
+    "fullName": "Бюльтер",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213378,
+    "fullName": "Тильманн",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213377,
+    "fullName": "Майна",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213376,
+    "fullName": "Каминьски",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213375,
+    "fullName": "Кайнц",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213374,
+    "fullName": "Ахе",
+    "clubName": "Кельн",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213373,
+    "fullName": "Хусейнбашич",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213372,
+    "fullName": "Тиггес",
+    "clubName": "Кельн",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213371,
+    "fullName": "Мартель",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213370,
+    "fullName": "Краус",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213369,
+    "fullName": "Йоуханнессон",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213365,
+    "fullName": "Швэбе",
+    "clubName": "Кельн",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 4.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213368,
+    "fullName": "Саид Эль Мала",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213367,
+    "fullName": "Малек Эль Мала",
+    "clubName": "Кельн",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213366,
+    "fullName": "Йоэль Шмид",
+    "clubName": "Кельн",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213364,
+    "fullName": "Хюберс",
+    "clubName": "Кельн",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213363,
+    "fullName": "Себулонсен",
+    "clubName": "Кельн",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213362,
+    "fullName": "Рондич",
+    "clubName": "Кельн",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213361,
+    "fullName": "Пакярада",
+    "clubName": "Кельн",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213360,
+    "fullName": "Якоб Кристенсен",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213359,
+    "fullName": "Дитц",
+    "clubName": "Кельн",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213358,
+    "fullName": "Газибегович",
+    "clubName": "Кельн",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213357,
+    "fullName": "Аршауи",
+    "clubName": "Кельн",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 4.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213356,
+    "fullName": "Адамян",
+    "clubName": "Кельн",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 10.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213350,
+    "fullName": "Кеббинг",
+    "clubName": "Кельн",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213355,
+    "fullName": "Цилер",
+    "clubName": "Кельн",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 2.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213354,
+    "fullName": "Хайнц",
+    "clubName": "Кельн",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213353,
+    "fullName": "Телле",
+    "clubName": "Кельн",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213352,
+    "fullName": "Паули",
+    "clubName": "Кельн",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213351,
+    "fullName": "Килиан",
+    "clubName": "Кельн",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213406,
+    "fullName": "Небель",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 4.1,
+    "fp_last": 137.0
+  },
+  {
+    "playerId": 213405,
+    "fullName": "Ли Чжэ Сон",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 3.5,
+    "fp_last": 138.0
+  },
+  {
+    "playerId": 213404,
+    "fullName": "Амири",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 7.8,
+    "fp_last": 120.0
+  },
+  {
+    "playerId": 213403,
+    "fullName": "Холлербах",
+    "clubName": "Майнц",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213402,
+    "fullName": "Сано",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.1,
+    "fp_last": 106.0
+  },
+  {
+    "playerId": 213401,
+    "fullName": "Вайпер",
+    "clubName": "Майнц",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.4,
+    "fp_last": 46.0
+  },
+  {
+    "playerId": 213400,
+    "fullName": "Норден",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.4,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 213399,
+    "fullName": "Центнер",
+    "clubName": "Майнц",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 3.3,
+    "fp_last": 110.0
+  },
+  {
+    "playerId": 213398,
+    "fullName": "Мвене",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 2.6,
+    "fp_last": 97.0
+  },
+  {
+    "playerId": 213397,
+    "fullName": "Каси",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 6.2,
+    "fp_last": 107.0
+  },
+  {
+    "playerId": 213394,
+    "fullName": "Кавасаки",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213396,
+    "fullName": "Мэлоуни",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 22.0
+  },
+  {
+    "playerId": 213395,
+    "fullName": "Кор",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.4,
+    "fp_last": 80.0
+  },
+  {
+    "playerId": 213393,
+    "fullName": "да Кошта",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.3,
+    "fp_last": 75.0
+  },
+  {
+    "playerId": 213392,
+    "fullName": "Хон Хен Сок",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 24.0
+  },
+  {
+    "playerId": 213391,
+    "fullName": "Ханче-Ольсен",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 213390,
+    "fullName": "Ферачниг",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 15.0
+  },
+  {
+    "playerId": 213389,
+    "fullName": "Гляйбер",
+    "clubName": "Майнц",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213388,
+    "fullName": "Видмер",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.0,
+    "fp_last": 38.0
+  },
+  {
+    "playerId": 213387,
+    "fullName": "Белль",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.5,
+    "fp_last": 46.0
+  },
+  {
+    "playerId": 213381,
+    "fullName": "Бац",
+    "clubName": "Майнц",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 5.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213386,
+    "fullName": "Шопп",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213385,
+    "fullName": "Рисс",
+    "clubName": "Майнц",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 213384,
+    "fullName": "Ляйтш",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.5,
+    "fp_last": 29.0
+  },
+  {
     "playerId": 213383,
     "fullName": "Даль",
     "clubName": "Майнц",
@@ -23897,6 +22277,366 @@
     "league": "Bundesliga",
     "price": 4.0,
     "popularity": 0.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213382,
+    "fullName": "Бос",
+    "clubName": "Майнц",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 4.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213444,
+    "fullName": "Симонс",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 10.0,
+    "popularity": 7.6,
+    "fp_last": 146.0
+  },
+  {
+    "playerId": 213443,
+    "fullName": "Шешко",
+    "clubName": "РБ Лейпциг",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 9.0,
+    "popularity": 2.4,
+    "fp_last": 136.0
+  },
+  {
+    "playerId": 213442,
+    "fullName": "Опенда",
+    "clubName": "РБ Лейпциг",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 8.5,
+    "popularity": 10.0,
+    "fp_last": 123.0
+  },
+  {
+    "playerId": 213441,
+    "fullName": "Бакайоко",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 5.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213440,
+    "fullName": "Нуса",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 3.0,
+    "fp_last": 81.0
+  },
+  {
+    "playerId": 213439,
+    "fullName": "Диоманде",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213438,
+    "fullName": "Вернер",
+    "clubName": "РБ Лейпциг",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 4.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213437,
+    "fullName": "Баумгартнер",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 2.9,
+    "fp_last": 69.0
+  },
+  {
+    "playerId": 213436,
+    "fullName": "Элмаз",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.6,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 213429,
+    "fullName": "Айдара",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.8,
+    "fp_last": 46.0
+  },
+  {
+    "playerId": 213430,
+    "fullName": "Андре Силва",
+    "clubName": "РБ Лейпциг",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213431,
+    "fullName": "Баку",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 5.1,
+    "fp_last": 112.0
+  },
+  {
+    "playerId": 213432,
+    "fullName": "Гулачи",
+    "clubName": "РБ Лейпциг",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 6.9,
+    "fp_last": 127.0
+  },
+  {
+    "playerId": 213433,
+    "fullName": "Зайвальд",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.5,
+    "fp_last": 70.0
+  },
+  {
+    "playerId": 213434,
+    "fullName": "Раум",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 9.6,
+    "fp_last": 92.0
+  },
+  {
+    "playerId": 213435,
+    "fullName": "Шлагер",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.8,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 213426,
+    "fullName": "Вандевордт",
+    "clubName": "РБ Лейпциг",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.3,
+    "fp_last": 9.0
+  },
+  {
+    "playerId": 213428,
+    "fullName": "Уэдраого",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 3.0
+  },
+  {
+    "playerId": 213427,
+    "fullName": "Вилли Орбан",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 7.6,
+    "fp_last": 101.0
+  },
+  {
+    "playerId": 213425,
+    "fullName": "Бандзузи",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213417,
+    "fullName": "Вермерен",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 48.0
+  },
+  {
+    "playerId": 213416,
+    "fullName": "Битшиабу",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.5,
+    "fp_last": 38.0
+  },
+  {
+    "playerId": 213418,
+    "fullName": "Гертрюйда",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 3.3,
+    "fp_last": 64.0
+  },
+  {
+    "playerId": 213419,
+    "fullName": "Гомис",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 10.0
+  },
+  {
+    "playerId": 213420,
+    "fullName": "Кампль",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.9,
+    "fp_last": 53.0
+  },
+  {
+    "playerId": 213421,
+    "fullName": "Клостерманн",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.2,
+    "fp_last": 71.0
+  },
+  {
+    "playerId": 213422,
+    "fullName": "Лукеба",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.1,
+    "fp_last": 61.0
+  },
+  {
+    "playerId": 213423,
+    "fullName": "Максимович",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213424,
+    "fullName": "Неделькович",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 15.0
+  },
+  {
+    "playerId": 213415,
+    "fullName": "Хенрихс",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 32.0
+  },
+  {
+    "playerId": 213414,
+    "fullName": "Финкгрефе",
+    "clubName": "РБ Лейпциг",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213413,
+    "fullName": "Рамсак",
+    "clubName": "РБ Лейпциг",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213412,
+    "fullName": "Нуха Джатта",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213411,
+    "fullName": "Вигго Гебель",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213410,
+    "fullName": "Бунги",
+    "clubName": "РБ Лейпциг",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
     "fp_last": 0.0
   },
   {
@@ -23920,6 +22660,236 @@
     "fp_last": 0.0
   },
   {
+    "playerId": 213472,
+    "fullName": "Перейра Лаже",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213471,
+    "fullName": "Ирвайн",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.1,
+    "fp_last": 111.0
+  },
+  {
+    "playerId": 213470,
+    "fullName": "Синани",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 54.0
+  },
+  {
+    "playerId": 213469,
+    "fullName": "Афолайян",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.9,
+    "fp_last": 71.0
+  },
+  {
+    "playerId": 213468,
+    "fullName": "Фудзита",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213467,
+    "fullName": "Унтонджи",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213466,
+    "fullName": "Смит",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.3,
+    "fp_last": 80.0
+  },
+  {
+    "playerId": 213465,
+    "fullName": "Салиакас",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.3,
+    "fp_last": 106.0
+  },
+  {
+    "playerId": 213464,
+    "fullName": "Меткалф",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 10.0
+  },
+  {
+    "playerId": 213463,
+    "fullName": "Василь",
+    "clubName": "Санкт-Паули",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 9.6,
+    "fp_last": 127.0
+  },
+  {
+    "playerId": 213462,
+    "fullName": "Валь",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.3,
+    "fp_last": 89.0
+  },
+  {
+    "playerId": 213461,
+    "fullName": "Скотт Бэнкс",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.9,
+    "fp_last": 11.0
+  },
+  {
+    "playerId": 213459,
+    "fullName": "Сэндс",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.1,
+    "fp_last": 15.0
+  },
+  {
+    "playerId": 213460,
+    "fullName": "Шмиц",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213458,
+    "fullName": "Сисей",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 6.0
+  },
+  {
+    "playerId": 213457,
+    "fullName": "Ритцка",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 40.0
+  },
+  {
+    "playerId": 213456,
+    "fullName": "Пырка",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213455,
+    "fullName": "Оппи",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213454,
+    "fullName": "Немет",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 59.0
+  },
+  {
+    "playerId": 213453,
+    "fullName": "Метс",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 213452,
+    "fullName": "Джонс",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 2.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213451,
+    "fullName": "Альстранд",
+    "clubName": "Санкт-Паули",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 11.4,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 213450,
+    "fullName": "Айгбекэн",
+    "clubName": "Санкт-Паули",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 2.2,
+    "fp_last": 0.0
+  },
+  {
     "playerId": 213445,
     "fullName": "Дзвигала",
     "clubName": "Санкт-Паули",
@@ -23928,36 +22898,6 @@
     "price": 4.0,
     "popularity": 2.8,
     "fp_last": 11.0
-  },
-  {
-    "playerId": 213446,
-    "fullName": "Робатш",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213447,
-    "fullName": "Стивенс",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.8,
-    "fp_last": 1.0
-  },
-  {
-    "playerId": 213448,
-    "fullName": "Фолль",
-    "clubName": "Санкт-Паули",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.1,
-    "fp_last": 2.0
   },
   {
     "playerId": 213449,
@@ -23970,223 +22910,283 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213474,
-    "fullName": "Огбемудиа",
-    "clubName": "Унион Берлин",
+    "playerId": 213448,
+    "fullName": "Фолль",
+    "clubName": "Санкт-Паули",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.1,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 213447,
+    "fullName": "Стивенс",
+    "clubName": "Санкт-Паули",
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
+    "popularity": 0.8,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 213446,
+    "fullName": "Робатш",
+    "clubName": "Санкт-Паули",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213501,
+    "fullName": "Чжон Ву Ен",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 62.0
+  },
+  {
+    "playerId": 213500,
+    "fullName": "Илич",
+    "clubName": "Унион Берлин",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.4,
+    "fp_last": 53.0
+  },
+  {
+    "playerId": 213499,
+    "fullName": "Бенеш",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.1,
+    "fp_last": 36.0
+  },
+  {
+    "playerId": 213498,
+    "fullName": "Шефер",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5,
+    "fp_last": 54.0
+  },
+  {
+    "playerId": 213497,
+    "fullName": "Скарке",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 46.0
+  },
+  {
+    "playerId": 213496,
+    "fullName": "Роте",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 2.7,
+    "fp_last": 71.0
+  },
+  {
+    "playerId": 213495,
+    "fullName": "Берк",
+    "clubName": "Унион Берлин",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213494,
+    "fullName": "Ансах",
+    "clubName": "Унион Берлин",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213487,
+    "fullName": "Крал",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
     "popularity": 0.7,
     "fp_last": 0.0
   },
   {
-    "playerId": 213475,
-    "fullName": "Рааб",
+    "playerId": 213493,
+    "fullName": "Хедира",
     "clubName": "Унион Берлин",
-    "position": "GK",
+    "position": "MID",
     "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 97.0
   },
   {
-    "playerId": 213476,
-    "fullName": "Штайн",
+    "playerId": 213492,
+    "fullName": "Хаберер",
     "clubName": "Унион Берлин",
-    "position": "GK",
+    "position": "MID",
     "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.5,
-    "fp_last": 0.0
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 60.0
   },
   {
-    "playerId": 213502,
-    "fullName": "Флориан Мюллер",
-    "clubName": "Фрайбург",
-    "position": "GK",
+    "playerId": 213491,
+    "fullName": "Тузар",
+    "clubName": "Унион Берлин",
+    "position": "MID",
     "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.1,
-    "fp_last": 17.0
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 21.0
   },
   {
-    "playerId": 213503,
-    "fullName": "Огбус",
-    "clubName": "Фрайбург",
+    "playerId": 213490,
+    "fullName": "Триммель",
+    "clubName": "Унион Берлин",
     "position": "DEF",
     "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 213504,
-    "fullName": "Хут",
-    "clubName": "Фрайбург",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213534,
-    "fullName": "Буш",
-    "clubName": "Хайденхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 4.3,
-    "fp_last": 47.0
-  },
-  {
-    "playerId": 213535,
-    "fullName": "Келлер",
-    "clubName": "Хайденхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.9,
-    "fp_last": 4.0
-  },
-  {
-    "playerId": 213536,
-    "fullName": "Феллер",
-    "clubName": "Хайденхайм",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.9,
-    "fp_last": 7.0
-  },
-  {
-    "playerId": 213537,
-    "fullName": "Ференбах",
-    "clubName": "Хайденхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.0,
-    "fp_last": 47.0
-  },
-  {
-    "playerId": 213538,
-    "fullName": "Чернут",
-    "clubName": "Хайденхайм",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213560,
-    "fullName": "Беренс",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 7.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213561,
-    "fullName": "Гранач",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.1,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 213562,
-    "fullName": "Дрекслер",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.7,
-    "fp_last": 3.0
-  },
-  {
-    "playerId": 213563,
-    "fullName": "Кабак",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213564,
-    "fullName": "Петерссон",
-    "clubName": "Хоффенхайм",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213409,
-    "fullName": "Цингерле",
-    "clubName": "РБ Лейпциг",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213445,
-    "fullName": "Дзвигала",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 2.8,
-    "fp_last": 11.0
-  },
-  {
-    "playerId": 213446,
-    "fullName": "Робатш",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213447,
-    "fullName": "Стивенс",
-    "clubName": "Санкт-Паули",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
+    "price": 5.0,
     "popularity": 0.8,
-    "fp_last": 1.0
+    "fp_last": 60.0
   },
   {
-    "playerId": 213448,
-    "fullName": "Фолль",
-    "clubName": "Санкт-Паули",
-    "position": "GK",
+    "playerId": 213489,
+    "fullName": "Сков",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
     "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.1,
-    "fp_last": 2.0
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 43.0
   },
   {
-    "playerId": 213449,
-    "fullName": "Шпари",
-    "clubName": "Санкт-Паули",
+    "playerId": 213488,
+    "fullName": "Реннов",
+    "clubName": "Унион Берлин",
     "position": "GK",
     "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.4,
+    "price": 5.0,
+    "popularity": 2.7,
+    "fp_last": 110.0
+  },
+  {
+    "playerId": 213486,
+    "fullName": "Кемляйн",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 33.0
+  },
+  {
+    "playerId": 213485,
+    "fullName": "Дуки",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.9,
+    "fp_last": 86.0
+  },
+  {
+    "playerId": 213484,
+    "fullName": "Диогу Лейте",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.6,
+    "fp_last": 91.0
+  },
+  {
+    "playerId": 213483,
+    "fullName": "Юранович",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.3,
+    "fp_last": 37.0
+  },
+  {
+    "playerId": 213482,
+    "fullName": "Прой",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 213481,
+    "fullName": "Нсоки",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213480,
+    "fullName": "Маркграф",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213479,
+    "fullName": "Любичич",
+    "clubName": "Унион Берлин",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.8,
+    "fp_last": 19.0
+  },
+  {
+    "playerId": 213478,
+    "fullName": "Кверфельд",
+    "clubName": "Унион Берлин",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.8,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 213477,
+    "fullName": "Бурджу",
+    "clubName": "Унион Берлин",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
     "fp_last": 0.0
   },
   {
@@ -24200,13 +23200,13 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213474,
-    "fullName": "Огбемудиа",
+    "playerId": 213476,
+    "fullName": "Штайн",
     "clubName": "Унион Берлин",
-    "position": "DEF",
+    "position": "GK",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 0.7,
+    "popularity": 1.5,
     "fp_last": 0.0
   },
   {
@@ -24220,13 +23220,293 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213476,
-    "fullName": "Штайн",
+    "playerId": 213474,
+    "fullName": "Огбемудиа",
     "clubName": "Унион Берлин",
-    "position": "GK",
+    "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213532,
+    "fullName": "Грифо",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 9.7,
+    "fp_last": 144.0
+  },
+  {
+    "playerId": 213531,
+    "fullName": "Хелер",
+    "clubName": "Фрайбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.0,
+    "fp_last": 90.0
+  },
+  {
+    "playerId": 213530,
+    "fullName": "Шерхант",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213529,
+    "fullName": "Судзуки",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.8,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213528,
+    "fullName": "Динкчи",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.7,
+    "fp_last": 54.0
+  },
+  {
+    "playerId": 213527,
+    "fullName": "Адаму",
+    "clubName": "Фрайбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.8,
+    "fp_last": 52.0
+  },
+  {
+    "playerId": 213526,
+    "fullName": "Эггештайн",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213525,
+    "fullName": "Рель",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.2,
+    "fp_last": 36.0
+  },
+  {
+    "playerId": 213524,
+    "fullName": "Матанович",
+    "clubName": "Фрайбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213523,
+    "fullName": "Грегорич",
+    "clubName": "Фрайбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.0,
+    "fp_last": 35.0
+  },
+  {
+    "playerId": 213522,
+    "fullName": "Бесте",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 1.7,
+    "fp_last": 15.0
+  },
+  {
+    "playerId": 213517,
+    "fullName": "Гюнтер",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 6.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213521,
+    "fullName": "Максимилиан Филипп",
+    "clubName": "Фрайбург",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.1,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 213520,
+    "fullName": "Остерхаге",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 81.0
+  },
+  {
+    "playerId": 213519,
+    "fullName": "Манзамби",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 26.0
+  },
+  {
+    "playerId": 213518,
+    "fullName": "Ириэ",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213516,
+    "fullName": "Вайсхаупт",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.2,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213515,
+    "fullName": "Атуболу",
+    "clubName": "Фрайбург",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 7.1,
+    "fp_last": 104.0
+  },
+  {
+    "playerId": 213514,
+    "fullName": "Хефлер",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.4,
+    "fp_last": 32.0
+  },
+  {
+    "playerId": 213513,
+    "fullName": "Треу",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213512,
+    "fullName": "Линхарт",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.1,
+    "fp_last": 92.0
+  },
+  {
+    "playerId": 213511,
+    "fullName": "Кюблер",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 9.4,
+    "fp_last": 91.0
+  },
+  {
+    "playerId": 213510,
+    "fullName": "Гинтер",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 7.2,
+    "fp_last": 98.0
+  },
+  {
+    "playerId": 213509,
+    "fullName": "Юнг",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213508,
+    "fullName": "Розенфельдер",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 44.0
+  },
+  {
+    "playerId": 213507,
+    "fullName": "Муслия",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 9.0
+  },
+  {
+    "playerId": 213506,
+    "fullName": "Макенго",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 21.0
+  },
+  {
+    "playerId": 213505,
+    "fullName": "Кьере",
+    "clubName": "Фрайбург",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5,
     "fp_last": 0.0
   },
   {
@@ -24240,16 +23520,6 @@
     "fp_last": 17.0
   },
   {
-    "playerId": 213503,
-    "fullName": "Огбус",
-    "clubName": "Фрайбург",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.6,
-    "fp_last": 2.0
-  },
-  {
     "playerId": 213504,
     "fullName": "Хут",
     "clubName": "Фрайбург",
@@ -24260,6 +23530,226 @@
     "fp_last": 0.0
   },
   {
+    "playerId": 213503,
+    "fullName": "Огбус",
+    "clubName": "Фрайбург",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 213559,
+    "fullName": "Шеппнер",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.8,
+    "fp_last": 114.0
+  },
+  {
+    "playerId": 213558,
+    "fullName": "Хонзак",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.6,
+    "fp_last": 68.0
+  },
+  {
+    "playerId": 213557,
+    "fullName": "Пирингер",
+    "clubName": "Хайденхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.8,
+    "fp_last": 99.0
+  },
+  {
+    "playerId": 213556,
+    "fullName": "Сиенза",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 60.0
+  },
+  {
+    "playerId": 213555,
+    "fullName": "Зивзивадзе",
+    "clubName": "Хайденхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.7,
+    "fp_last": 42.0
+  },
+  {
+    "playerId": 213554,
+    "fullName": "Бек",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.2,
+    "fp_last": 78.0
+  },
+  {
+    "playerId": 213553,
+    "fullName": "Конте",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 39.0
+  },
+  {
+    "playerId": 213552,
+    "fullName": "Ибрагимович",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.0,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213551,
+    "fullName": "Дорш",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 54.0
+  },
+  {
+    "playerId": 213550,
+    "fullName": "Бройниг",
+    "clubName": "Хайденхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.8,
+    "fp_last": 23.0
+  },
+  {
+    "playerId": 213547,
+    "fullName": "Траоре",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.0,
+    "fp_last": 69.0
+  },
+  {
+    "playerId": 213549,
+    "fullName": "Янеш",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213548,
+    "fullName": "Шиммер",
+    "clubName": "Хайденхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 12.0
+  },
+  {
+    "playerId": 213546,
+    "fullName": "Рамай",
+    "clubName": "Хайденхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213545,
+    "fullName": "Нихьюс",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 7.0
+  },
+  {
+    "playerId": 213544,
+    "fullName": "Кевин Мюллер",
+    "clubName": "Хайденхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 2.7,
+    "fp_last": 95.0
+  },
+  {
+    "playerId": 213543,
+    "fullName": "Майнка",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.1,
+    "fp_last": 81.0
+  },
+  {
+    "playerId": 213542,
+    "fullName": "Кербер",
+    "clubName": "Хайденхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.9,
+    "fp_last": 36.0
+  },
+  {
+    "playerId": 213541,
+    "fullName": "Кауфманн",
+    "clubName": "Хайденхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.4,
+    "fp_last": 11.0
+  },
+  {
+    "playerId": 213540,
+    "fullName": "Зирслебен",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 35.0
+  },
+  {
+    "playerId": 213539,
+    "fullName": "Гимбер",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.3,
+    "fp_last": 67.0
+  },
+  {
     "playerId": 213534,
     "fullName": "Буш",
     "clubName": "Хайденхайм",
@@ -24267,36 +23757,6 @@
     "league": "Bundesliga",
     "price": 4.0,
     "popularity": 4.3,
-    "fp_last": 47.0
-  },
-  {
-    "playerId": 213535,
-    "fullName": "Келлер",
-    "clubName": "Хайденхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.9,
-    "fp_last": 4.0
-  },
-  {
-    "playerId": 213536,
-    "fullName": "Феллер",
-    "clubName": "Хайденхайм",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.9,
-    "fp_last": 7.0
-  },
-  {
-    "playerId": 213537,
-    "fullName": "Ференбах",
-    "clubName": "Хайденхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.0,
     "fp_last": 47.0
   },
   {
@@ -24310,6 +23770,296 @@
     "fp_last": 0.0
   },
   {
+    "playerId": 213537,
+    "fullName": "Ференбах",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.0,
+    "fp_last": 47.0
+  },
+  {
+    "playerId": 213536,
+    "fullName": "Феллер",
+    "clubName": "Хайденхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.9,
+    "fp_last": 7.0
+  },
+  {
+    "playerId": 213535,
+    "fullName": "Келлер",
+    "clubName": "Хайденхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.9,
+    "fp_last": 4.0
+  },
+  {
+    "playerId": 213591,
+    "fullName": "Крамарич",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 11.6,
+    "fp_last": 162.0
+  },
+  {
+    "playerId": 213590,
+    "fullName": "Гложек",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 2.3,
+    "fp_last": 99.0
+  },
+  {
+    "playerId": 213589,
+    "fullName": "Аслани",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213588,
+    "fullName": "Туре",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213587,
+    "fullName": "Лемперле",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 6.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213586,
+    "fullName": "Прасс",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.6,
+    "fp_last": 47.0
+  },
+  {
+    "playerId": 213585,
+    "fullName": "Гифт Орбан",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.8,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 213584,
+    "fullName": "Морстедт",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 13.0
+  },
+  {
+    "playerId": 213583,
+    "fullName": "Гриллич",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 1.4,
+    "fp_last": 19.0
+  },
+  {
+    "playerId": 213582,
+    "fullName": "Бебу",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 213576,
+    "fullName": "Бекер",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.6,
+    "fp_last": 28.0
+  },
+  {
+    "playerId": 213581,
+    "fullName": "Тохумджу",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.3,
+    "fp_last": 16.0
+  },
+  {
+    "playerId": 213580,
+    "fullName": "Премель",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.2,
+    "fp_last": 5.0
+  },
+  {
+    "playerId": 213579,
+    "fullName": "Гайгер",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 24.0
+  },
+  {
+    "playerId": 213578,
+    "fullName": "Бургер",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213577,
+    "fullName": "Бериша",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213575,
+    "fullName": "Бауманн",
+    "clubName": "Хоффенхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 4.6,
+    "fp_last": 90.0
+  },
+  {
+    "playerId": 213574,
+    "fullName": "Авдуллаху",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213573,
+    "fullName": "Чавес",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.9,
+    "fp_last": 41.0
+  },
+  {
+    "playerId": 213572,
+    "fullName": "Цайтлер",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213571,
+    "fullName": "Хюрюляйнен",
+    "clubName": "Хоффенхайм",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213570,
+    "fullName": "Моква",
+    "clubName": "Хоффенхайм",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 213569,
+    "fullName": "Матида",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213568,
+    "fullName": "Жандре",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.2,
+    "fp_last": 40.0
+  },
+  {
+    "playerId": 213567,
+    "fullName": "Бернардо",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.1,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213566,
+    "fullName": "Акпогума",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 1.3,
+    "fp_last": 46.0
+  },
+  {
     "playerId": 213560,
     "fullName": "Беренс",
     "clubName": "Хоффенхайм",
@@ -24317,46 +24067,6 @@
     "league": "Bundesliga",
     "price": 4.0,
     "popularity": 7.5,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213561,
-    "fullName": "Гранач",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.1,
-    "fp_last": 2.0
-  },
-  {
-    "playerId": 213562,
-    "fullName": "Дрекслер",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.7,
-    "fp_last": 3.0
-  },
-  {
-    "playerId": 213563,
-    "fullName": "Кабак",
-    "clubName": "Хоффенхайм",
-    "position": "DEF",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 1.9,
-    "fp_last": 0.0
-  },
-  {
-    "playerId": 213564,
-    "fullName": "Петерссон",
-    "clubName": "Хоффенхайм",
-    "position": "GK",
-    "league": "Bundesliga",
-    "price": 4.0,
-    "popularity": 0.6,
     "fp_last": 0.0
   },
   {
@@ -24370,14 +24080,304 @@
     "fp_last": 11.0
   },
   {
-    "playerId": 213592,
-    "fullName": "Аль-Дахиль",
+    "playerId": 213564,
+    "fullName": "Петерссон",
+    "clubName": "Хоффенхайм",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213563,
+    "fullName": "Кабак",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.9,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213562,
+    "fullName": "Дрекслер",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.7,
+    "fp_last": 3.0
+  },
+  {
+    "playerId": 213561,
+    "fullName": "Гранач",
+    "clubName": "Хоффенхайм",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.0,
+    "popularity": 1.1,
+    "fp_last": 2.0
+  },
+  {
+    "playerId": 213618,
+    "fullName": "Ундав",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 9.0,
+    "popularity": 8.8,
+    "fp_last": 112.0
+  },
+  {
+    "playerId": 213617,
+    "fullName": "Вольтемаде",
+    "clubName": "Штутгарт",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 8.0,
+    "popularity": 9.2,
+    "fp_last": 99.0
+  },
+  {
+    "playerId": 213616,
+    "fullName": "Демирович",
+    "clubName": "Штутгарт",
+    "position": "FWD",
+    "league": "Bundesliga",
+    "price": 7.5,
+    "popularity": 3.2,
+    "fp_last": 117.0
+  },
+  {
+    "playerId": 213615,
+    "fullName": "Штиллер",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 5.3,
+    "fp_last": 119.0
+  },
+  {
+    "playerId": 213614,
+    "fullName": "Фюрих",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 1.5,
+    "fp_last": 85.0
+  },
+  {
+    "playerId": 213613,
+    "fullName": "Левелинг",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 7.0,
+    "popularity": 2.4,
+    "fp_last": 68.0
+  },
+  {
+    "playerId": 213612,
+    "fullName": "Каразор",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 1.1,
+    "fp_last": 101.0
+  },
+  {
+    "playerId": 213316,
+    "fullName": "Тиагу Томаш",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 6.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213611,
+    "fullName": "Нюбель",
+    "clubName": "Штутгарт",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 9.3,
+    "fp_last": 101.0
+  },
+  {
+    "playerId": 213610,
+    "fullName": "Миттельштедт",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 18.3,
+    "fp_last": 86.0
+  },
+  {
+    "playerId": 213609,
+    "fullName": "Мвумпа",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.6,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213608,
+    "fullName": "Йованович",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213607,
+    "fullName": "Диль",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 0.4,
+    "fp_last": 11.0
+  },
+  {
+    "playerId": 213606,
+    "fullName": "Ассиньон",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.5,
+    "popularity": 3.3,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213605,
+    "fullName": "Шабо",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 1.3,
+    "fp_last": 82.0
+  },
+  {
+    "playerId": 213604,
+    "fullName": "Кайтель",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.1,
+    "fp_last": 16.0
+  },
+  {
+    "playerId": 213603,
+    "fullName": "Дарвиш",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 0.5,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213602,
+    "fullName": "Вагноман",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 5.0,
+    "popularity": 2.3,
+    "fp_last": 55.0
+  },
+  {
+    "playerId": 213601,
+    "fullName": "Штенцель",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 20.0
+  },
+  {
+    "playerId": 213600,
+    "fullName": "Хендрикс",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 36.0
+  },
+  {
+    "playerId": 213599,
+    "fullName": "Хакес",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.4,
+    "fp_last": 10.0
+  },
+  {
+    "playerId": 213598,
+    "fullName": "Стергиу",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.5,
+    "fp_last": 31.0
+  },
+  {
+    "playerId": 213597,
+    "fullName": "Нарти",
+    "clubName": "Штутгарт",
+    "position": "MID",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.3,
+    "fp_last": 1.0
+  },
+  {
+    "playerId": 213596,
+    "fullName": "Ельч",
+    "clubName": "Штутгарт",
+    "position": "DEF",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.6,
+    "fp_last": 16.0
+  },
+  {
+    "playerId": 213595,
+    "fullName": "Бредлов",
+    "clubName": "Штутгарт",
+    "position": "GK",
+    "league": "Bundesliga",
+    "price": 4.5,
+    "popularity": 0.7,
+    "fp_last": 0.0
+  },
+  {
+    "playerId": 213594,
+    "fullName": "Загаду",
     "clubName": "Штутгарт",
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 10.9,
-    "fp_last": 10.0
+    "popularity": 1.6,
+    "fp_last": 1.0
   },
   {
     "playerId": 213593,
@@ -24390,13 +24390,13 @@
     "fp_last": 0.0
   },
   {
-    "playerId": 213594,
-    "fullName": "Загаду",
+    "playerId": 213592,
+    "fullName": "Аль-Дахиль",
     "clubName": "Штутгарт",
     "position": "DEF",
     "league": "Bundesliga",
     "price": 4.0,
-    "popularity": 1.6,
-    "fp_last": 1.0
+    "popularity": 10.9,
+    "fp_last": 10.0
   }
 ]


### PR DESCRIPTION
## Summary
- fetch team IDs from fantasy-h2h and iterate club filters when collecting players
- dedupe players by ID and update cached player list

## Testing
- `python -m py_compile draft_app/top4_services.py`
- `python - <<'PY'
from draft_app.top4_services import load_players
players = load_players()
print('Total players:', len(players))
print(players[0])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a5cfbd7fe08323a5ae6f889c673bb3