### PR TITLE
Cache mantra player data per id

### DIFF
--- a/draft_app/mantra_routes.py
+++ b/draft_app/mantra_routes.py
@@ -22,6 +22,7 @@ API_URL = "https://mantrafootball.org/api/players/{id}/stats"
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 ROUND_CACHE_DIR = BASE_DIR / "data" / "cache" / "mantra_rounds"
+PLAYER_CACHE_DIR = BASE_DIR / "data" / "cache" / "mantra_players"
 
 
 def _s3_rounds_prefix() -> str:
@@ -31,6 +32,15 @@ def _s3_rounds_prefix() -> str:
 def _s3_key(rnd: int) -> str:
     prefix = _s3_rounds_prefix().strip().strip("/")
     return f"{prefix}/round{int(rnd)}.json"
+
+
+def _s3_players_prefix() -> str:
+    return os.getenv("DRAFT_S3_MANTRA_PLAYERS_PREFIX", "mantra_players")
+
+
+def _player_key(pid: int) -> str:
+    prefix = _s3_players_prefix().strip().strip("/")
+    return f"{prefix}/{int(pid)}.json"
 
 
 def _load_round_cache(rnd: int) -> dict:
@@ -68,14 +78,49 @@ def _save_round_cache(rnd: int, data: dict) -> None:
     os.replace(tmp, ROUND_CACHE_DIR / f"round{int(rnd)}.json")
 
 
-def _fetch_round_stats(pid: int):
+def _fetch_player(pid: int) -> dict:
     try:
         r = requests.get(API_URL.format(id=pid), timeout=10)
         r.raise_for_status()
-        data = r.json().get("data", {})
-        return data.get("round_stats", [])
+        return r.json().get("data", {})
     except Exception:
-        return []
+        return {}
+
+
+def _save_player_cache(pid: int, data: dict) -> None:
+    payload = data or {}
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _player_key(pid)
+        if bucket and key and not _s3_put_json(bucket, key, payload):
+            print(f"[MANTRA:S3] save_player_cache fallback pid={pid}")
+    PLAYER_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix="player_", suffix=".json", dir=str(PLAYER_CACHE_DIR))
+    os.close(fd)
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, PLAYER_CACHE_DIR / f"{int(pid)}.json")
+
+
+def _load_player(pid: int) -> dict:
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _player_key(pid)
+        if bucket and key:
+            data = _s3_get_json(bucket, key)
+            if isinstance(data, dict):
+                return data
+    p = PLAYER_CACHE_DIR / f"{int(pid)}.json"
+    if p.exists():
+        try:
+            with p.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            pass
+    data = _fetch_player(pid)
+    if data:
+        _save_player_cache(pid, data)
+    return data
 
 
 def _calc_score(stat: dict, pos: str) -> int:
@@ -195,7 +240,8 @@ def lineups():
                     if key in cache:
                         pts = int(cache[key])
                     else:
-                        round_stats = _fetch_round_stats(mid)
+                        player = _load_player(mid)
+                        round_stats = player.get("round_stats", [])
                         stat = next((
                             s for s in round_stats
                             if int(s.get("tournament_round_number", 0)) == league_round
@@ -209,7 +255,8 @@ def lineups():
                         cache[key] = int(pts)
                         cache_updated = True
                 elif round_no == current_round:
-                    round_stats = _fetch_round_stats(mid)
+                    player = _load_player(mid)
+                    round_stats = player.get("round_stats", [])
                     stat = next((
                         s for s in round_stats
                         if int(s.get("tournament_round_number", 0)) == league_round


### PR DESCRIPTION
## Summary
- Cache mantra API player data to S3/local files named by mantra_id
- Use cached player data to calculate Top-4 fantasy points

## Testing
- `python -m py_compile draft_app/mantra_routes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bae61e2518832388b93b39d79ae6b3