### PR TITLE
Sort Top4 lineups by position

### DIFF
--- a/draft_app/mantra_routes.py
+++ b/draft_app/mantra_routes.py
@@ -121,10 +121,7 @@ def _load_lineups_json(rnd: int) -> dict | None:
                 players = lineup.get("players")
                 if isinstance(players, list):
                     players.sort(
-                        key=lambda r: (
-                            POS_ORDER.get(r.get("pos"), 99),
-                            -int(r.get("points", 0)),
-                        )
+                        key=lambda r: POS_ORDER.get(r.get("pos"), 99)
                     )
         return data
 
@@ -372,7 +369,7 @@ def _build_lineups(round_no: int, current_round: int, state: dict) -> dict:
             debug.append(f"{manager}: {name} ({pos}) -> {int(pts)}")
             lineup.append({"name": name, "pos": pos, "points": int(pts)})
             total += pts
-        lineup.sort(key=lambda r: (POS_ORDER.get(r["pos"], 99), -r["points"]))
+        lineup.sort(key=lambda r: POS_ORDER.get(r["pos"], 99))
         results[manager] = {"players": lineup, "total": int(total)}
         debug.append(f"manager {manager} total={int(total)}")
         print(f"[lineups] manager {manager} total={int(total)}")

--- a/templates/top4_lineups.html
+++ b/templates/top4_lineups.html
@@ -62,8 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
       players.sort((a, b) => {
         const oa = posOrder[a.pos] ?? 99;
         const ob = posOrder[b.pos] ?? 99;
-        if (oa !== ob) return oa - ob;
-        return (b.points ?? 0) - (a.points ?? 0);
+        return oa - ob;
       });
       let lastPos = null;
       players.forEach((p, j) => {


### PR DESCRIPTION
## Summary
- Sort Top4 lineup players purely by position
- Remove point-based secondary ordering in Top4 lineup rendering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c03649de8c832386efe1a7a32c4ce6