### PR TITLE
Version score caches by season

### DIFF
--- a/draft_app/gw_score_store.py
+++ b/draft_app/gw_score_store.py
@@ -4,10 +4,17 @@ import tempfile
 from pathlib import Path
 from typing import Dict
 
-from .epl_services import _s3_enabled, _s3_bucket, _s3_get_json, _s3_put_json
+from .epl_services import (
+    _s3_enabled,
+    _s3_bucket,
+    _s3_get_json,
+    _s3_put_json,
+    LAST_SEASON,
+)
 
 BASE_DIR = Path(__file__).resolve().parent.parent
-GW_SCORE_DIR = BASE_DIR / "data" / "cache" / "gw_scores"
+SEASON_TAG = LAST_SEASON.replace("/", "-")
+GW_SCORE_DIR = BASE_DIR / "data" / "cache" / "gw_scores" / SEASON_TAG
 GW_SCORE_DIR.mkdir(parents=True, exist_ok=True)
 
 def _s3_results_prefix() -> str:
@@ -15,7 +22,7 @@ def _s3_results_prefix() -> str:
 
 def _s3_key(gw: int) -> str:
     prefix = _s3_results_prefix().strip().strip("/")
-    return f"{prefix}/gw{int(gw)}.json"
+    return f"{prefix}/{SEASON_TAG}/gw{int(gw)}.json"
 
 def load_gw_score(gw: int) -> Dict[str, int]:
     """Load cached total scores for a gameweek."""

--- a/draft_app/mantra_routes.py
+++ b/draft_app/mantra_routes.py
@@ -26,6 +26,7 @@ from .top4_services import (
     _s3_bucket,
     _s3_get_json,
     _s3_put_json,
+    TOP4_CACHE_VERSION,
 )
 from .top4_schedule import build_schedule
 from .player_map_store import load_player_map, save_player_map
@@ -37,8 +38,8 @@ bp = Blueprint("top4", __name__, url_prefix="/top4")
 API_URL = "https://mantrafootball.org/api/players/{id}/stats"
 
 BASE_DIR = Path(__file__).resolve().parent.parent
-ROUND_CACHE_DIR = BASE_DIR / "data" / "cache" / "mantra_rounds"
-LINEUPS_DIR = BASE_DIR / "data" / "cache" / "top4_lineups"
+ROUND_CACHE_DIR = BASE_DIR / "data" / "cache" / "mantra_rounds" / TOP4_CACHE_VERSION
+LINEUPS_DIR = BASE_DIR / "data" / "cache" / "top4_lineups" / TOP4_CACHE_VERSION
 
 POS_ORDER = {
     "GKP": 0,
@@ -72,7 +73,8 @@ def _to_int(value) -> int:
 
 
 def _s3_rounds_prefix() -> str:
-    return os.getenv("DRAFT_S3_MANTRA_ROUNDS_PREFIX", "mantra_rounds")
+    base = os.getenv("DRAFT_S3_MANTRA_ROUNDS_PREFIX", "mantra_rounds")
+    return f"{base.rstrip('/')}/{TOP4_CACHE_VERSION}"
 
 
 def _s3_key(rnd: int) -> str:
@@ -81,7 +83,8 @@ def _s3_key(rnd: int) -> str:
 
 
 def _s3_lineups_prefix() -> str:
-    return os.getenv("DRAFT_S3_TOP4_LINEUPS_PREFIX", "top4_lineups")
+    base = os.getenv("DRAFT_S3_TOP4_LINEUPS_PREFIX", "top4_lineups")
+    return f"{base.rstrip('/')}/{TOP4_CACHE_VERSION}"
 
 
 def _s3_lineups_key(rnd: int) -> str:

--- a/draft_app/top4_score_store.py
+++ b/draft_app/top4_score_store.py
@@ -4,15 +4,22 @@ import tempfile
 from pathlib import Path
 from typing import Dict
 
-from .top4_services import _s3_enabled, _s3_bucket, _s3_get_json, _s3_put_json
+from .top4_services import (
+    _s3_enabled,
+    _s3_bucket,
+    _s3_get_json,
+    _s3_put_json,
+    TOP4_CACHE_VERSION,
+)
 
 BASE_DIR = Path(__file__).resolve().parent.parent
-TOP4_SCORE_DIR = BASE_DIR / "data" / "cache" / "top4_scores"
+TOP4_SCORE_DIR = BASE_DIR / "data" / "cache" / "top4_scores" / TOP4_CACHE_VERSION
 TOP4_SCORE_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def _s3_prefix() -> str:
-    return os.getenv("TOP4_S3_SCORES_PREFIX", "top4_scores")
+    base = os.getenv("TOP4_S3_SCORES_PREFIX", "top4_scores")
+    return f"{base.rstrip('/')}/{TOP4_CACHE_VERSION}"
 
 
 def _s3_key(pid: int) -> str:

--- a/draft_app/top4_services.py
+++ b/draft_app/top4_services.py
@@ -37,6 +37,12 @@ LEAGUE_TOURNAMENTS_2024 = {
     "Bundesliga": 290,
 }
 LEAGUES = list(LEAGUE_TOURNAMENTS.keys())
+
+# Fingerprint of current season used to version cached data.  Tournament
+# identifiers change every year, so combining them yields a unique tag for the
+# season which allows us to automatically discard stale caches when a new
+# campaign begins.
+TOP4_CACHE_VERSION = "-".join(str(v) for v in sorted(LEAGUE_TOURNAMENTS.values()))
 POS_CANON = {"GK": "GK", "D": "DEF", "M": "MID", "F": "FWD"}
 MIN_PER_LEAGUE = 3
 LEAGUE_CODES = {


### PR DESCRIPTION
## Summary
- fingerprint Top-4 tournaments to build `TOP4_CACHE_VERSION`
- namespace Top-4 player and round caches by season
- isolate EPL gameweek score cache per season

## Testing
- `python -m py_compile draft_app/gw_score_store.py draft_app/top4_score_store.py draft_app/mantra_routes.py draft_app/top4_services.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17d801e188323a10699a4e91cb538