### PR TITLE
Add verbose logging to top4 lineups view

### DIFF
--- a/templates/top4_lineups.html
+++ b/templates/top4_lineups.html
@@ -23,6 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
   fetch(`{{ url_for('top4.lineups_data') }}?round={{ round }}`)
     .then(resp => resp.json())
     .then(data => {
+      console.log('lineups data', data);
       const managers = data.managers || [];
       const lineups = data.lineups || {};
 
@@ -82,6 +83,11 @@ document.addEventListener('DOMContentLoaded', () => {
         dbg.textContent = data.debug.join('\n');
         container.appendChild(dbg);
       }
+      const raw = document.createElement('pre');
+      raw.style.whiteSpace = 'pre-wrap';
+      raw.style.marginTop = '1em';
+      raw.textContent = JSON.stringify(data, null, 2);
+      container.appendChild(raw);
     })
     .catch(() => {
       container.textContent = 'Ошибка загрузки данных';


### PR DESCRIPTION
## Summary
- add detailed debug logging within top4 lineup calculation and routes
- display raw lineup JSON and console logs on lineups page for troubleshooting

## Testing
- `python3 -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baf8cdbe208323b62e6556c5f72f29