### PR TITLE
Improve Top-4 player info debugging and AJAX error reporting

### DIFF
--- a/draft_app/player_map_store.py
+++ b/draft_app/player_map_store.py
@@ -33,7 +33,8 @@ def load_player_map() -> Dict[str, int]:
             if isinstance(data, dict):
                 try:
                     s3_map = {str(k): int(v) for k, v in data.items()}
-                except Exception:
+                except Exception as exc:
+                    print(f"[MAP] failed to parse S3 mapping: {exc}")
                     s3_map = {}
 
     local_map: Dict[str, int] = {}
@@ -43,7 +44,8 @@ def load_player_map() -> Dict[str, int]:
                 data = json.load(f)
             if isinstance(data, dict):
                 local_map = {str(k): int(v) for k, v in data.items()}
-        except Exception:
+        except Exception as exc:
+            print(f"[MAP] failed to parse local mapping: {exc}")
             local_map = {}
 
     merged = {**s3_map, **local_map}


### PR DESCRIPTION
## Summary
- log parse failures when loading player mapping from S3/local sources and report counts
- expose lineup build exceptions to the client via `lineups/data` for better AJAX error visibility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1fd44ba108323958c3eca5e2f66e1