### PR TITLE
Handle varied position codes in Top4 lineups

### DIFF
--- a/draft_app/mantra_routes.py
+++ b/draft_app/mantra_routes.py
@@ -40,7 +40,17 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 ROUND_CACHE_DIR = BASE_DIR / "data" / "cache" / "mantra_rounds"
 LINEUPS_DIR = BASE_DIR / "data" / "cache" / "top4_lineups"
 
-POS_ORDER = {"GKP": 0, "GK": 0, "DEF": 1, "MID": 2, "FWD": 3}
+POS_ORDER = {
+    "GKP": 0,
+    "GK": 0,
+    "G": 0,
+    "DEF": 1,
+    "D": 1,
+    "MID": 2,
+    "M": 2,
+    "FWD": 3,
+    "F": 3,
+}
 
 BUILDING_ROUNDS: set[int] = set()
 BUILDING_LOCK = Lock()
@@ -121,7 +131,9 @@ def _load_lineups_json(rnd: int) -> dict | None:
                 players = lineup.get("players")
                 if isinstance(players, list):
                     players.sort(
-                        key=lambda r: POS_ORDER.get(r.get("pos"), 99)
+                        key=lambda r: POS_ORDER.get(
+                            (r.get("pos") or "").strip().upper(), 99
+                        )
                     )
         return data
 
@@ -369,7 +381,11 @@ def _build_lineups(round_no: int, current_round: int, state: dict) -> dict:
             debug.append(f"{manager}: {name} ({pos}) -> {int(pts)}")
             lineup.append({"name": name, "pos": pos, "points": int(pts)})
             total += pts
-        lineup.sort(key=lambda r: POS_ORDER.get(r["pos"], 99))
+        lineup.sort(
+            key=lambda r: POS_ORDER.get(
+                (r.get("pos") or "").strip().upper(), 99
+            )
+        )
         results[manager] = {"players": lineup, "total": int(total)}
         debug.append(f"manager {manager} total={int(total)}")
         print(f"[lineups] manager {manager} total={int(total)}")

--- a/templates/top4_lineups.html
+++ b/templates/top4_lineups.html
@@ -25,7 +25,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const render = data => {
     const managers = data.managers || [];
     const lineups = data.lineups || {};
-    const posOrder = { GKP: 0, GK: 0, DEF: 1, MID: 2, FWD: 3 };
+    const posOrder = {
+      GKP: 0,
+      GK: 0,
+      G: 0,
+      DEF: 1,
+      D: 1,
+      MID: 2,
+      M: 2,
+      FWD: 3,
+      F: 3,
+    };
 
     const table = document.createElement('table');
     table.className = 'table is-striped is-compact';
@@ -60,8 +70,10 @@ document.addEventListener('DOMContentLoaded', () => {
       const c1 = `hsl(${hue}, 70%, 90%)`;
       const c2 = `hsl(${hue}, 70%, 80%)`;
       players.sort((a, b) => {
-        const oa = posOrder[a.pos] ?? 99;
-        const ob = posOrder[b.pos] ?? 99;
+        const pa = (a.pos || '').toUpperCase();
+        const pb = (b.pos || '').toUpperCase();
+        const oa = posOrder[pa] ?? 99;
+        const ob = posOrder[pb] ?? 99;
         return oa - ob;
       });
       let lastPos = null;


### PR DESCRIPTION
## Summary
- Normalize position codes when ordering Top-4 lineups
- Extend position order mapping to support single-letter codes
- Align client-side sorting with updated normalization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0463952b0832399a69286ae601aba