### PR TITLE
Enable pick button based on Can Pick logic

### DIFF
--- a/draft_app/static/wishlist.js
+++ b/draft_app/static/wishlist.js
@@ -86,6 +86,8 @@
       qsa('#players tbody tr').forEach(tr => {
         const inWishlist = tr.classList.contains('is-wishlist');
         const canPick = tr.getAttribute('data-can-pick') === '1';
+        const pickBtn = qs('form button[type="submit"]', tr);
+        if (pickBtn) pickBtn.disabled = !canPick;
         const status = tr.getAttribute('data-status') || '';
         const chance = Number(tr.getAttribute('data-chance') || '0');
         const news = (tr.getAttribute('data-news') || '').toLowerCase();


### PR DESCRIPTION
## Summary
- Enable "Выбрать" button when a player can be picked

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf01d87938832393edede0b26140db