### PR TITLE
Enable Mantra mapping selector and lineup overview

### DIFF
--- a/draft_app/mantra_routes.py
+++ b/draft_app/mantra_routes.py
@@ -59,6 +59,18 @@ def mapping():
     state = load_top4_state()
     rosters = state.get("rosters") or {}
     top4_ids = {str(p.get("playerId") or p.get("id")) for roster in rosters.values() for p in roster or []}
+
+    # Build selector options from drafted players that are not yet mapped
+    mapped_ids = set(mapping.keys())
+    options = []
+    for fid in top4_ids:
+        if fid in mapped_ids:
+            continue
+        meta = pidx.get(fid, {})
+        name = meta.get("fullName") or meta.get("shortName") or fid
+        options.append({"id": fid, "name": name})
+    options.sort(key=lambda x: x["name"])
+
     if request.method == "POST":
         fpl_id = request.form.get("fpl_id", type=int)
         mantra_id = request.form.get("mantra_id", type=int)
@@ -69,6 +81,7 @@ def mapping():
             save_player_map(mapping)
             flash("Сохранено", "success")
         return redirect(url_for("mantra.mapping"))
+
     mapped = []
     for fid, mid in mapping.items():
         if str(fid) not in top4_ids:
@@ -80,7 +93,7 @@ def mapping():
             "mantra_id": mid,
         })
     mapped.sort(key=lambda x: x["name"])
-    return render_template("mantra_mapping.html", mapped=mapped)
+    return render_template("mantra_mapping.html", mapped=mapped, players=options)
 
 
 @bp.route("/lineups")
@@ -90,18 +103,27 @@ def lineups():
     pidx = top4_players_index(players)
     state = load_top4_state()
     rosters = state.get("rosters") or {}
-    top4_ids = {str(p.get("playerId") or p.get("id")) for roster in rosters.values() for p in roster or []}
     round_no = request.args.get("round", type=int) or 1
-    results = []
-    for fid, mid in mapping.items():
-        if str(fid) not in top4_ids:
-            continue
-        meta = pidx.get(str(fid), {})
-        pos = meta.get("position")
-        name = meta.get("fullName") or meta.get("shortName") or fid
-        round_stats = _fetch_round_stats(mid)
-        stat = next((s for s in round_stats if int(s.get("tournament_round_number", 0)) == round_no), None)
-        pts = _calc_score(stat, pos) if stat else 0
-        results.append({"name": name, "pos": pos, "points": int(pts)})
-    results.sort(key=lambda r: -r["points"])
-    return render_template("mantra_lineups.html", players=results, round=round_no)
+
+    results: dict[str, dict] = {}
+    for manager, roster in rosters.items():
+        lineup = []
+        total = 0
+        for item in roster or []:
+            fid = str(item.get("playerId") or item.get("id"))
+            meta = pidx.get(fid, {})
+            pos = item.get("position") or meta.get("position")
+            name = meta.get("fullName") or meta.get("shortName") or fid
+            mid = mapping.get(fid)
+            pts = 0
+            if mid:
+                round_stats = _fetch_round_stats(mid)
+                stat = next((s for s in round_stats if int(s.get("tournament_round_number", 0)) == round_no), None)
+                pts = _calc_score(stat, pos) if stat else 0
+            lineup.append({"name": name, "pos": pos, "points": int(pts)})
+            total += pts
+        lineup.sort(key=lambda r: -r["points"])
+        results[manager] = {"players": lineup, "total": int(total)}
+
+    managers = sorted(results.keys())
+    return render_template("mantra_lineups.html", lineups=results, managers=managers, round=round_no)

--- a/templates/mantra_lineups.html
+++ b/templates/mantra_lineups.html
@@ -10,11 +10,31 @@
   </div>
 </form>
 <table class="table is-striped is-compact">
-  <thead><tr><th>Игрок</th><th>Позиция</th><th>Очки</th></tr></thead>
+  <thead>
+    <tr>
+      {% for m in managers %}
+      <th>
+        {{ m }}
+        {% if lineups[m].total is not none %}
+        <span style="background-color:#006400;color:white;padding:0 4px;border-radius:3px;">{{ lineups[m].total }}</span>
+        {% endif %}
+      </th>
+      {% endfor %}
+    </tr>
+  </thead>
   <tbody>
-    {% for p in players %}
-    <tr><td>{{ p.name }}</td><td>{{ p.pos }}</td><td>{{ p.points }}</td></tr>
-    {% endfor %}
+    <tr>
+      {% for m in managers %}
+      <td>
+        {% for p in lineups[m].players %}
+        <div class="is-flex is-justify-content-space-between">
+          <span>{{ p.name }} ({{ p.pos }})</span>
+          <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
+        </div>
+        {% endfor %}
+      </td>
+      {% endfor %}
+    </tr>
   </tbody>
 </table>
 {% endblock %}

--- a/templates/mantra_mapping.html
+++ b/templates/mantra_mapping.html
@@ -4,8 +4,16 @@
 <h1 class="title">Маппинг игроков</h1>
 <form method="post" class="mb-4">
   <div class="field">
-    <label class="label">FPL Player ID</label>
-    <div class="control"><input class="input" type="number" name="fpl_id" required></div>
+    <label class="label">Игрок</label>
+    <div class="control">
+      <div class="select is-fullwidth">
+        <select name="fpl_id" required>
+          {% for p in players %}
+          <option value="{{ p.id }}">{{ p.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
   </div>
   <div class="field">
     <label class="label">Mantra Player ID</label>


### PR DESCRIPTION
## Summary
- allow mapping Top-4 drafted players to Mantra IDs via dropdown selector
- show Mantra lineups and totals for each Top-4 roster

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9c3769f808323a6b192d3e7beb093