### PR TITLE
Display gameweek numbers for schedule and lineups

### DIFF
--- a/draft_app/mantra_routes.py
+++ b/draft_app/mantra_routes.py
@@ -11,6 +11,7 @@ from .top4_services import (
     players_index as top4_players_index,
     load_state as load_top4_state,
 )
+from .top4_schedule import build_schedule
 from .player_map_store import load_player_map, save_player_map
 from .epl_services import _s3_enabled, _s3_bucket, _s3_get_json, _s3_put_json
 
@@ -204,5 +205,17 @@ def lineups():
     if cache_updated:
         _save_round_cache(round_no, cache)
 
+    schedule = build_schedule()
+    gw_rounds: dict[str, int | None] = {}
+    for league, rounds in schedule.items():
+        match = next((r for r in rounds if r.get("gw") == round_no), None)
+        gw_rounds[league] = match.get("round") if match else None
+
     managers = sorted(results.keys())
-    return render_template("mantra_lineups.html", lineups=results, managers=managers, round=round_no)
+    return render_template(
+        "mantra_lineups.html",
+        lineups=results,
+        managers=managers,
+        round=round_no,
+        gw_rounds=gw_rounds,
+    )

--- a/draft_app/top4_schedule.py
+++ b/draft_app/top4_schedule.py
@@ -46,12 +46,17 @@ def build_schedule() -> Dict[str, List[Dict]]:
         rounds = _load_rounds(league)
         skip_nums = set(SKIP_ROUNDS.get(league, []))
         info: List[Dict] = []
+        gw_counter = 0
         for rd in rounds:
+            skip = rd["round"] in skip_nums
+            if not skip:
+                gw_counter += 1
             info.append({
                 "round": rd["round"],
                 "date": rd["date"].strftime("%Y-%m-%d"),
-                "skip": rd["round"] in skip_nums,
+                "skip": skip,
                 "closed": rd["date"] < today,
+                "gw": gw_counter if not skip else None,
             })
         for item in info:
             if not item["skip"] and not item["closed"]:

--- a/templates/mantra_lineups.html
+++ b/templates/mantra_lineups.html
@@ -1,9 +1,16 @@
 {% extends "base.html" %}
 {% block title %}Лайнапы{% endblock %}
 {% block content %}
-<h1 class="title">Лайнапы раунд {{ round }}</h1>
+<h1 class="title">Лайнапы GW{{ round }}</h1>
+{% if gw_rounds %}
+<div class="mb-4">
+  {% for league, rnd in gw_rounds.items() %}
+  <span class="mr-2">{{ league }} – Тур {{ rnd if rnd else '—' }}</span>
+  {% endfor %}
+</div>
+{% endif %}
 <form method="get" class="mb-4">
-  <label class="label">Раунд</label>
+  <label class="label">GW</label>
   <div class="field has-addons">
     <div class="control"><input class="input" type="number" name="round" value="{{ round }}" min="1" style="width:90px"/></div>
     <div class="control"><button class="button is-link" type="submit">Показать</button></div>

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -10,7 +10,7 @@
       <tbody>
       {% for r in rounds %}
         <tr class="{% if r.skip %}has-background-danger-light{% elif r.closed %}has-background-info-light{% elif r.current %}has-background-success-light{% endif %}">
-          <td>Тур {{ r.round }}</td>
+          <td>Тур {{ r.round }} ({{ 'GW' ~ r.gw if r.gw is not none else '—' }})</td>
           <td>{{ r.date }}</td>
         </tr>
       {% endfor %}


### PR DESCRIPTION
## Summary
- Number gameweeks while building the Top-4 schedule and show them next to league rounds
- Rename mantra lineups header to gameweek and list matching rounds for each league

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bacfaf8a208323945b198f66d87f51