### PR TITLE
Fix Top-4 lineup name formatting when player info lacks name fields

### DIFF
--- a/draft_app/mantra_routes.py
+++ b/draft_app/mantra_routes.py
@@ -519,9 +519,11 @@ def _build_lineups(round_no: int, current_round: int, state: dict) -> dict:
             # Read player metadata from cache only.  Any missing entries will be
             # fetched asynchronously after the lineups JSON has been generated.
             info = load_player_info(mid) if mid else {}
+            first = (info.get('first_name') or "").strip()
+            last = (info.get('name') or "").strip()
             display_name = (
                 (info.get('full_name') or "").strip()
-                or f"{info.get('first_name', '').strip()} {info.get('name', '').strip()}".strip()
+                or f"{first} {last}".strip()
                 or name
             )
             logo = (info.get('club') or {}).get('logo_path')


### PR DESCRIPTION
## Summary
- avoid AttributeError in lineups when Top-4 player metadata has null `first_name` or `name`

## Testing
- `python -m py_compile draft_app/mantra_routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2001e88d08323ad643b68033b7906