### PR TITLE
Use flat S3 paths for Top-4 caches

### DIFF
--- a/draft_app/top4_player_info_store.py
+++ b/draft_app/top4_player_info_store.py
@@ -18,8 +18,16 @@ INFO_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def _s3_prefix() -> str:
+    """Return S3 prefix for cached player info.
+
+    The storage layout no longer uses the seasonal cache version in the S3
+    path.  Files must be stored simply as ``top4_player_info/<ID>.json``.  This
+    helper therefore returns just the base prefix from the environment
+    variable (defaulting to ``top4_player_info``) without appending
+    ``TOP4_CACHE_VERSION``.
+    """
     base = os.getenv("TOP4_S3_PLAYER_INFO_PREFIX", "top4_player_info")
-    return f"{base.rstrip('/')}/{TOP4_CACHE_VERSION}"
+    return base.rstrip("/")
 
 
 def _s3_key(pid: int) -> str:

--- a/draft_app/top4_score_store.py
+++ b/draft_app/top4_score_store.py
@@ -21,8 +21,17 @@ SCORE_CACHE_TTL = timedelta(minutes=30)
 
 
 def _s3_prefix() -> str:
+    """Return S3 prefix for cached Top-4 scores.
+
+    User requirements changed so cached files should now live directly under
+    ``top4_scores/<ID>.json`` without the cache version component.  The
+    previous implementation appended ``TOP4_CACHE_VERSION`` to the prefix which
+    resulted in paths like ``top4_scores/<version>/<ID>.json``.  To comply with
+    the new layout we expose only the base prefix from the environment
+    variable (defaulting to ``top4_scores``) and omit the version.
+    """
     base = os.getenv("TOP4_S3_SCORES_PREFIX", "top4_scores")
-    return f"{base.rstrip('/')}/{TOP4_CACHE_VERSION}"
+    return base.rstrip("/")
 
 
 def _s3_key(pid: int) -> str:


### PR DESCRIPTION
## Summary
- drop seasonal version from S3 prefixes for Top-4 player info and score caches
- fetch player metadata from API only when no cache file exists
- clarify score cache layout and keep timestamped 30‑minute TTL

## Testing
- `python -m py_compile draft_app/top4_score_store.py draft_app/top4_player_info_store.py draft_app/mantra_routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c197e4ef408323bba3279ce5558b50