### PR TITLE
Add timestamped cache for Top-4 score data

### DIFF
--- a/draft_app/top4_score_store.py
+++ b/draft_app/top4_score_store.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tempfile
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict
 
@@ -16,6 +17,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 TOP4_SCORE_DIR = BASE_DIR / "data" / "cache" / "top4_scores" / TOP4_CACHE_VERSION
 TOP4_SCORE_DIR.mkdir(parents=True, exist_ok=True)
 
+SCORE_CACHE_TTL = timedelta(minutes=30)
+
 
 def _s3_prefix() -> str:
     base = os.getenv("TOP4_S3_SCORES_PREFIX", "top4_scores")
@@ -27,28 +30,48 @@ def _s3_key(pid: int) -> str:
     return f"{prefix}/{int(pid)}.json"
 
 
+def _fresh(data: Dict) -> bool:
+    ts = data.get("cached_at")
+    if not ts:
+        return False
+    try:
+        cached = datetime.fromisoformat(ts)
+    except Exception:
+        return False
+    return datetime.utcnow() - cached < SCORE_CACHE_TTL
+
+
 def load_top4_score(pid: int) -> Dict:
-    """Load cached response for a Top-4 player."""
+    """Load cached response for a Top-4 player (local first, then S3)."""
+    p = TOP4_SCORE_DIR / f"{int(pid)}.json"
+    data = None
+    if p.exists():
+        try:
+            with p.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if _fresh(data):
+                return data
+        except Exception:
+            data = None
     if _s3_enabled():
         bucket = _s3_bucket()
         key = _s3_key(pid)
         if bucket and key:
-            data = _s3_get_json(bucket, key)
-            if isinstance(data, dict):
-                return data
-    p = TOP4_SCORE_DIR / f"{int(pid)}.json"
-    if p.exists():
-        try:
-            with p.open("r", encoding="utf-8") as f:
-                return json.load(f)
-        except Exception:
-            pass
-    return {}
+            s3_data = _s3_get_json(bucket, key)
+            if isinstance(s3_data, dict):
+                tmp_fd, tmp_name = tempfile.mkstemp(prefix="top4_", suffix=".json", dir=str(TOP4_SCORE_DIR))
+                os.close(tmp_fd)
+                with open(tmp_name, "w", encoding="utf-8") as f:
+                    json.dump(s3_data, f, ensure_ascii=False, indent=2)
+                os.replace(tmp_name, p)
+                return s3_data
+    return data or {}
 
 
 def save_top4_score(pid: int, data: Dict) -> None:
     """Persist response for a Top-4 player (S3 + local)."""
-    payload = data or {}
+    payload = dict(data or {})
+    payload["cached_at"] = datetime.utcnow().isoformat()
     if _s3_enabled():
         bucket = _s3_bucket()
         key = _s3_key(pid)


### PR DESCRIPTION
## Summary
- Store `cached_at` timestamp for Top-4 score data and prioritize local cache before S3
- Introduce 30‑minute TTL check in `mantra_routes` to skip redundant API calls

## Testing
- `python -m py_compile draft_app/top4_score_store.py draft_app/mantra_routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c19488bdf48323bacf67dff01b3e40