### PR TITLE
Fix UCL transfer window initialization

### DIFF
--- a/draft_app/top4_routes.py
+++ b/draft_app/top4_routes.py
@@ -659,6 +659,7 @@ def open_transfer_window():
         
         # Create backup before opening transfer window
         state = load_state()
+        current_round = state.get("current_round") or 1
         create_backup(state, "before_transfer_window")
         
         # FORCE FRESH START: Clear any existing transfer data
@@ -685,7 +686,9 @@ def open_transfer_window():
             participants=transfer_order,
             transfers_per_manager=3,  # 3 rounds of transfers
             position_limits={"GK": 2, "DEF": 5, "MID": 5, "FWD": 3},
-            max_from_club=1
+            max_from_club=1,
+            gw=current_round,
+            total_rounds=3,
         )
         
         if success:

--- a/draft_app/ucl.py
+++ b/draft_app/ucl.py
@@ -2149,16 +2149,25 @@ def open_transfer_window():
             transfer_order = ["Сергей", "Андрей", "Серёга Б", "Женя", "Ксана", "Саша", "Руслан", "Макс"]
         
         # Initialize transfer window
+        current_matchday = _ucl_default_matchday(state)
+
         success = init_transfers_for_league(
             draft_type="ucl",
             participants=transfer_order,
             transfers_per_manager=1,  # 1 transfer after MD 1-7
             position_limits={"GK": 3, "DEF": 8, "MID": 9, "FWD": 5},
-            max_from_club=1
+            max_from_club=1,
+            gw=current_matchday,
+            total_rounds=1,
         )
-        
+
         if success:
-            flash("Трансферное окно UCL открыто! Очередность: " + " → ".join(transfer_order), "success")
+            flash(
+                "Трансферное окно UCL открыто! Очередность: "
+                + " → ".join(transfer_order)
+                + f" (MD{current_matchday})",
+                "success",
+            )
         else:
             flash("Ошибка при открытии трансферного окна", "error")
             

--- a/tests/test_top4_transfers.py
+++ b/tests/test_top4_transfers.py
@@ -107,6 +107,10 @@ def test_top4_transfer_flow_and_admin_revert(isolated_top4_state):
 
     state_on_disk = json.loads(data["top4_state_path"].read_text(encoding="utf-8"))
     assert state_on_disk.get("transfer_window", {}).get("active"), state_on_disk.get("transfer_window")
+    active_window = state_on_disk.get("transfers", {}).get("active_window")
+    assert active_window, state_on_disk.get("transfers")
+    assert active_window.get("managers_order") == participants
+    assert active_window.get("transfer_phase") == "out"
 
     create_transfer_system = data["create_transfer_system"]
     transfer_system = create_transfer_system("top4")

--- a/tests/test_ucl_transfers.py
+++ b/tests/test_ucl_transfers.py
@@ -126,6 +126,10 @@ def test_ucl_transfer_flow_and_admin_revert(isolated_ucl_state):
 
     state_on_disk = json.loads(data["ucl_state_path"].read_text(encoding="utf-8"))
     assert state_on_disk.get("transfer_window", {}).get("active"), state_on_disk.get("transfer_window")
+    active_window = state_on_disk.get("transfers", {}).get("active_window")
+    assert active_window, state_on_disk.get("transfers")
+    assert active_window.get("managers_order") == participants
+    assert active_window.get("transfer_phase") == "out"
 
     create_transfer_system = data["create_transfer_system"]
     transfer_system = create_transfer_system("ucl")


### PR DESCRIPTION
## Summary
- synchronize legacy and unified transfer window data structures so UCL/TOP4 windows expose a proper managers queue and metadata
- keep legacy transfer state in sync when phases advance or windows close and enrich window initialization with matchday/round info
- update admin routes and regression tests to cover the expanded transfer window payloads

## Testing
- pytest tests/test_ucl_transfers.py tests/test_top4_transfers.py

------
https://chatgpt.com/codex/tasks/task_e_68daf236f2b483238d73bad47d54a636