### PR TITLE
Add Top-4 schedule page with league skip alignment

### DIFF
--- a/draft_app/top4_routes.py
+++ b/draft_app/top4_routes.py
@@ -10,6 +10,7 @@ from .top4_services import (
     build_status_context,
     wishlist_load, wishlist_save,
 )
+from .top4_schedule import build_schedule
 
 bp = Blueprint("top4", __name__)
 
@@ -110,6 +111,12 @@ def index():
 def status():
     ctx = build_status_context()
     return render_template("status.html", **ctx)
+
+
+@bp.get("/top4/schedule")
+def schedule_view():
+    data = build_schedule()
+    return render_template("schedule.html", schedule=data)
 
 # ---- Wishlist API ----
 @bp.route("/top4/api/wishlist", methods=["GET", "PATCH", "POST"])

--- a/draft_app/top4_schedule.py
+++ b/draft_app/top4_schedule.py
@@ -62,6 +62,22 @@ def _choose_skip(other_dates: List[date], bundes_dates: List[date]) -> List[int]
     skips.sort()
     return skips
 
+
+def _enforce_constraints(skips: List[int], total_rounds: int) -> List[int]:
+    """Ensure last round is skipped and no consecutive skips remain."""
+    skip_set = set(skips)
+    skip_set.add(total_rounds)
+    ordered: List[int] = []
+    for s in sorted(skip_set):
+        if ordered and s == ordered[-1] + 1:
+            if s == total_rounds:
+                ordered[-1] = s
+            else:
+                continue
+        else:
+            ordered.append(s)
+    return ordered
+
 def build_schedule() -> Dict[str, List[Dict]]:
     today = date.today()
     bundes = _load_rounds("Bundesliga")
@@ -72,6 +88,8 @@ def build_schedule() -> Dict[str, List[Dict]]:
         rounds = _load_rounds(league)
         dates = [r["date"] for r in rounds]
         skip_idx = _choose_skip(dates, bundes_dates) if league != "Bundesliga" else []
+        if league != "Bundesliga":
+            skip_idx = _enforce_constraints(skip_idx, len(rounds))
         info: List[Dict] = []
         for idx, rd in enumerate(rounds, start=1):
             if rd["date"] >= today:

--- a/draft_app/top4_schedule.py
+++ b/draft_app/top4_schedule.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+from datetime import datetime, date
+from functools import lru_cache
+from typing import Dict, List
+import requests
+
+OPENFOOTBALL_URLS = {
+    "Bundesliga": "https://raw.githubusercontent.com/openfootball/football.json/master/2024-25/de.1.json",
+    "EPL": "https://raw.githubusercontent.com/openfootball/football.json/master/2024-25/en.1.json",
+    "La Liga": "https://raw.githubusercontent.com/openfootball/football.json/master/2024-25/es.1.json",
+    "Serie A": "https://raw.githubusercontent.com/openfootball/football.json/master/2024-25/it.1.json",
+}
+
+@lru_cache()
+def _load_rounds(league: str) -> List[Dict]:
+    url = OPENFOOTBALL_URLS.get(league)
+    if not url:
+        return []
+    try:
+        data = requests.get(url, timeout=10).json()
+    except Exception:
+        return []
+    rounds: Dict[int, date] = {}
+    for m in data.get("matches", []):
+        try:
+            r = int(str(m.get("round", "")).split()[-1])
+            d = datetime.strptime(m.get("date"), "%Y-%m-%d").date()
+        except Exception:
+            continue
+        if r not in rounds or d < rounds[r]:
+            rounds[r] = d
+    return [{"round": r, "date": rounds[r]} for r in sorted(rounds)]
+
+def _choose_skip(other_dates: List[date], bundes_dates: List[date]) -> List[int]:
+    n = len(other_dates)
+    m = len(bundes_dates)
+    dp = [[float("inf")]*(m+1) for _ in range(n+1)]
+    path = [[None]*(m+1) for _ in range(n+1)]
+    dp[0][0] = 0.0
+    for i in range(1, n+1):
+        dp[i][0] = 0.0
+        path[i][0] = "skip"
+    for i in range(1, n+1):
+        for j in range(1, min(i, m)+1):
+            cost = abs((other_dates[i-1] - bundes_dates[j-1]).days)
+            if dp[i-1][j-1] + cost < dp[i][j]:
+                dp[i][j] = dp[i-1][j-1] + cost
+                path[i][j] = "align"
+            if dp[i-1][j] <= dp[i][j]:
+                dp[i][j] = dp[i-1][j]
+                path[i][j] = "skip"
+    i, j = n, m
+    skips: List[int] = []
+    while i > 0 or j > 0:
+        act = path[i][j]
+        if act == "align":
+            i -= 1
+            j -= 1
+        else:
+            skips.append(i)
+            i -= 1
+    skips.sort()
+    return skips
+
+def build_schedule() -> Dict[str, List[Dict]]:
+    today = date.today()
+    bundes = _load_rounds("Bundesliga")
+    bundes_dates = [r["date"] for r in bundes]
+    result: Dict[str, List[Dict]] = {}
+    leagues = ["Bundesliga", "EPL", "La Liga", "Serie A"]
+    for league in leagues:
+        rounds = _load_rounds(league)
+        dates = [r["date"] for r in rounds]
+        skip_idx = _choose_skip(dates, bundes_dates) if league != "Bundesliga" else []
+        info: List[Dict] = []
+        for idx, rd in enumerate(rounds, start=1):
+            if rd["date"] >= today:
+                info.append({
+                    "round": rd["round"],
+                    "date": rd["date"].strftime("%Y-%m-%d"),
+                    "skip": idx in skip_idx,
+                })
+        if not info:
+            for idx, rd in enumerate(rounds, start=1):
+                info.append({
+                    "round": rd["round"],
+                    "date": rd["date"].strftime("%Y-%m-%d"),
+                    "skip": idx in skip_idx,
+                })
+        for item in info:
+            if not item["skip"]:
+                item["current"] = True
+                break
+        result[league] = info
+    return result

--- a/draft_app/top4_schedule.py
+++ b/draft_app/top4_schedule.py
@@ -5,10 +5,10 @@ from typing import Dict, List
 import requests
 
 OPENFOOTBALL_URLS = {
-    "Bundesliga": "https://raw.githubusercontent.com/openfootball/football.json/master/2024-25/de.1.json",
-    "EPL": "https://raw.githubusercontent.com/openfootball/football.json/master/2024-25/en.1.json",
-    "La Liga": "https://raw.githubusercontent.com/openfootball/football.json/master/2024-25/es.1.json",
-    "Serie A": "https://raw.githubusercontent.com/openfootball/football.json/master/2024-25/it.1.json",
+    "Bundesliga": "https://raw.githubusercontent.com/openfootball/football.json/master/2025-26/de.1.json",
+    "EPL": "https://raw.githubusercontent.com/openfootball/football.json/master/2025-26/en.1.json",
+    "La Liga": "https://raw.githubusercontent.com/openfootball/football.json/master/2025-26/es.1.json",
+    "Serie A": "https://raw.githubusercontent.com/openfootball/football.json/master/2025-26/it.1.json",
 }
 
 @lru_cache()

--- a/templates/base.html
+++ b/templates/base.html
@@ -42,7 +42,13 @@
             <a class="navbar-item" href="{{ url_for('epl.results') }}">Результаты</a>
           </div>
         </div>
-        <a class="navbar-item" href="{{ url_for('top4.index') }}">Топ-4</a>
+        <div class="navbar-item has-dropdown is-hoverable">
+          <a class="navbar-link" href="{{ url_for('top4.index') }}">Топ-4</a>
+          <div class="navbar-dropdown">
+            <a class="navbar-item" href="{{ url_for('top4.index') }}">Пики</a>
+            <a class="navbar-item" href="{{ url_for('top4.schedule_view') }}">Расписание</a>
+          </div>
+        </div>
       </div>
       <div class="navbar-end">
         {% if session.get('user_name') %}

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block title %}Расписание Топ-4{% endblock %}
+{% block content %}
+<h1 class="title">Расписание лиг</h1>
+<div class="columns is-multiline">
+  {% for league, rounds in schedule.items() %}
+  <div class="column is-half-tablet is-one-quarter-desktop">
+    <h2 class="subtitle">{{ league }}</h2>
+    <table class="table is-bordered is-striped is-narrow is-fullwidth">
+      <tbody>
+      {% for r in rounds %}
+        <tr class="{% if r.skip %}has-background-danger-light{% elif r.current %}has-background-info-light{% endif %}">
+          <td>Тур {{ r.round }}</td>
+          <td>{{ r.date }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Top-4 schedule page calculating rounds to skip for EPL, La Liga and Serie A
- provide navigation submenu for Top-4 with Picks and Schedule
- compute fixture alignment against Bundesliga using openfootball data

## Testing
- `python -m py_compile draft_app/top4_schedule.py draft_app/top4_routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5dd458b7483239c8b47c6256b9a8c