### PR TITLE
Show round class points on EPL results

### DIFF
--- a/draft_app/epl_routes.py
+++ b/draft_app/epl_routes.py
@@ -629,6 +629,7 @@ def results():
     cls_map = {1: 8, 2: 6, 3: 4, 4: 3, 5: 2, 6: 1, 7: 0, 8: 0}
 
     points_by_manager: Dict[str, Dict[int, int]] = {m: {} for m in managers}
+    class_points_by_manager: Dict[str, Dict[int, int]] = {m: {} for m in managers}
     class_total: Dict[str, int] = {m: 0 for m in managers}
     wins_total: Dict[str, int] = {m: 0 for m in managers}
     raw_total: Dict[str, int] = {m: 0 for m in managers}
@@ -727,7 +728,9 @@ def results():
         )
         for idx, m in enumerate(ordered_managers, start=1):
             pts = gw_scores.get(m, 0)
-            class_total[m] += cls_map.get(idx, 0)
+            cls_pts = cls_map.get(idx, 0)
+            class_points_by_manager[m][gw] = cls_pts
+            class_total[m] += cls_pts
             raw_total[m] += pts
         if ordered_managers:
             max_pts = gw_scores.get(ordered_managers[0], 0)
@@ -739,6 +742,7 @@ def results():
         {
             "manager": m,
             "gw_points": points_by_manager[m],
+            "gw_class_points": class_points_by_manager[m],
             "class_points": class_total[m],
             "wins": wins_total[m],
             "raw_points": raw_total[m],

--- a/templates/epl_results.html
+++ b/templates/epl_results.html
@@ -20,7 +20,15 @@
     <tr>
       <td>{{ row.manager }}</td>
       {% for gw in gws %}
-      <td>{{ row.gw_points.get(gw, 0) }}</td>
+      {% set cls = row.gw_class_points.get(gw, 0) %}
+      <td>
+        {{ row.gw_points.get(gw, 0) }} /
+        {% if cls == 8 %}
+          <strong style="color:red;">{{ cls }}</strong>
+        {% else %}
+          {{ cls }}
+        {% endif %}
+      </td>
       {% endfor %}
       <td>{{ row.class_points }}</td>
       <td>{{ row.wins }}</td>


### PR DESCRIPTION
## Summary
- Display each manager's per-gameweek class points alongside raw scores on EPL results
- Highlight 8-point rounds in red bold text

## Testing
- `pytest`
- `python -m py_compile draft_app/epl_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68c21c6a6a548323b86ba91daab36182