### PR TITLE
Fix red player filter and extend transfer filter

### DIFF
--- a/draft_app/static/wishlist.js
+++ b/draft_app/static/wishlist.js
@@ -89,8 +89,8 @@
         const status = tr.getAttribute('data-status') || '';
         const chance = Number(tr.getAttribute('data-chance') || '0');
         const news = (tr.getAttribute('data-news') || '').toLowerCase();
-        const isRed = status && chance < 50;
-        const isTransfer = isRed && news.includes('joined');
+        const isRed = status && status !== 'a' && chance < 50;
+        const isTransfer = isRed && (news.includes('joined') || news.includes('loan') || news.includes('departed'));
         let visible = true;
         if (wlOnly) visible = visible && inWishlist;
         if (canPickOnly) visible = visible && canPick;


### PR DESCRIPTION
## Summary
- Correct `Hide reds` logic to ignore available players
- Extend `Hide transfers` to also cover loaned and departed players

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b99cc7335883239661aaad45800a8c