### PR TITLE
Remove ID field from transfer table

### DIFF
--- a/draft_app/epl_routes.py
+++ b/draft_app/epl_routes.py
@@ -17,6 +17,7 @@ from .epl_services import (
     start_transfer_window, transfer_current_manager,
     advance_transfer_turn, record_transfer,
 )
+from .transfer_store import pop_transfer_target
 from .lineup_store import load_lineup, save_lineup
 from .gw_score_store import load_gw_score, save_gw_score, GW_SCORE_DIR
 
@@ -711,7 +712,7 @@ def do_transfer():
     if transfer_current_manager(state) != user:
         abort(403)
     out_pid = request.form.get("out", type=int)
-    in_pid = request.form.get("in", type=int)
+    in_pid = pop_transfer_target(user)
     if not out_pid or not in_pid:
         flash("Некорректный трансфер", "danger")
         return redirect(url_for("epl.squad"))

--- a/draft_app/transfer_store.py
+++ b/draft_app/transfer_store.py
@@ -1,8 +1,8 @@
-import json
 import os
+import json
 import tempfile
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 
 from .epl_services import _s3_enabled, _s3_bucket, _s3_get_json, _s3_put_json
 
@@ -13,6 +13,10 @@ TRANSFERS_DIR.mkdir(parents=True, exist_ok=True)
 
 def _s3_key() -> str:
     return os.getenv("DRAFT_S3_TRANSFERS_KEY", "transfers.json")
+
+
+def _s3_targets_key() -> str:
+    return os.getenv("DRAFT_S3_TRANSFER_TARGETS_KEY", "transfer_targets.json")
 
 
 def load_transfer_log() -> List[Dict[str, Any]]:
@@ -49,3 +53,52 @@ def append_transfer(event: Dict[str, Any]) -> None:
     with open(tmp, "w", encoding="utf-8") as f:
         json.dump(log, f, ensure_ascii=False, indent=2)
     os.replace(tmp, p)
+
+
+def _targets_path() -> Path:
+    return TRANSFERS_DIR / "targets.json"
+
+
+def load_targets() -> Dict[str, List[int]]:
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _s3_targets_key()
+        if bucket:
+            data = _s3_get_json(bucket, key)
+            if isinstance(data, dict):
+                return {k: [int(x) for x in v] for k, v in data.items()}
+    p = _targets_path()
+    if p.exists():
+        try:
+            with p.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                return {k: [int(x) for x in v] for k, v in data.items()}
+        except Exception:
+            pass
+    return {}
+
+
+def save_targets(data: Dict[str, List[int]]) -> None:
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _s3_targets_key()
+        if bucket and not _s3_put_json(bucket, key, data):
+            print("[EPL:S3] save_targets fallback")
+    p = _targets_path()
+    fd, tmp = tempfile.mkstemp(prefix="targets_", suffix=".json", dir=str(TRANSFERS_DIR))
+    os.close(fd)
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, p)
+
+
+def pop_transfer_target(manager: str) -> Optional[int]:
+    targets = load_targets()
+    queue = targets.get(manager) or []
+    if not queue:
+        return None
+    pid = int(queue.pop(0))
+    targets[manager] = queue
+    save_targets(targets)
+    return pid

--- a/templates/squad.html
+++ b/templates/squad.html
@@ -69,7 +69,7 @@
               <th>Игрок</th>
               <th class="num">FP 2025/26</th>
               <th>Статус</th>
-              {% if transfer_active and transfer_user == session.get('user_name') %}<th>Действия</th>{% endif %}
+              {% if transfer_active and transfer_user == session.get('user_name') %}<th>Transfer Out</th>{% endif %}
             </tr>
           </thead>
           <tbody>
@@ -94,7 +94,6 @@
               <td>
                 <form method="post" action="{{ url_for('epl.do_transfer') }}" class="transfer-form">
                   <input type="hidden" name="out" value="{{ p.playerId }}" />
-                  <input type="number" name="in" placeholder="ID" class="input is-small" required />
                   <button type="submit" class="button is-small">Transfer Out</button>
                 </form>
               </td>


### PR DESCRIPTION
## Summary
- drop manual ID entry from squad list transfer form
- choose incoming player via S3-backed transfer targets
- pull transfer targets from S3 and update after each use

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9ac66d77483238a8b631d22902845