### PR TITLE
Add debug logging for Top-4 API data

### DIFF
--- a/templates/top4_lineups.html
+++ b/templates/top4_lineups.html
@@ -75,6 +75,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
       container.innerHTML = '';
       container.appendChild(table);
+      if (data.debug && data.debug.length) {
+        const dbg = document.createElement('pre');
+        dbg.style.whiteSpace = 'pre-wrap';
+        dbg.style.marginTop = '1em';
+        dbg.textContent = data.debug.join('\n');
+        container.appendChild(dbg);
+      }
     })
     .catch(() => {
       container.textContent = 'Ошибка загрузки данных';


### PR DESCRIPTION
## Summary
- log Top-4 API requests and persist empty responses for investigation
- expose fetch and mapping debug info on lineups page

## Testing
- `python -m py_compile draft_app/mantra_routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baf0d588a8832387174cb62df7703d