### PR TITLE
Fix transfer form endpoint and recompute EPL results

### DIFF
--- a/templates/squad.html
+++ b/templates/squad.html
@@ -56,7 +56,7 @@
                 <span>{{ p.shortName or p.fullName }}</span>
                 <small>{{ p.position }}{% if p.fixture %} {{ p.fixture }}{% endif %}</small>
                 {% if transfer_active and transfer_user == session.get('user_name') %}
-                <form method="post" action="{{ url_for('epl.transfer') }}" class="transfer-form">
+                <form method="post" action="{{ url_for('epl.do_transfer') }}" class="transfer-form">
                   <input type="hidden" name="out" value="{{ p.playerId }}" />
                   <input type="number" name="in" placeholder="ID" class="input is-small" required />
                   <button type="submit" class="button is-small">Transfer Out</button>


### PR DESCRIPTION
## Summary
- Fix squad transfer form to call the `do_transfer` endpoint instead of undefined `transfer`
- Recompute and cache EPL weekly scores to ensure results table shows actual earned points

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9a4e93a5c83238619ca82248a2a4f