### PR TITLE
feat: add transfer window mechanics

### DIFF
--- a/draft_app/transfer_store.py
+++ b/draft_app/transfer_store.py
@@ -1,0 +1,51 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Dict, Any, List
+
+from .epl_services import _s3_enabled, _s3_bucket, _s3_get_json, _s3_put_json
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+TRANSFERS_DIR = BASE_DIR / "data" / "transfers"
+TRANSFERS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _s3_key() -> str:
+    return os.getenv("DRAFT_S3_TRANSFERS_KEY", "transfers.json")
+
+
+def load_transfer_log() -> List[Dict[str, Any]]:
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _s3_key()
+        if bucket:
+            data = _s3_get_json(bucket, key)
+            if isinstance(data, list):
+                return data
+    p = TRANSFERS_DIR / "transfers.json"
+    if p.exists():
+        try:
+            with p.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, list):
+                return data
+        except Exception:
+            pass
+    return []
+
+
+def append_transfer(event: Dict[str, Any]) -> None:
+    log = load_transfer_log()
+    log.append(event)
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _s3_key()
+        if bucket and not _s3_put_json(bucket, key, log):
+            print("[EPL:S3] append_transfer fallback")
+    p = TRANSFERS_DIR / "transfers.json"
+    fd, tmp = tempfile.mkstemp(prefix="transfer_", suffix=".json", dir=str(TRANSFERS_DIR))
+    os.close(fd)
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(log, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, p)

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,15 @@
     <div class="topbar-left">
       <h1 class="page-title">{{ draft_title }}</h1>
       <div class="meta">
-        {% if draft_completed %}
+        {% if transfer_active %}
+          <span class="badge badge-info">Идут трансферы</span>
+          Сейчас ход: <strong>{{ transfer_user }}</strong>
+          {% if current_user == transfer_user %}
+          <form method="post" action="{{ url_for('epl.transfer_skip') }}" style="display:inline;">
+            <button type="submit" class="btn btn-small">Пропустить трансфер</button>
+          </form>
+          {% endif %}
+        {% elif draft_completed %}
           <span class="badge badge-muted">Драфт завершён</span>
         {% else %}
           {% if next_user %}

--- a/templates/squad.html
+++ b/templates/squad.html
@@ -55,6 +55,13 @@
                 {% endif %}
                 <span>{{ p.shortName or p.fullName }}</span>
                 <small>{{ p.position }}{% if p.fixture %} {{ p.fixture }}{% endif %}</small>
+                {% if transfer_active and transfer_user == session.get('user_name') %}
+                <form method="post" action="{{ url_for('epl.transfer') }}" class="transfer-form">
+                  <input type="hidden" name="out" value="{{ p.playerId }}" />
+                  <input type="number" name="in" placeholder="ID" class="input is-small" required />
+                  <button type="submit" class="button is-small">Transfer Out</button>
+                </form>
+                {% endif %}
               </div>
             {% endfor %}
           </div>


### PR DESCRIPTION
## Summary
- implement scheduled transfer windows with multi-round order
- expose transfer status and skip controls on EPL pages
- store transfer history in S3

## Testing
- `python -m py_compile draft_app/epl_services.py draft_app/epl_routes.py draft_app/transfer_store.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9a01ecfbc8323a6bc238dedb7ae32