### PR TITLE
Allow manual transfer replacement

### DIFF
--- a/draft_app/epl_services.py
+++ b/draft_app/epl_services.py
@@ -491,8 +491,14 @@ def annotate_can_pick(players: List[Dict[str, Any]], state: Dict[str, Any], curr
     if not current_user:
         for p in players: p["canPick"] = False
         return
-    draft_completed = bool(state.get("draft_completed", False))
-    on_clock = (state.get("next_user") or who_is_on_clock(state)) == current_user
+    transfer_state = state.get("transfer") or {}
+    transfer_active = bool(transfer_state.get("active"))
+    if transfer_active:
+        on_clock = transfer_current_manager(state) == current_user
+        draft_completed = False
+    else:
+        draft_completed = bool(state.get("draft_completed", False))
+        on_clock = (state.get("next_user") or who_is_on_clock(state)) == current_user
     if draft_completed or not on_clock:
         for p in players: p["canPick"] = False
         return


### PR DESCRIPTION
## Summary
- Allow managers to remove a player without an immediate replacement and complete the transfer later through the picks page
- Enable picking during transfer window when pending transfer exists
- Respect transfer turn when deciding which players are selectable

## Testing
- `python -m pytest`
- `python -m py_compile draft_app/epl_routes.py draft_app/epl_services.py`


------
https://chatgpt.com/codex/tasks/task_e_68bef7c826548323a21520ae81c9ca60