### PR TITLE
Show full season schedule with round statuses

### DIFF
--- a/draft_app/top4_schedule.py
+++ b/draft_app/top4_schedule.py
@@ -47,21 +47,14 @@ def build_schedule() -> Dict[str, List[Dict]]:
         skip_nums = set(SKIP_ROUNDS.get(league, []))
         info: List[Dict] = []
         for rd in rounds:
-            if rd["date"] >= today:
-                info.append({
-                    "round": rd["round"],
-                    "date": rd["date"].strftime("%Y-%m-%d"),
-                    "skip": rd["round"] in skip_nums,
-                })
-        if not info:
-            for rd in rounds:
-                info.append({
-                    "round": rd["round"],
-                    "date": rd["date"].strftime("%Y-%m-%d"),
-                    "skip": rd["round"] in skip_nums,
-                })
+            info.append({
+                "round": rd["round"],
+                "date": rd["date"].strftime("%Y-%m-%d"),
+                "skip": rd["round"] in skip_nums,
+                "closed": rd["date"] < today,
+            })
         for item in info:
-            if not item["skip"]:
+            if not item["skip"] and not item["closed"]:
                 item["current"] = True
                 break
         result[league] = info

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -9,7 +9,7 @@
     <table class="table is-bordered is-striped is-narrow is-fullwidth">
       <tbody>
       {% for r in rounds %}
-        <tr class="{% if r.skip %}has-background-danger-light{% elif r.current %}has-background-info-light{% endif %}">
+        <tr class="{% if r.skip %}has-background-danger-light{% elif r.closed %}has-background-info-light{% elif r.current %}has-background-success-light{% endif %}">
           <td>Тур {{ r.round }}</td>
           <td>{{ r.date }}</td>
         </tr>


### PR DESCRIPTION
## Summary
- show all season rounds in schedule builder
- mark skipped, closed, and current rounds
- color schedule rows for skipped (red), closed (blue), and current (green)

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b040c8bc83239f6e664f865b321e