### PR TITLE
Show club logos and full names in Top4 lineups

### DIFF
--- a/draft_app/top4_player_info_store.py
+++ b/draft_app/top4_player_info_store.py
@@ -1,0 +1,66 @@
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Dict
+
+from .top4_services import (
+    _s3_enabled,
+    _s3_bucket,
+    _s3_get_json,
+    _s3_put_json,
+    TOP4_CACHE_VERSION,
+)
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+INFO_DIR = BASE_DIR / "data" / "cache" / "top4_player_info" / TOP4_CACHE_VERSION
+INFO_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _s3_prefix() -> str:
+    base = os.getenv("TOP4_S3_PLAYER_INFO_PREFIX", "top4_player_info")
+    return f"{base.rstrip('/')}/{TOP4_CACHE_VERSION}"
+
+
+def _s3_key(pid: int) -> str:
+    prefix = _s3_prefix().strip().strip("/")
+    return f"{prefix}/{int(pid)}.json"
+
+
+def load_player_info(pid: int) -> Dict:
+    """Load cached info for a Top-4 player (local first, then S3)."""
+    p = INFO_DIR / f"{int(pid)}.json"
+    if p.exists():
+        try:
+            with p.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            pass
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _s3_key(pid)
+        if bucket and key:
+            data = _s3_get_json(bucket, key)
+            if isinstance(data, dict):
+                fd, tmp = tempfile.mkstemp(prefix="player_info_", suffix=".json", dir=str(INFO_DIR))
+                os.close(fd)
+                with open(tmp, "w", encoding="utf-8") as f:
+                    json.dump(data, f, ensure_ascii=False, indent=2)
+                os.replace(tmp, p)
+                return data
+    return {}
+
+
+def save_player_info(pid: int, data: Dict) -> None:
+    """Persist player info (S3 + local)."""
+    payload = data or {}
+    if _s3_enabled():
+        bucket = _s3_bucket()
+        key = _s3_key(pid)
+        if bucket and key and not _s3_put_json(bucket, key, payload):
+            print(f"[TOP4:S3] save_player_info fallback pid={pid}")
+    fd, tmp = tempfile.mkstemp(prefix="player_info_", suffix=".json", dir=str(INFO_DIR))
+    os.close(fd)
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, INFO_DIR / f"{int(pid)}.json")

--- a/templates/top4_lineups.html
+++ b/templates/top4_lineups.html
@@ -89,10 +89,19 @@ document.addEventListener('DOMContentLoaded', () => {
         div.className = 'is-flex is-justify-content-space-between';
         div.style.backgroundColor = rowColor;
         const spanName = document.createElement('span');
-        spanName.textContent = `${p.name} (${p.pos})`;
+        if (p.logo) {
+          const img = document.createElement('img');
+          img.src = p.logo;
+          img.alt = '';
+          img.style.height = '1em';
+          img.style.marginRight = '4px';
+          spanName.appendChild(img);
+        }
+        spanName.appendChild(document.createTextNode(p.name));
         const spanPts = document.createElement('span');
         spanPts.className = 'has-text-right';
         spanPts.style.minWidth = '2em';
+        spanPts.style.marginRight = '5px';
         spanPts.textContent = p.points;
         div.appendChild(spanName);
         div.appendChild(spanPts);


### PR DESCRIPTION
## Summary
- cache player info from mantra API to S3 and local storage
- display club logo and full name on Top4 lineups table
- offset earned points from the right edge by 5px

## Testing
- `python -m py_compile draft_app/mantra_routes.py draft_app/top4_player_info_store.py`

------
https://chatgpt.com/codex/tasks/task_e_68c18c1847a0832399b11b4b3e34346d