### PR TITLE
Add mapping and lineup pages using Mantra stats

### DIFF
--- a/draft_app/__init__.py
+++ b/draft_app/__init__.py
@@ -11,6 +11,7 @@ from .wishlist import bp as wishlist_bp
 from .status import bp as status_bp
 from draft_app.epl_routes import bp as epl_bp
 from draft_app.top4_routes import bp as top4_bp
+from .mantra_routes import bp as mantra_bp
 
 def create_app():
     app = Flask(__name__, template_folder=os.path.join(BASE_DIR, "templates"))
@@ -32,5 +33,6 @@ def create_app():
     app.register_blueprint(status_bp)
     app.register_blueprint(epl_bp)
     app.register_blueprint(top4_bp)
+    app.register_blueprint(mantra_bp)
 
     return app

--- a/draft_app/mantra_routes.py
+++ b/draft_app/mantra_routes.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import requests
+from flask import Blueprint, render_template, request, redirect, url_for, session, abort, flash
+
+from .epl_services import ensure_fpl_bootstrap_fresh, players_from_fpl, players_index
+from .player_map_store import load_player_map, save_player_map
+
+bp = Blueprint("mantra", __name__, url_prefix="/mantra")
+
+API_URL = "https://mantrafootball.org/api/players/{id}/stats"
+
+
+def _fetch_round_stats(pid: int):
+    try:
+        r = requests.get(API_URL.format(id=pid), timeout=10)
+        r.raise_for_status()
+        data = r.json().get("data", {})
+        return data.get("round_stats", [])
+    except Exception:
+        return []
+
+
+def _calc_score(stat: dict, pos: str) -> int:
+    mins = int(stat.get("played_minutes", 0))
+    score = 0
+    if mins >= 60:
+        score += 2
+    elif mins > 0:
+        score += 1
+    goals = float(stat.get("goals", 0))
+    goal_pts = {"GK": 6, "DEF": 6, "MID": 5, "FWD": 4}
+    score += goal_pts.get(pos, 0) * goals
+    assists = float(stat.get("assists", 0))
+    score += 3 * assists
+    if stat.get("cleansheet") and mins >= 60:
+        if pos in ("GK", "DEF"):
+            score += 4
+        elif pos == "MID":
+            score += 1
+    if pos == "GK":
+        score += 5 * float(stat.get("caught_penalty", 0))
+        score += int(int(stat.get("saves", 0)) / 3)
+    score -= 2 * float(stat.get("missed_penalty", 0))
+    if pos in ("GK", "DEF"):
+        score -= int(float(stat.get("missed_goals", 0)) / 2)
+    score -= int(stat.get("yellow_card") or 0)
+    score -= 3 * int(stat.get("red_card") or 0)
+    return int(score)
+
+
+@bp.route("/mapping", methods=["GET", "POST"])
+def mapping():
+    if not session.get("godmode"):
+        abort(403)
+    mapping = load_player_map()
+    bootstrap = ensure_fpl_bootstrap_fresh()
+    players = players_from_fpl(bootstrap)
+    pidx = players_index(players)
+    if request.method == "POST":
+        fpl_id = request.form.get("fpl_id", type=int)
+        mantra_id = request.form.get("mantra_id", type=int)
+        if not fpl_id or not mantra_id or str(fpl_id) not in pidx:
+            flash("Некорректные ID", "danger")
+        else:
+            mapping[str(fpl_id)] = int(mantra_id)
+            save_player_map(mapping)
+            flash("Сохранено", "success")
+        return redirect(url_for("mantra.mapping"))
+    mapped = []
+    for fid, mid in mapping.items():
+        meta = pidx.get(str(fid), {})
+        mapped.append({
+            "fpl_id": fid,
+            "name": meta.get("fullName") or meta.get("shortName") or fid,
+            "mantra_id": mid,
+        })
+    mapped.sort(key=lambda x: x["name"])
+    return render_template("mantra_mapping.html", mapped=mapped)
+
+
+@bp.route("/lineups")
+def lineups():
+    mapping = load_player_map()
+    bootstrap = ensure_fpl_bootstrap_fresh()
+    players = players_from_fpl(bootstrap)
+    pidx = players_index(players)
+    round_no = request.args.get("round", type=int) or 1
+    results = []
+    for fid, mid in mapping.items():
+        meta = pidx.get(str(fid), {})
+        pos = meta.get("position")
+        name = meta.get("fullName") or meta.get("shortName") or fid
+        round_stats = _fetch_round_stats(mid)
+        stat = next((s for s in round_stats if int(s.get("tournament_round_number", 0)) == round_no), None)
+        pts = _calc_score(stat, pos) if stat else 0
+        results.append({"name": name, "pos": pos, "points": int(pts)})
+    results.sort(key=lambda r: -r["points"])
+    return render_template("mantra_lineups.html", players=results, round=round_no)

--- a/draft_app/player_map_store.py
+++ b/draft_app/player_map_store.py
@@ -1,0 +1,48 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Dict
+
+from .epl_services import _s3_enabled, _s3_bucket, _s3_get_json, _s3_put_json
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+MAP_FILE = BASE_DIR / "data" / "player_map.json"
+MAP_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+def _s3_key() -> str:
+    return os.getenv("DRAFT_S3_PLAYER_MAP_KEY", "player_map.json")
+
+def load_player_map() -> Dict[str, int]:
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _s3_key()
+        if bucket and key:
+            data = _s3_get_json(bucket, key)
+            if isinstance(data, dict):
+                try:
+                    return {str(k): int(v) for k, v in data.items()}
+                except Exception:
+                    return {}
+    if MAP_FILE.exists():
+        try:
+            with MAP_FILE.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                return {str(k): int(v) for k, v in data.items()}
+        except Exception:
+            pass
+    return {}
+
+def save_player_map(mapping: Dict[str, int]) -> None:
+    payload = {str(k): int(v) for k, v in mapping.items()}
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _s3_key()
+        if bucket and key and not _s3_put_json(bucket, key, payload):
+            print(f"[MAP] Failed to save to s3://{bucket}/{key}")
+    fd, tmp = tempfile.mkstemp(prefix="player_map_", suffix=".json", dir=str(MAP_FILE.parent))
+    os.close(fd)
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, MAP_FILE)

--- a/templates/mantra_lineups.html
+++ b/templates/mantra_lineups.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block title %}Лайнапы{% endblock %}
+{% block content %}
+<h1 class="title">Лайнапы раунд {{ round }}</h1>
+<form method="get" class="mb-4">
+  <label class="label">Раунд</label>
+  <div class="field has-addons">
+    <div class="control"><input class="input" type="number" name="round" value="{{ round }}" min="1" style="width:90px"/></div>
+    <div class="control"><button class="button is-link" type="submit">Показать</button></div>
+  </div>
+</form>
+<table class="table is-striped is-compact">
+  <thead><tr><th>Игрок</th><th>Позиция</th><th>Очки</th></tr></thead>
+  <tbody>
+    {% for p in players %}
+    <tr><td>{{ p.name }}</td><td>{{ p.pos }}</td><td>{{ p.points }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/mantra_mapping.html
+++ b/templates/mantra_mapping.html
@@ -1,0 +1,26 @@
+{% extends "base.html" %}
+{% block title %}Маппинг игроков{% endblock %}
+{% block content %}
+<h1 class="title">Маппинг игроков</h1>
+<form method="post" class="mb-4">
+  <div class="field">
+    <label class="label">FPL Player ID</label>
+    <div class="control"><input class="input" type="number" name="fpl_id" required></div>
+  </div>
+  <div class="field">
+    <label class="label">Mantra Player ID</label>
+    <div class="control"><input class="input" type="number" name="mantra_id" required></div>
+  </div>
+  <div class="field">
+    <div class="control"><button class="button is-link" type="submit">Добавить</button></div>
+  </div>
+</form>
+<table class="table is-striped is-compact">
+  <thead><tr><th>FPL ID</th><th>Имя</th><th>Mantra ID</th></tr></thead>
+  <tbody>
+    {% for p in mapped %}
+    <tr><td>{{ p.fpl_id }}</td><td>{{ p.name }}</td><td>{{ p.mantra_id }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add S3-backed storage for mapping FPL players to Mantra IDs
- introduce Mantra blueprint with player mapping UI and lineup results
- render new templates for mapping and lineup scores

## Testing
- `python -m py_compile draft-app/draft_app/player_map_store.py draft-app/draft_app/mantra_routes.py draft-app/draft_app/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68b9bddc39cc8323bc3fc0fb036831a1