### PR TITLE
Add list view toggle for squad page

### DIFF
--- a/draft_app/static/css/squad.css
+++ b/draft_app/static/css/squad.css
@@ -34,6 +34,31 @@
   margin-bottom: 1rem;
 }
 
+.squad-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+#roster.list-mode .roster-line {
+  flex-direction: column;
+  gap: 0;
+}
+
+#roster.list-mode .player,
+#lineup.list-mode .player {
+  width: 100%;
+  text-align: left;
+  font-size: 0.875rem;
+  padding: 2px 4px;
+  border-bottom: 1px solid #eee;
+}
+
+#lineup.list-mode .slots {
+  flex-direction: column;
+}
+
 .lineup-pos[data-pos="BENCH"] .slots {
   flex-wrap: nowrap;
 }

--- a/draft_app/static/js/squad.js
+++ b/draft_app/static/js/squad.js
@@ -115,6 +115,26 @@ document.addEventListener('DOMContentLoaded',()=>{
   placePreset();
   const modal=initPlayerModal();
 
+  const viewBtn=document.getElementById('view-toggle');
+  let listMode=false;
+  function setViewMode(list){
+    const players=document.querySelectorAll('.player');
+    players.forEach(p=>{
+      if(!p.dataset.orig){
+        p.dataset.orig=p.innerHTML;
+        const fx=p.dataset.fixture?` ${p.dataset.fixture}`:'';
+        p.dataset.list=`${p.dataset.pos} ${p.dataset.name}${fx}`;
+      }
+      p.innerHTML=list?p.dataset.list:p.dataset.orig;
+    });
+    document.getElementById('roster').classList.toggle('list-mode',list);
+    document.getElementById('lineup').classList.toggle('list-mode',list);
+    if(viewBtn) viewBtn.textContent=list?'Фото':'Список';
+  }
+  if(viewBtn){
+    viewBtn.addEventListener('click',()=>{ listMode=!listMode; setViewMode(listMode); });
+  }
+
   function iconHover(e){
     const icon=e.target.closest('.flag, .info-icon');
     if(icon && modal){

--- a/templates/squad.html
+++ b/templates/squad.html
@@ -25,13 +25,17 @@
   </div>
   <div class="columns">
     <div class="column is-half">
-      <h2 class="subtitle">Состав</h2>
+      <div class="squad-header">
+        <h2 class="subtitle">Состав</h2>
+        <button type="button" id="view-toggle" class="button is-small">Список</button>
+      </div>
       <div id="roster" class="player-list">
         {% for pos in ['GK','DEF','MID','FWD'] %}
           <div class="roster-line" id="roster-{{ pos }}">
             {% for p in roster if p.position == pos %}
               <div class="player" data-id="{{ p.playerId }}" data-pos="{{ p.position }}"
                    data-name="{{ p.shortName or p.fullName }}"
+                   data-fixture="{{ p.fixture }}"
                    data-news="{{ p.news or '' }}"
                    data-stats='{{ p.stats|tojson|safe }}'>
                 <img src="{{ p.photo }}" alt="" />


### PR DESCRIPTION
## Summary
- add view toggle to squad page and support list view display
- allow players to be shown as compact list

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b990566c348323abdff508de536921