### PR TITLE
feat: show current season fp on EPL page

### DIFF
--- a/draft_app/static/js/draft_epl.js
+++ b/draft_app/static/js/draft_epl.js
@@ -75,7 +75,31 @@ document.addEventListener('DOMContentLoaded', function () {
         }
       });
     });
-  
+
+    // -------- FP 2025/26: сортировка --------
+    const fpCurCells = Array.from(document.querySelectorAll('.fp-cur-cell'));
+    const sortCurBtn = document.getElementById('fp-cur-sort-btn');
+    const sortCurArrow = document.getElementById('fp-cur-sort-arrow');
+
+    function sortByFpCur(dir) {
+      const body = document.querySelector('#players tbody');
+      const rows = Array.from(body.querySelectorAll('tr'));
+      rows.sort((a, b) => {
+        const afp = Number(a.querySelector('.fp-cur-cell')?.getAttribute('data-fp') || '0');
+        const bfp = Number(b.querySelector('.fp-cur-cell')?.getAttribute('data-fp') || '0');
+        return dir === 'asc' ? (afp - bfp) : (bfp - afp);
+      });
+      rows.forEach(r => body.appendChild(r));
+    }
+
+    sortCurBtn?.addEventListener('click', () => {
+      const cur = sortCurBtn.getAttribute('data-dir') || 'desc';
+      const next = cur === 'desc' ? 'asc' : 'desc';
+      sortCurBtn.setAttribute('data-dir', next);
+      sortCurArrow.textContent = next === 'desc' ? '↓' : '↑';
+      sortByFpCur(next);
+    });
+
     // -------- FP 2024/25: подгрузка + сортировка --------
     const fpCells = Array.from(document.querySelectorAll('.fp-cell'));
     const sortBtn = document.getElementById('fp-sort-btn');

--- a/templates/index.html
+++ b/templates/index.html
@@ -98,6 +98,13 @@
             <th>Клуб</th>
             <th>Позиция</th>
             {% if table_league == 'epl' %}<th>Статистика</th>{% endif %}
+            {% if table_league == 'epl' %}
+            <th class="num">
+              <button type="button" id="fp-cur-sort-btn" class="link" data-dir="desc" title="Сортировать по FP 2025/26">
+                FP 2025/26 <span id="fp-cur-sort-arrow">↓</span>
+              </button>
+            </th>
+            {% endif %}
             <th class="num">
               <button type="button" id="fp-sort-btn" class="link" data-dir="desc" title="Сортировать по FP 2024/25">
                 FP 2024/25 <span id="fp-sort-arrow">↓</span>
@@ -142,6 +149,9 @@
               {% if table_league == 'epl' %}
               <td>
                 <button type="button" class="link link-stat" data-pid="{{ p.playerId }}" data-name="{{ p.shortName or p.fullName }}">stat</button>
+              </td>
+              <td class="num">
+                <span class="fp-cur-cell" data-fp="{{ (p.stats.points or 0)|int }}">{{ (p.stats.points or 0)|int }}</span>
               </td>
               {% endif %}
               <td class="num">


### PR DESCRIPTION
## Summary
- show FP 2025/26 values on EPL page
- allow sorting by current-season fantasy points

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b997ade8348323808b6f8c22c078ee