### PR TITLE
Fix UCL state S3 fallback

### DIFF
--- a/draft_app/state.py
+++ b/draft_app/state.py
@@ -25,11 +25,10 @@ def _ucl_state_s3_key() -> str:
         return legacy.strip()
     generic = os.getenv("DRAFT_S3_STATE_KEY")
     if generic:
-        g = generic.strip().lstrip("/")
+        g = generic.strip()
         if "ucl" in g.lower():
             return g
-        return f"ucl/{g}"
-    return f"ucl/{os.path.basename(UCL_STATE_FILE)}"
+    return "prod/draft_state_ucl.json"
 
 
 def _epl_state_s3_key() -> str:

--- a/draft_app/ucl.py
+++ b/draft_app/ucl.py
@@ -53,11 +53,10 @@ def _ucl_s3_key() -> Optional[str]:
         return legacy.strip()
     generic = os.getenv("DRAFT_S3_STATE_KEY")
     if generic:
-        g = generic.strip().lstrip("/")
+        g = generic.strip()
         if "ucl" in g.lower():
             return g
-        return f"ucl/{g}"
-    return f"ucl/{UCL_STATE.name}"
+    return "prod/draft_state_ucl.json"
 
 def _ucl_s3_client():
     if not boto3:


### PR DESCRIPTION
## Summary
- route UCL state S3 fallback to prod/draft_state_ucl.json
- avoid deriving UCL keys from EPL defaults