### PR TITLE
Fix Top-4 status return link

### DIFF
--- a/draft_app/top4_routes.py
+++ b/draft_app/top4_routes.py
@@ -109,6 +109,7 @@ def index():
 @bp.get("/top4/status")
 def status():
     ctx = build_status_context()
+    ctx["draft_url"] = url_for("top4.index")
     return render_template("status.html", **ctx)
 
 # ---- Wishlist API ----


### PR DESCRIPTION
## Summary
- Ensure Top-4 status page back button navigates to Top-4 draft

## Testing
- `python -m py_compile draft_app/top4_routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5d90506548323a4c63e09464ad46e