### PR TITLE
feat: add EPL red-status filters

### DIFF
--- a/draft_app/static/wishlist.js
+++ b/draft_app/static/wishlist.js
@@ -81,12 +81,21 @@
     function applyFilters() {
       const wlOnly = qs('#wishlist-only-toggle')?.checked;
       const canPickOnly = qs('#can-pick-toggle')?.checked;
+      const hideTransfers = qs('#hide-transfers-toggle')?.checked;
+      const hideReds = qs('#hide-reds-toggle')?.checked;
       qsa('#players tbody tr').forEach(tr => {
         const inWishlist = tr.classList.contains('is-wishlist');
         const canPick = tr.getAttribute('data-can-pick') === '1';
+        const status = tr.getAttribute('data-status') || '';
+        const chance = Number(tr.getAttribute('data-chance') || '0');
+        const news = (tr.getAttribute('data-news') || '').toLowerCase();
+        const isRed = status && chance < 50;
+        const isTransfer = isRed && news.includes('joined');
         let visible = true;
         if (wlOnly) visible = visible && inWishlist;
         if (canPickOnly) visible = visible && canPick;
+        if (hideReds && isRed) visible = false;
+        if (hideTransfers && isTransfer) visible = false;
         tr.style.display = visible ? '' : 'none';
       });
     }
@@ -118,8 +127,12 @@
       // фильтры
       const wlOnly = qs('#wishlist-only-toggle');
       const canPickOnly = qs('#can-pick-toggle');
+      const hideTransfers = qs('#hide-transfers-toggle');
+      const hideReds = qs('#hide-reds-toggle');
       wlOnly && wlOnly.addEventListener('change', applyFilters);
       canPickOnly && canPickOnly.addEventListener('change', applyFilters);
+      hideTransfers && hideTransfers.addEventListener('change', applyFilters);
+      hideReds && hideReds.addEventListener('change', applyFilters);
       applyFilters();
   
       // выгрузить хвост при уходе

--- a/templates/index.html
+++ b/templates/index.html
@@ -71,6 +71,16 @@
         <input type="checkbox" id="can-pick-toggle" />
         <span>Can Pick</span>
       </label>
+      {% if table_league == 'epl' %}
+      <label class="toggle">
+        <input type="checkbox" id="hide-transfers-toggle" />
+        <span>Спрятать трансферы</span>
+      </label>
+      <label class="toggle">
+        <input type="checkbox" id="hide-reds-toggle" />
+        <span>Спрятать красных</span>
+      </label>
+      {% endif %}
     </div>
 
     <div class="fld">
@@ -139,7 +149,9 @@
         <tbody>
           {% for p in players %}
             {% set disabled = draft_completed or (next_user and current_user != next_user and not session.get('godmode')) or (table_league == 'top4' and not p.canPick) %}
-            <tr data-player-id="{{ p.playerId }}" data-can-pick="{{ '1' if p.canPick else '0' }}">
+            <tr data-player-id="{{ p.playerId }}" data-can-pick="{{ '1' if p.canPick else '0' }}"
+                data-status="{{ p.status or '' }}" data-chance="{{ p.chance or 0 }}"
+                data-news="{{ (p.news or '')|lower|e }}">
               <td class="wishlist-cell">
                 <input type="checkbox" class="wishlist-toggle" data-player-id="{{ p.playerId }}" />
               </td>


### PR DESCRIPTION
## Summary
- add checkboxes to hide transfer and red-status players on EPL page
- filter table rows in wishlist.js according to new toggles

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b99b3c4690832387ec86cd8f9559f2