### PR TITLE
Load Top-4 lineups via AJAX

### DIFF
--- a/templates/top4_lineups.html
+++ b/templates/top4_lineups.html
@@ -16,32 +16,70 @@
     <div class="control"><button class="button is-link" type="submit">Показать</button></div>
   </div>
 </form>
-<table class="table is-striped is-compact">
-  <thead>
-    <tr>
-      {% for m in managers %}
-      <th>
-        {{ m }}
-        {% if lineups[m].total is not none %}
-        <span style="background-color:#006400;color:white;padding:0 4px;border-radius:3px;">{{ lineups[m].total }}</span>
-        {% endif %}
-      </th>
-      {% endfor %}
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      {% for m in managers %}
-      <td>
-        {% for p in lineups[m].players %}
-        <div class="is-flex is-justify-content-space-between">
-          <span>{{ p.name }} ({{ p.pos }})</span>
-          <span class="has-text-right" style="min-width:2em">{{ p.points }}</span>
-        </div>
-        {% endfor %}
-      </td>
-      {% endfor %}
-    </tr>
-  </tbody>
-</table>
+<div id="lineups-container">Загрузка...</div>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('lineups-container');
+  fetch(`{{ url_for('top4.lineups_data') }}?round={{ round }}`)
+    .then(resp => resp.json())
+    .then(data => {
+      const managers = data.managers || [];
+      const lineups = data.lineups || {};
+
+      const table = document.createElement('table');
+      table.className = 'table is-striped is-compact';
+
+      const thead = document.createElement('thead');
+      const headRow = document.createElement('tr');
+      managers.forEach(m => {
+        const th = document.createElement('th');
+        th.textContent = m;
+        const total = lineups[m] && lineups[m].total;
+        if (total !== undefined && total !== null) {
+          const span = document.createElement('span');
+          span.style.backgroundColor = '#006400';
+          span.style.color = 'white';
+          span.style.padding = '0 4px';
+          span.style.borderRadius = '3px';
+          span.textContent = total;
+          th.appendChild(document.createTextNode(' '));
+          th.appendChild(span);
+        }
+        headRow.appendChild(th);
+      });
+      thead.appendChild(headRow);
+      table.appendChild(thead);
+
+      const tbody = document.createElement('tbody');
+      const bodyRow = document.createElement('tr');
+      managers.forEach(m => {
+        const td = document.createElement('td');
+        const players = (lineups[m] && lineups[m].players) || [];
+        players.forEach(p => {
+          const div = document.createElement('div');
+          div.className = 'is-flex is-justify-content-space-between';
+          const spanName = document.createElement('span');
+          spanName.textContent = `${p.name} (${p.pos})`;
+          const spanPts = document.createElement('span');
+          spanPts.className = 'has-text-right';
+          spanPts.style.minWidth = '2em';
+          spanPts.textContent = p.points;
+          div.appendChild(spanName);
+          div.appendChild(spanPts);
+          td.appendChild(div);
+        });
+        bodyRow.appendChild(td);
+      });
+      tbody.appendChild(bodyRow);
+      table.appendChild(tbody);
+
+      container.innerHTML = '';
+      container.appendChild(table);
+    })
+    .catch(() => {
+      container.textContent = 'Ошибка загрузки данных';
+    });
+});
+</script>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- Load Top-4 lineups asynchronously
- Provide API endpoint for lineups JSON

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baea7c4f048323804542fb0e1cb629