### PR TITLE
feat: store JSON files on S3

### DIFF
--- a/draft_app/auth.py
+++ b/draft_app/auth.py
@@ -1,3 +1,4 @@
+import os
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session, current_app
 from .config import AUTH_FILE
 from .services import load_json
@@ -5,7 +6,8 @@ from .services import load_json
 bp = Blueprint("auth", __name__)
 
 def load_auth_users():
-    data = load_json(AUTH_FILE, default={'users': []})
+    s3_key = os.getenv("DRAFT_S3_AUTH_KEY", os.path.basename(AUTH_FILE))
+    data = load_json(AUTH_FILE, default={'users': []}, s3_key=s3_key)
     return {str(u['id']): u for u in data.get('users', [])}
 
 @bp.route("/login", methods=["GET", "POST"])

--- a/draft_app/state.py
+++ b/draft_app/state.py
@@ -33,7 +33,8 @@ def _build_snake_order(users, rounds_total):
 def init_ucl(app):
     global ucl_state, ucl_players
     # состояние
-    state = load_json(UCL_STATE_FILE, default=None)
+    ucl_key = os.getenv("UCL_S3_STATE_KEY", os.path.basename(UCL_STATE_FILE))
+    state = load_json(UCL_STATE_FILE, default=None, s3_key=ucl_key)
     if state is None:
         state = _default_state(UCL_USERS)
     ucl_state = state
@@ -44,12 +45,13 @@ def init_ucl(app):
     if not ucl_state['draft_order']:
         total = sum(UCL_POSITION_LIMITS.values())
         ucl_state['draft_order'] = _build_snake_order(UCL_USERS, total)
-        save_json(UCL_STATE_FILE, ucl_state)
+        save_json(UCL_STATE_FILE, ucl_state, s3_key=ucl_key)
 
 def init_epl(app):
     global epl_state, epl_players
     # состояние
-    state = load_json(EPL_STATE_FILE, default=None)
+    epl_key = os.getenv("EPL_S3_STATE_KEY", os.path.basename(EPL_STATE_FILE))
+    state = load_json(EPL_STATE_FILE, default=None, s3_key=epl_key)
     if state is None:
         state = _default_state(EPL_USERS)
     epl_state = state
@@ -59,7 +61,7 @@ def init_epl(app):
     if not epl_state['draft_order']:
         total = sum(EPL_POSITION_LIMITS.values())  # 22
         epl_state['draft_order'] = _build_snake_order(EPL_USERS, total)
-        save_json(EPL_STATE_FILE, epl_state)
+        save_json(EPL_STATE_FILE, epl_state, s3_key=epl_key)
 
 def init_top4(app):
     global top4_state
@@ -72,10 +74,12 @@ def init_top4(app):
 
 # Общие хелперы
 def save_ucl_state():
-    save_json(UCL_STATE_FILE, ucl_state)
+    key = os.getenv("UCL_S3_STATE_KEY", os.path.basename(UCL_STATE_FILE))
+    save_json(UCL_STATE_FILE, ucl_state, s3_key=key)
 
 def save_epl_state():
-    save_json(EPL_STATE_FILE, epl_state)
+    key = os.getenv("EPL_S3_STATE_KEY", os.path.basename(EPL_STATE_FILE))
+    save_json(EPL_STATE_FILE, epl_state, s3_key=key)
 
 def user_is_full(roster, limits):
     return len(roster) >= sum(limits.values())

--- a/draft_app/stats.py
+++ b/draft_app/stats.py
@@ -15,14 +15,16 @@ def index(pid):
 
     cache_path = os.path.join(UCL_CACHE_DIR, f'popupstats_70_{pid}.json')
     popup_url  = f'https://gaming.uefa.com/en/uclfantasy/services/feeds/popupstats/popupstats_70_{pid}.json'
+    s3_prefix = os.getenv("UCL_STATS_S3_PREFIX", "ucl_stats").strip().strip("/")
+    s3_key = f"{s3_prefix}/popupstats_70_{pid}.json"
 
-    data = load_json(cache_path, default=None)
+    data = load_json(cache_path, default=None, s3_key=s3_key)
     if data is None:
         try:
             r = HTTP_SESSION.get(popup_url, headers=HEADERS_GENERIC, timeout=10)
             r.raise_for_status()
             data = r.json()
-            save_json(cache_path, data)
+            save_json(cache_path, data, s3_key=s3_key)
         except Exception:
             data = {}
 


### PR DESCRIPTION
## Summary
- mirror JSON loads/saves to S3 when configured
- persist UCL/EPL state and cached stats to S3
- read auth user list from S3

## Testing
- `python -m py_compile draft_app/services.py draft_app/state.py draft_app/stats.py draft_app/auth.py`

------
https://chatgpt.com/codex/tasks/task_e_68bae47adb0883239a015b570fddfb1b