### PR TITLE
Integrate Mantra features into Top-4 draft

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -47,6 +47,10 @@
           <div class="navbar-dropdown">
             <a class="navbar-item" href="{{ url_for('top4.index') }}">Пики</a>
             <a class="navbar-item" href="{{ url_for('top4.schedule_view') }}">Расписание</a>
+            {% if session.get('godmode') %}
+            <a class="navbar-item" href="{{ url_for('mantra.mapping') }}">Маппинг</a>
+            {% endif %}
+            <a class="navbar-item" href="{{ url_for('mantra.lineups') }}">Лайнапы</a>
           </div>
         </div>
       </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -28,6 +28,10 @@
       <p class="title is-5">Топ-4 Драфт</p>
       <div class="buttons">
         <a class="button is-link is-light" href="{{ url_for('top4.index') }}">Пики</a>
+        {% if session.get('godmode') %}
+        <a class="button is-warning is-light" href="{{ url_for('mantra.mapping') }}">Маппинг</a>
+        {% endif %}
+        <a class="button is-warning is-light" href="{{ url_for('mantra.lineups') }}">Лайнапы</a>
       </div>
     </article>
   </div>
@@ -35,3 +39,4 @@
 
 <p class="mt-3 muted small">Подсказка: авторизация — через ID и 4-значный PIN (auth.json). Godmode виден в правом верхнем углу.</p>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- Move Mantra mapping and lineups under Top-4 navigation and homepage tile
- Restrict Mantra mapping and scoring to players drafted in Top-4

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b9c00543b48323959cd2cdf332ae45