### PR TITLE
Sort Top-4 lineups by position

### DIFF
--- a/draft_app/mantra_routes.py
+++ b/draft_app/mantra_routes.py
@@ -40,6 +40,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 ROUND_CACHE_DIR = BASE_DIR / "data" / "cache" / "mantra_rounds"
 LINEUPS_DIR = BASE_DIR / "data" / "cache" / "top4_lineups"
 
+POS_ORDER = {"GKP": 0, "GK": 0, "DEF": 1, "MID": 2, "FWD": 3}
+
 BUILDING_ROUNDS: set[int] = set()
 BUILDING_LOCK = Lock()
 
@@ -356,7 +358,7 @@ def _build_lineups(round_no: int, current_round: int, state: dict) -> dict:
             debug.append(f"{manager}: {name} ({pos}) -> {int(pts)}")
             lineup.append({"name": name, "pos": pos, "points": int(pts)})
             total += pts
-        lineup.sort(key=lambda r: -r["points"])
+        lineup.sort(key=lambda r: (POS_ORDER.get(r["pos"], 99), -r["points"]))
         results[manager] = {"players": lineup, "total": int(total)}
         debug.append(f"manager {manager} total={int(total)}")
         print(f"[lineups] manager {manager} total={int(total)}")

--- a/templates/top4_lineups.html
+++ b/templates/top4_lineups.html
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const render = data => {
     const managers = data.managers || [];
     const lineups = data.lineups || {};
+    const posOrder = { GKP: 0, GK: 0, DEF: 1, MID: 2, FWD: 3 };
 
     const table = document.createElement('table');
     table.className = 'table is-striped is-compact';
@@ -52,12 +53,30 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const tbody = document.createElement('tbody');
     const bodyRow = document.createElement('tr');
-    managers.forEach(m => {
+    managers.forEach((m, idx) => {
       const td = document.createElement('td');
       const players = (lineups[m] && lineups[m].players) || [];
-      players.forEach(p => {
+      const hue = idx * 60;
+      const c1 = `hsl(${hue}, 70%, 90%)`;
+      const c2 = `hsl(${hue}, 70%, 80%)`;
+      players.sort((a, b) => {
+        const oa = posOrder[a.pos] ?? 99;
+        const ob = posOrder[b.pos] ?? 99;
+        if (oa !== ob) return oa - ob;
+        return (b.points ?? 0) - (a.points ?? 0);
+      });
+      let lastPos = null;
+      players.forEach((p, j) => {
+        if (lastPos && p.pos !== lastPos) {
+          const hr = document.createElement('hr');
+          hr.className = 'my-1';
+          td.appendChild(hr);
+        }
+        lastPos = p.pos;
+        const rowColor = j % 2 === 0 ? c1 : c2;
         const div = document.createElement('div');
         div.className = 'is-flex is-justify-content-space-between';
+        div.style.backgroundColor = rowColor;
         const spanName = document.createElement('span');
         spanName.textContent = `${p.name} (${p.pos})`;
         const spanPts = document.createElement('span');


### PR DESCRIPTION
## Summary
- order Top-4 lineup players by their positions
- render Top-4 lineups with position groups separated by horizontal lines

## Testing
- `pytest`
- `python -m py_compile draft_app/mantra_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68c02952d37c8323a1346b8b3a0633c0