### PR TITLE
Add Top-4 results page with aggregated points

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -51,6 +51,7 @@
             <a class="navbar-item" href="{{ url_for('top4.mapping') }}">Маппинг</a>
             {% endif %}
             <a class="navbar-item" href="{{ url_for('top4.lineups') }}">Лайнапы</a>
+            <a class="navbar-item" href="{{ url_for('top4.results') }}">Результаты</a>
           </div>
         </div>
       </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -32,6 +32,7 @@
         <a class="button is-warning is-light" href="{{ url_for('top4.mapping') }}">Маппинг</a>
         {% endif %}
         <a class="button is-warning is-light" href="{{ url_for('top4.lineups') }}">Лайнапы</a>
+        <a class="button is-warning is-light" href="{{ url_for('top4.results') }}">Результаты</a>
       </div>
     </article>
   </div>

--- a/templates/top4_results.html
+++ b/templates/top4_results.html
@@ -1,0 +1,181 @@
+{% extends "base.html" %}
+{% block title %}Результаты{% endblock %}
+{% block content %}
+<h1 class="title">Результаты</h1>
+<div id="lineups-container">Загрузка...</div>
+
+<div id="points-modal" class="modal">
+  <div class="modal-background"></div>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title">Очки по GW</p>
+      <button class="delete" aria-label="close"></button>
+    </header>
+    <section class="modal-card-body" id="points-modal-body"></section>
+    <footer class="modal-card-foot">
+      <button class="button" id="points-modal-close">Закрыть</button>
+    </footer>
+  </div>
+</div>
+
+<style>
+  #lineups-container { display:inline-block; }
+  #lineups-container .tabs { display:flex; }
+  #lineups-container .tabs ul { flex-grow:0; }
+  .player-row { display:flex; justify-content:space-between; align-items:center; white-space:nowrap; }
+  .player-name { overflow:hidden; text-overflow:ellipsis; margin-right:6px; }
+  .points-box { background:#add8e6; border-radius:4px; padding:0 6px; min-width:2em; text-align:center; cursor:pointer; }
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('lineups-container');
+  container.style.display = 'inline-block';
+  const modal = document.getElementById('points-modal');
+  const modalBody = document.getElementById('points-modal-body');
+  const closeModal = () => modal.classList.remove('is-active');
+  modal.querySelector('.modal-background').addEventListener('click', closeModal);
+  modal.querySelector('.delete').addEventListener('click', closeModal);
+  document.getElementById('points-modal-close').addEventListener('click', closeModal);
+  const url = `{{ url_for('top4.results_data') }}`;
+
+  const posOrder = { GKP:0, GK:0, G:0, DEF:1, D:1, MID:2, M:2, FWD:3, F:3 };
+
+  const showPopup = p => {
+    modalBody.innerHTML = '';
+    modal.querySelector('.modal-card-title').textContent = 'Очки по GW';
+    if (p.breakdown && p.breakdown.length) {
+      const table = document.createElement('table');
+      table.className = 'table is-narrow';
+      const tbody = document.createElement('tbody');
+      let total = 0;
+      p.breakdown.forEach(it => {
+        const tr = document.createElement('tr');
+        const tdL = document.createElement('td');
+        tdL.textContent = it.label;
+        const tdP = document.createElement('td');
+        tdP.className = 'has-text-right';
+        tdP.textContent = it.points;
+        tr.appendChild(tdL);
+        tr.appendChild(tdP);
+        tbody.appendChild(tr);
+        total += it.points;
+      });
+      const totalRow = document.createElement('tr');
+      const tdTL = document.createElement('td');
+      tdTL.innerHTML = '<strong>Итого</strong>';
+      const tdTP = document.createElement('td');
+      tdTP.className = 'has-text-right';
+      tdTP.innerHTML = `<strong>${total}</strong>`;
+      totalRow.appendChild(tdTL);
+      totalRow.appendChild(tdTP);
+      tbody.appendChild(totalRow);
+      table.appendChild(tbody);
+      modalBody.appendChild(table);
+    } else {
+      modalBody.textContent = 'Нет данных';
+    }
+    modal.classList.add('is-active');
+  };
+
+  const render = data => {
+    const managers = data.managers || [];
+    const lineups = data.lineups || {};
+    container.innerHTML = '';
+
+    const tabs = document.createElement('div');
+    tabs.className = 'tabs';
+    const ul = document.createElement('ul');
+    ul.style.flexGrow = '0';
+    tabs.appendChild(ul);
+
+    const contents = document.createElement('div');
+    contents.style.display = 'block';
+
+    managers.forEach((m, idx) => {
+      const li = document.createElement('li');
+      if (idx === 0) li.classList.add('is-active');
+      const a = document.createElement('a');
+      const nameStrong = document.createElement('strong');
+      nameStrong.textContent = m;
+      a.appendChild(nameStrong);
+      const total = lineups[m] && lineups[m].total;
+      if (total !== undefined && total !== null) {
+        const span = document.createElement('span');
+        span.style.backgroundColor = '#006400';
+        span.style.color = 'white';
+        span.style.padding = '0 4px';
+        span.style.borderRadius = '3px';
+        span.style.marginLeft = '4px';
+        span.textContent = total;
+        a.appendChild(span);
+      }
+      li.appendChild(a);
+      ul.appendChild(li);
+
+      const mgrDiv = document.createElement('div');
+      mgrDiv.style.display = idx === 0 ? 'block' : 'none';
+      const players = (lineups[m] && lineups[m].players) || [];
+      const hue = idx * 60;
+      const c1 = `hsl(${hue}, 70%, 90%)`;
+      const c2 = `hsl(${hue}, 70%, 80%)`;
+      players.sort((a, b) => {
+        const pa = (a.pos || '').toUpperCase();
+        const pb = (b.pos || '').toUpperCase();
+        return (posOrder[pa] ?? 99) - (posOrder[pb] ?? 99);
+      });
+      let lastPos = null;
+      players.forEach((p, j) => {
+        if (lastPos && p.pos !== lastPos) {
+          const hr = document.createElement('hr');
+          hr.className = 'my-1';
+          mgrDiv.appendChild(hr);
+        }
+        lastPos = p.pos;
+        const row = document.createElement('div');
+        row.className = 'player-row';
+        row.style.backgroundColor = j % 2 === 0 ? c1 : c2;
+        const spanName = document.createElement('span');
+        spanName.className = 'player-name';
+        if (p.logo) {
+          const img = document.createElement('img');
+          img.src = p.logo;
+          img.alt = '';
+          img.style.height = '1em';
+          img.style.marginRight = '4px';
+          spanName.appendChild(img);
+        }
+        spanName.appendChild(document.createTextNode(p.name));
+        const spanPts = document.createElement('span');
+        spanPts.className = 'points-box';
+        spanPts.textContent = p.points;
+        spanPts.addEventListener('click', () => showPopup(p));
+        row.appendChild(spanName);
+        row.appendChild(spanPts);
+        mgrDiv.appendChild(row);
+      });
+      contents.appendChild(mgrDiv);
+
+      li.addEventListener('click', () => {
+        Array.from(ul.children).forEach((el, i) => {
+          el.classList.toggle('is-active', el === li);
+          const c = contents.children[i];
+          if (c) c.style.display = el === li ? 'block' : 'none';
+        });
+      });
+    });
+
+    container.appendChild(tabs);
+    container.appendChild(contents);
+  };
+
+  fetch(url)
+    .then(resp => resp.json())
+    .then(render)
+    .catch(() => {
+      container.textContent = 'Ошибка загрузки данных';
+    });
+});
+</script>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- add server-side aggregation for Top-4 total points across all gameweeks
- expose `/top4/results` page with per-GW breakdown popup
- link results page in navigation and home page

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2100271108323b4be0dac485dad84