### PR TITLE
Align transfer system S3 key resolution with state loaders

### DIFF
--- a/draft_app/transfer_system.py
+++ b/draft_app/transfer_system.py
@@ -907,27 +907,81 @@ class TransferSystem:
 
 
 # Factory function to create transfer system for different draft types
+def _resolve_ucl_state_s3_key() -> str:
+    """Return the S3 key used for the UCL draft state."""
+
+    explicit = os.getenv("DRAFT_S3_UCL_STATE_KEY")
+    if explicit:
+        return explicit.strip()
+
+    legacy = os.getenv("UCL_S3_STATE_KEY")
+    if legacy:
+        return legacy.strip()
+
+    generic = os.getenv("DRAFT_S3_STATE_KEY")
+    if generic and "ucl" in generic.lower():
+        return generic.strip()
+
+    old_name = os.getenv("UCL_STATE_S3_KEY")
+    if old_name:
+        return old_name.strip()
+
+    return "prod/draft_state_ucl.json"
+
+
+def _resolve_epl_state_s3_key() -> str:
+    """Return the S3 key used for the EPL draft state."""
+
+    generic = os.getenv("DRAFT_S3_STATE_KEY")
+    if generic:
+        return generic.strip()
+
+    legacy = os.getenv("EPL_S3_STATE_KEY")
+    if legacy:
+        return legacy.strip()
+
+    old_name = os.getenv("EPL_STATE_S3_KEY")
+    if old_name:
+        return old_name.strip()
+
+    return "draft_state_epl.json"
+
+
+def _resolve_top4_state_s3_key() -> str:
+    """Return the S3 key used for the TOP4 draft state."""
+
+    explicit = os.getenv("TOP4_S3_STATE_KEY")
+    if explicit:
+        return explicit.strip()
+
+    old_name = os.getenv("TOP4_STATE_S3_KEY")
+    if old_name:
+        return old_name.strip()
+
+    return "draft_state_top4.json"
+
+
 def create_transfer_system(draft_type: str) -> TransferSystem:
     """Create transfer system instance for specific draft type"""
     BASE_DIR = Path(__file__).resolve().parent.parent
-    
+
     if draft_type.upper() == "UCL":
         return TransferSystem(
-            "UCL", 
+            "UCL",
             BASE_DIR / "draft_state_ucl.json",
-            s3_key=os.getenv("UCL_STATE_S3_KEY", "prod/draft_state_ucl.json")
+            s3_key=_resolve_ucl_state_s3_key()
         )
     elif draft_type.upper() == "EPL":
         return TransferSystem(
             "EPL",
-            BASE_DIR / "draft_state_epl.json", 
-            s3_key=os.getenv("EPL_STATE_S3_KEY", "draft_state_epl.json")
+            BASE_DIR / "draft_state_epl.json",
+            s3_key=_resolve_epl_state_s3_key()
         )
     elif draft_type.upper() == "TOP4":
         return TransferSystem(
             "TOP4",
             BASE_DIR / "draft_state_top4.json",
-            s3_key=os.getenv("TOP4_STATE_S3_KEY", "draft_state_top4.json")  
+            s3_key=_resolve_top4_state_s3_key()
         )
     else:
         raise ValueError(f"Unsupported draft type: {draft_type}")

--- a/tests/test_transfer_system_env.py
+++ b/tests/test_transfer_system_env.py
@@ -1,0 +1,84 @@
+from draft_app.transfer_system import create_transfer_system
+
+
+def _clear_env(monkeypatch, *names):
+    for name in names:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_create_transfer_system_uses_ucl_specific_env(monkeypatch):
+    env_names = (
+        "DRAFT_S3_UCL_STATE_KEY",
+        "UCL_S3_STATE_KEY",
+        "DRAFT_S3_STATE_KEY",
+        "UCL_STATE_S3_KEY",
+    )
+    _clear_env(monkeypatch, *env_names)
+
+    ts = create_transfer_system("ucl")
+    assert ts.s3_key == "prod/draft_state_ucl.json"
+
+    monkeypatch.setenv("DRAFT_S3_UCL_STATE_KEY", "custom/ucl.json")
+    ts = create_transfer_system("ucl")
+    assert ts.s3_key == "custom/ucl.json"
+    _clear_env(monkeypatch, "DRAFT_S3_UCL_STATE_KEY")
+
+    monkeypatch.setenv("UCL_S3_STATE_KEY", "legacy/ucl.json")
+    ts = create_transfer_system("ucl")
+    assert ts.s3_key == "legacy/ucl.json"
+    _clear_env(monkeypatch, "UCL_S3_STATE_KEY")
+
+    monkeypatch.setenv("DRAFT_S3_STATE_KEY", "shared/ucl_state.json")
+    ts = create_transfer_system("ucl")
+    assert ts.s3_key == "shared/ucl_state.json"
+    _clear_env(monkeypatch, "DRAFT_S3_STATE_KEY")
+
+    monkeypatch.setenv("UCL_STATE_S3_KEY", "old/ucl.json")
+    ts = create_transfer_system("ucl")
+    assert ts.s3_key == "old/ucl.json"
+
+
+def test_create_transfer_system_uses_epl_env(monkeypatch):
+    env_names = (
+        "DRAFT_S3_STATE_KEY",
+        "EPL_S3_STATE_KEY",
+        "EPL_STATE_S3_KEY",
+    )
+    _clear_env(monkeypatch, *env_names)
+
+    ts = create_transfer_system("epl")
+    assert ts.s3_key == "draft_state_epl.json"
+
+    monkeypatch.setenv("DRAFT_S3_STATE_KEY", "shared/epl_state.json")
+    ts = create_transfer_system("epl")
+    assert ts.s3_key == "shared/epl_state.json"
+    _clear_env(monkeypatch, "DRAFT_S3_STATE_KEY")
+
+    monkeypatch.setenv("EPL_S3_STATE_KEY", "legacy/epl.json")
+    ts = create_transfer_system("epl")
+    assert ts.s3_key == "legacy/epl.json"
+    _clear_env(monkeypatch, "EPL_S3_STATE_KEY")
+
+    monkeypatch.setenv("EPL_STATE_S3_KEY", "old/epl.json")
+    ts = create_transfer_system("epl")
+    assert ts.s3_key == "old/epl.json"
+
+
+def test_create_transfer_system_uses_top4_env(monkeypatch):
+    env_names = (
+        "TOP4_S3_STATE_KEY",
+        "TOP4_STATE_S3_KEY",
+    )
+    _clear_env(monkeypatch, *env_names)
+
+    ts = create_transfer_system("top4")
+    assert ts.s3_key == "draft_state_top4.json"
+
+    monkeypatch.setenv("TOP4_S3_STATE_KEY", "custom/top4.json")
+    ts = create_transfer_system("top4")
+    assert ts.s3_key == "custom/top4.json"
+    _clear_env(monkeypatch, "TOP4_S3_STATE_KEY")
+
+    monkeypatch.setenv("TOP4_STATE_S3_KEY", "old/top4.json")
+    ts = create_transfer_system("top4")
+    assert ts.s3_key == "old/top4.json"


### PR DESCRIPTION
## Summary
- ensure the transfer system resolves UCL, EPL, and TOP4 state S3 keys using the same environment variable precedence as the draft state loaders
- add regression tests that confirm the correct environment variables are honored for each league

## Testing
- `pytest tests/test_transfer_system_env.py tests/test_ucl_transfers.py::test_ucl_transfer_flow_and_admin_revert -q`


------
https://chatgpt.com/codex/tasks/task_e_68daf6fa9abc8323826cbae4d1a1f64e