### PR TITLE
Add automatic formation selection option

### DIFF
--- a/templates/squad.html
+++ b/templates/squad.html
@@ -16,6 +16,7 @@
       <label class="label">Схема</label>
       <div class="select">
         <select id="formation" name="formation">
+          <option value="auto" {% if formation=='auto' %}selected{% endif %}>Как бог пошлёт</option>
           {% for f in formations %}
             <option value="{{ f }}" {% if f==formation %}selected{% endif %}>{{ f }}</option>
           {% endfor %}
@@ -94,6 +95,7 @@
 </form>
 <script id="lineup-data" type="application/json">{{ lineup|map(attribute='playerId')|list|tojson }}</script>
 <script id="bench-data" type="application/json">{{ bench|map(attribute='playerId')|list|tojson }}</script>
+<script id="formation-list" type="application/json">{{ formations|tojson }}</script>
 
 <div id="player-modal" class="modal" aria-hidden="true">
   <div class="modal-backdrop" data-close="1"></div>


### PR DESCRIPTION
## Summary
- Allow "Как бог пошлёт" formation option to auto-adjust lineup without preselecting a scheme
- Dynamically validate picks against remaining possible formations, moving impossible picks to bench
- Compute and store actual formation when saving lineups

## Testing
- `python -m py_compile draft_app/epl_routes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b99312f0e48323a3a41b41543e40c3