### PR TITLE
Remove unsupported understat dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ requests==2.32.3
 urllib3==2.2.2
 boto3>=1.34
 aiohttp>=3.9.0
-understat>=0.3.1
 beautifulsoup4>=4.12.0


### PR DESCRIPTION
## Summary
- drop understat from requirements to prevent install errors on Heroku

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5d530b1988323a06de012a362f29a