### PR TITLE
Fix top-4 draft undo

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
         <a class="btn" href="{{ status_url }}">Состояние драфта</a>
       {% endif %}
       {% if session.get('godmode') %}
-        <form method="post" action="{{ url_for('epl.undo_last_pick') }}">
+        <form method="post" action="{{ undo_url|default(url_for('epl.undo_last_pick')) }}">
           <button type="submit" class="btn btn-danger">Отменить последний пик</button>
         </form>
       {% endif %}


### PR DESCRIPTION
## Summary
- enable undo last pick in top-4 draft

## Testing
- python -m py_compile draft_app/top4_routes.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68a6eefc122c83238053d8077c90afe3