### PR TITLE
Fix zeroed first round results and add debugging

### DIFF
--- a/templates/epl_results.html
+++ b/templates/epl_results.html
@@ -32,4 +32,8 @@
 {% else %}
 <p>Нет завершённых туров.</p>
 {% endif %}
+{% if debug_info %}
+<h2 class="title is-4">Debug Info</h2>
+<pre>{{ debug_info | tojson(indent=2) }}</pre>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- Recompute gameweek scores if cached totals are all zeros
- Surface score caching details on the results page for troubleshooting

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c04fe4d8cc83239d8284e8ff74b85b