### PR TITLE
Store Top-4 API responses

### DIFF
--- a/draft_app/top4_score_store.py
+++ b/draft_app/top4_score_store.py
@@ -1,0 +1,54 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Dict
+
+from .epl_services import _s3_enabled, _s3_bucket, _s3_get_json, _s3_put_json
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+TOP4_SCORE_DIR = BASE_DIR / "data" / "cache" / "top4_scores"
+TOP4_SCORE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _s3_prefix() -> str:
+    return os.getenv("TOP4_S3_SCORES_PREFIX", "top4_scores")
+
+
+def _s3_key(pid: int) -> str:
+    prefix = _s3_prefix().strip().strip("/")
+    return f"{prefix}/{int(pid)}.json"
+
+
+def load_top4_score(pid: int) -> Dict:
+    """Load cached response for a Top-4 player."""
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _s3_key(pid)
+        if bucket and key:
+            data = _s3_get_json(bucket, key)
+            if isinstance(data, dict):
+                return data
+    p = TOP4_SCORE_DIR / f"{int(pid)}.json"
+    if p.exists():
+        try:
+            with p.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return {}
+
+
+def save_top4_score(pid: int, data: Dict) -> None:
+    """Persist response for a Top-4 player (S3 + local)."""
+    payload = data or {}
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _s3_key(pid)
+        if bucket and key and not _s3_put_json(bucket, key, payload):
+            print(f"[TOP4:S3] save_top4_score fallback pid={pid}")
+    tmp_fd, tmp_name = tempfile.mkstemp(prefix="top4_", suffix=".json", dir=str(TOP4_SCORE_DIR))
+    os.close(tmp_fd)
+    with open(tmp_name, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    os.replace(tmp_name, TOP4_SCORE_DIR / f"{int(pid)}.json")


### PR DESCRIPTION
## Summary
- cache Mantra API responses per player in `data/cache/top4_scores`
- use the cached JSON when fetching Top-4 player data

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bae7b0c80c8323a73ef5396aac23ab